### PR TITLE
docs only: warn about /proc visiblity when `--api-key` is used

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
     #[arg(long = "model", env = "ZS_MODEL", help = "Model name")]
     pub model: Option<String>,
 
-    #[arg(long = "api-key", help = "API key for the provider")]
+    #[arg(long = "api-key", help = "API key for the provider (WARNING: visible to other users via ps/htop; prefer env vars)")]
     pub api_key: Option<String>,
 
     #[arg(long = "max-tokens", help = "Maximum tokens in response")]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -81,6 +81,10 @@ fn resolve_api_key(
     cli_key: Option<&str>,
 ) -> anyhow::Result<String> {
     if let Some(key) = cli_key.filter(|k| !k.is_empty()) {
+        tracing::warn!(
+            "API key provided via --api-key is visible in process listings (/proc/*/cmdline). Use the {} environment variable instead.",
+            provider_env_var(kind)
+        );
         return Ok(key.to_string());
     }
 


### PR DESCRIPTION
Passing an API key via `--api-key` makes it visible to any user on the system through `/proc/<pid>/cmdline`, `htop`, or `ps auxww`.

This PR doesn't change that, it just highlights that in the CLI help text and the logs:

```bash
❯ ./zerostack --help
Minimal coding agent

Usage: zerostack [OPTIONS] [MESSAGE]...

Arguments:
  [MESSAGE]...  Prompt message(s)

Options:
[...]
      --api-key <API_KEY>          API key for the provider (WARNING: visible to other users via ps/htop; prefer env vars)
```