### PR TITLE
Add max_agent_turns option to control the number of agent turns

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -50,6 +50,9 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     let max_tokens = cli.resolve_max_tokens(cfg);
     builder = builder.max_tokens(max_tokens);
 
+    let max_turns = cli.resolve_max_agent_turns(cfg);
+    builder = builder.default_max_turns(max_turns);
+
     if let Some(temp) = cli.temperature {
         let clamped = temp.clamp(0.0, 2.0);
         builder = builder.temperature(clamped);

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -44,7 +44,7 @@ where
     let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(256);
 
     tokio::spawn(async move {
-        let mut stream = agent.stream_chat(prompt, history).multi_turn(100).await;
+        let mut stream = agent.stream_chat(prompt, history).await;
 
         while let Some(item) = stream.next().await {
             match item {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,9 @@ pub struct Cli {
     #[arg(long = "max-tokens", help = "Maximum tokens in response")]
     pub max_tokens: Option<u64>,
 
+    #[arg(long = "max-agent-turns", help = "Maximum agent turns")]
+    pub max_agent_turns: Option<usize>,
+
     #[arg(long = "temperature", help = "Model temperature (0.0 to 2.0)")]
     pub temperature: Option<f64>,
 
@@ -123,6 +126,10 @@ impl Cli {
 
     pub fn resolve_max_tokens(&self, cfg: &config::Config) -> u64 {
         self.max_tokens.or(cfg.max_tokens).unwrap_or(8192)
+    }
+
+    pub fn resolve_max_agent_turns(&self, cfg: &config::Config) -> usize {
+        self.max_agent_turns.or(cfg.max_agent_turns).unwrap_or(100)
     }
 
     pub fn resolve_no_context_files(&self, cfg: &config::Config) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub context_window: Option<u64>,
     pub reserve_tokens: Option<u64>,
     pub keep_recent_tokens: Option<u64>,
+    pub max_agent_turns: Option<usize>,
     pub compact_enabled: Option<bool>,
     pub custom_providers: Option<HashMap<String, CustomProviderConfig>>,
     pub permission: Option<serde_json::Value>,


### PR DESCRIPTION
I have a long running task that would fail due to the hard coded 100 turn limit. This little patch allows the turn limit to be set via the command line or the config file.
