### PR TITLE
Add Zima Labs as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The worktrees integrations offers 3 slash commands:
 - Anthropic
 - Gemini
 - Ollama
+- Zima Labs
 
 Custom providers can be configured with any base URL and API key environment
 variable in `$XDG_CONFIG_HOME/zerostack/config.json`.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -19,6 +19,8 @@ use crate::session::SessionMessage;
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::McpClientManager;
 
+const ZIMA_BASE_URL: &str = "https://zimalabs.io/api/v1";
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ProviderKind {
     OpenRouter,
@@ -26,6 +28,7 @@ pub enum ProviderKind {
     Anthropic,
     Gemini,
     Ollama,
+    Zima,
 }
 
 pub fn parse_provider(name: &str) -> Option<ProviderKind> {
@@ -35,6 +38,7 @@ pub fn parse_provider(name: &str) -> Option<ProviderKind> {
         "anthropic" => Some(ProviderKind::Anthropic),
         "gemini" | "google" => Some(ProviderKind::Gemini),
         "ollama" => Some(ProviderKind::Ollama),
+        "zima" | "zimalabs" => Some(ProviderKind::Zima),
         _ => None,
     }
 }
@@ -72,6 +76,7 @@ fn provider_env_var(kind: ProviderKind) -> &'static str {
         ProviderKind::Gemini => "GEMINI_API_KEY",
         ProviderKind::Ollama => "OLLAMA_API_KEY",
         ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
+        ProviderKind::Zima => "ZIMA_API_KEY",
     }
 }
 
@@ -260,7 +265,7 @@ pub fn create_client(
 ) -> anyhow::Result<AnyClient> {
     let info = resolve_provider_info(provider_name, custom_providers).ok_or_else(|| {
         anyhow::anyhow!(
-            "Unknown provider: {}. Supported providers: openrouter, openai, anthropic, gemini, ollama",
+            "Unknown provider: {}. Supported providers: openrouter, openai, anthropic, gemini, ollama, zima",
             provider_name
         )
     })?;
@@ -303,6 +308,12 @@ pub fn create_client(
                 b = b.base_url(base_url);
             }
             Ok(AnyClient::OpenRouter(b.build()?))
+        }
+        ProviderKind::Zima => {
+            let b = openai::CompletionsClient::builder()
+                .api_key(&key)
+                .base_url(info.base_url.as_deref().unwrap_or(ZIMA_BASE_URL));
+            Ok(AnyClient::OpenAI(b.build()?))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds [Zima Labs](https://zimalabs.io/) as a built-in provider (`--provider zima`), env var `ZIMA_API_KEY`, default base URL `https://zimalabs.io/api/v1`.
- Zima is OpenAI-compatible (chat/completions, Bearer auth), so the new `ProviderKind::Zima` reuses the `openai::CompletionsClient` builder and `AnyClient::OpenAI` — no new variants on `AnyClient` / `AnyModel` / `AnyAgent`.
- The existing `[custom_providers.zima]` override path still works (base URL and api_key_env can be overridden in `config.json`) because `resolve_provider_info` checks custom providers before built-in kinds.

Net change: ~10 lines across `src/provider.rs` and one line in `README.md`.

## Test plan

- [ ] `cargo check` and `cargo build --release` clean
- [ ] `cargo clippy` clean
- [ ] Smoke test with a real key: `ZIMA_API_KEY=zima_sk_... zerostack --provider zima --model <zima-model> -p "hi"`
- [ ] Confirm `Authorization: Bearer <key>` is the correct auth scheme for Zima (per their "works with existing OpenAI SDKs without modification" claim — if their server actually wants the raw header value without `Bearer `, the fix would be local to the Zima arm in `create_client`)
- [ ] Verify override path: a `[custom_providers.zima]` block in `config.json` takes precedence over the built-in defaults