### PR TITLE
[codex] add --no-
  color monochrome TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 - **Permission system**: four configurable modes with per-tool patterns, session allowlists, and external directory policies
 - **Session management**: save/load/resume sessions, auto-compaction to stay within context windows
 - **Terminal UI**: crossterm-based, markdown rendering, mouse selection/copy, scrollback, reasoning visibility toggle
+- **Monochrome mode**: `--no-color` forces the TUI into white/gray output
 - **Prompts system**: switch between system prompt modes at runtime (`code`, `plan`, `review`, `debug`, etc.) to tailor the agent's behavior to the task without having to manage Skills.
 - **MCP support**: connect MCP servers for extended tooling (exposed as an optional compile-time feature)
 - **Integrated Exa search**: allows for WebFetch and WebSearch tools
@@ -61,6 +62,9 @@ export OPENROUTER_API_KEY="[api_key]"
 
 # Interactive session (default prompt: code)
 zerostack
+
+# Monochrome TUI
+zerostack --no-color
 
 # One-shot mode
 zerostack -p "Explain this project"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,9 @@ pub struct Cli {
     #[arg(long = "no-tools", help = "Disable all tools")]
     pub no_tools: bool,
 
+    #[arg(long = "no-color", help = "Disable colored TUI output")]
+    pub no_color: bool,
+
     #[arg(
         long = "restrictive",
         short = 'R',

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -9,6 +9,7 @@ pub struct InputEditor {
     history: Vec<CompactString>,
     history_pos: Option<usize>,
     pub picker: Option<FilePicker>,
+    monochrome: bool,
 }
 
 impl InputEditor {
@@ -19,11 +20,20 @@ impl InputEditor {
             history: Vec::new(),
             history_pos: None,
             picker: None,
+            monochrome: false,
+        }
+    }
+
+    pub fn set_monochrome(&mut self, monochrome: bool) {
+        self.monochrome = monochrome;
+        if let Some(picker) = self.picker.as_mut() {
+            picker.set_monochrome(monochrome);
         }
     }
 
     pub fn start_picker(&mut self) {
         let picker = self.picker.get_or_insert_with(FilePicker::new);
+        picker.set_monochrome(self.monochrome);
         picker.activate();
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -36,6 +36,16 @@ const C_ERROR: Color = Color::Red;
 const C_TOOL: Color = Color::Yellow;
 const C_PERM: Color = Color::Magenta;
 
+#[inline]
+pub(crate) fn resolve_color(color: Color, monochrome: bool) -> Color {
+    if monochrome {
+        let _ = color;
+        Color::Reset
+    } else {
+        color
+    }
+}
+
 /// Formats a tool call showing only the primary file/command parameter.
 /// - read/write/edit → path
 /// - grep → pattern (and path if both present)
@@ -103,7 +113,9 @@ pub async fn run_interactive(
     let _guard = TerminalGuard::new()?;
 
     let mut renderer = Renderer::new()?;
+    renderer.set_monochrome(cli.no_color);
     let mut input = InputEditor::new();
+    input.set_monochrome(cli.no_color);
     let mut is_running = false;
     let mut agent_rx: Option<mpsc::Receiver<AgentEvent>> = None;
     let mut agent_line_started = false;

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -7,6 +7,8 @@ use crossterm::cursor::MoveTo;
 use crossterm::style::{Color, ResetColor, SetForegroundColor};
 use crossterm::terminal::Clear;
 
+use super::resolve_color;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +192,7 @@ pub struct FilePicker {
     pub matches: Vec<PathBuf>,
     pub selected: usize,
     file_cache: Arc<Mutex<Vec<PathBuf>>>,
+    monochrome: bool,
 }
 
 impl FilePicker {
@@ -201,7 +204,16 @@ impl FilePicker {
             matches: Vec::new(),
             selected: 0,
             file_cache: Arc::new(Mutex::new(Vec::new())),
+            monochrome: false,
         }
+    }
+
+    pub fn set_monochrome(&mut self, monochrome: bool) {
+        self.monochrome = monochrome;
+    }
+
+    fn color(&self, color: Color) -> Color {
+        resolve_color(color, self.monochrome)
     }
 
     pub fn activate(&mut self) {
@@ -307,7 +319,7 @@ impl FilePicker {
         if self.matches.is_empty() {
             let r = rows.saturating_sub(3);
             stdout.execute(MoveTo(0, r))?;
-            write!(stdout, "{}", SetForegroundColor(Color::DarkGrey))?;
+            write!(stdout, "{}", SetForegroundColor(self.color(Color::DarkGrey)))?;
             write!(stdout, "{}", "no matches")?;
             write!(stdout, "{}", ResetColor)?;
             stdout.flush()?;
@@ -340,10 +352,10 @@ impl FilePicker {
                 .collect();
 
             if i == self.selected {
-                write!(stdout, "{}", SetForegroundColor(Color::Green))?;
+                write!(stdout, "{}", SetForegroundColor(self.color(Color::Green)))?;
                 write!(stdout, "▸ {}", truncated)?;
             } else {
-                write!(stdout, "{}", SetForegroundColor(Color::DarkGrey))?;
+                write!(stdout, "{}", SetForegroundColor(self.color(Color::DarkGrey)))?;
                 write!(stdout, "  {}", truncated)?;
             }
             write!(stdout, "{}", ResetColor)?;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -6,6 +6,8 @@ use crossterm::cursor::MoveTo;
 use crossterm::style::{Attribute, Color, ResetColor, SetAttribute, SetForegroundColor};
 use crossterm::terminal::{Clear, ClearType, ScrollUp};
 
+use super::resolve_color;
+
 #[derive(Clone)]
 pub struct LineEntry {
     pub text: CompactString,
@@ -21,6 +23,7 @@ pub struct Renderer {
     partial_color: Color,
     scroll_offset: usize,
     input_scroll_offset: usize,
+    monochrome: bool,
     pub selection_active: bool,
     pub selection_start: Option<usize>,
     pub selection_end: Option<usize>,
@@ -37,10 +40,19 @@ impl Renderer {
             partial_color: Color::White,
             scroll_offset: 0,
             input_scroll_offset: 0,
+            monochrome: false,
             selection_active: false,
             selection_start: None,
             selection_end: None,
         })
+    }
+
+    pub fn set_monochrome(&mut self, monochrome: bool) {
+        self.monochrome = monochrome;
+    }
+
+    fn color(&self, color: Color) -> Color {
+        resolve_color(color, self.monochrome)
     }
 
     fn terminal_size(&self) -> (u16, u16) {
@@ -240,7 +252,7 @@ impl Renderer {
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
                 }
-                write!(stdout, "{}", SetForegroundColor(entry.color))?;
+                write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
                 write!(stdout, "{}", text)?;
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
@@ -259,7 +271,7 @@ impl Renderer {
             let indicator = format!(" SCROLL {}% ", pct);
             let x = cols.saturating_sub(indicator.len() as u16);
             stdout.execute(MoveTo(x, 0))?;
-            write!(stdout, "{}", SetForegroundColor(Color::DarkYellow))?;
+            write!(stdout, "{}", SetForegroundColor(self.color(Color::DarkYellow)))?;
             write!(stdout, "{}", indicator)?;
             write!(stdout, "{}", ResetColor)?;
         }
@@ -310,7 +322,7 @@ impl Renderer {
                     let r = self.content_row();
                     stdout.execute(MoveTo(0, r))?;
                     stdout.execute(Clear(ClearType::CurrentLine))?;
-                    write!(stdout, "{}", SetForegroundColor(color))?;
+                    write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                     writeln!(stdout, "{}", chunk)?;
                     write!(stdout, "{}", ResetColor)?;
                     self.lines = self.lines.saturating_add(1);
@@ -355,7 +367,7 @@ impl Renderer {
                     let r = self.content_row();
                     stdout.execute(MoveTo(self.col, r))?;
                     if !segment.is_empty() {
-                        write!(stdout, "{}", SetForegroundColor(color))?;
+                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", segment)?;
                         write!(stdout, "{}", ResetColor)?;
                     }
@@ -385,7 +397,7 @@ impl Renderer {
                         let mut stdout = io::stdout();
                         let r = self.content_row();
                         stdout.execute(MoveTo(self.col, r))?;
-                        write!(stdout, "{}", SetForegroundColor(color))?;
+                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", chunk)?;
                         write!(stdout, "{}", ResetColor)?;
                         self.col = self.col.saturating_add(chunk.chars().count() as u16);
@@ -443,7 +455,7 @@ impl Renderer {
         stdout.execute(MoveTo(0, input_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
         stdout.execute(MoveTo(0, input_row))?;
-        write!(stdout, "{}", SetForegroundColor(Color::Cyan))?;
+        write!(stdout, "{}", SetForegroundColor(self.color(Color::Cyan)))?;
         write!(stdout, "{}", prompt)?;
         write!(stdout, "{}", ResetColor)?;
         let visible_width = cols.saturating_sub(2) as usize;
@@ -467,7 +479,7 @@ impl Renderer {
         stdout.execute(MoveTo(0, status_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
         stdout.execute(MoveTo(0, status_row))?;
-        write!(stdout, "{}", SetForegroundColor(Color::DarkGrey))?;
+        write!(stdout, "{}", SetForegroundColor(self.color(Color::DarkGrey)))?;
         let status_display = if self.scroll_offset > 0 {
             format!("-- SCROLL -- {}", status)
         } else {


### PR DESCRIPTION
This adds a  flag so zerostack can start in a monochrome TUI mode.

  Why:
  - some terminals/themes make forced color output hard to read
  - I ran into a case where the UI was effectively washed out unless the app used the terminal’s default foreground color

  What changed:
  - added  to the CLI
  - threaded a monochrome mode through the TUI renderer
  - applied the same mode to the file picker and input flow
  - documented the flag in the README

  Validation:
  - carefully tested in Docker on a headless Linux Mint system
  - rebuilt with 
  - verified [?1049h[2J[?1000h[?1002h[?1003h[?1015h[?1006h[2J[1;1H[1;1H[2K[39mzerostack openrouter  deepseek/deepseek-v4-flash  1.0.2
[0m[2;1H[2K[39m
[0m[30;1H                                                                                                                                       [30;1H[39m> [0m[31;1H                                                                                                                                       [31;1H[39mzerostack | deepseek/deepseek-v4-flash | 0/128k (0%) | 0msgs | ready [code][0m[30;3H[30;1H                                                                                                                                       [30;1H[39m> [0m[31;1H                                                                                                                                       [31;1H[39mzerostack | deepseek/deepseek-v4-flash | 0/128k (0%) | 0msgs | ready [code][0m[30;3H[30;1H                                                                                                                                       [30;1H[39m> [0m[31;1H                                                                                                                                       [31;1H[39mzerostack | deepseek/deepseek-v4-flash | 0/128k (0%) | 0msgs | ready [code][0m[30;3H[30;1H                                                                                                                                       [30;1H[39m> [0m[31;1H                                                                                                                                       [31;1H[39mzerostack | deepseek/deepseek-v4-flash | 0/128k (0%) | 0msgs | ready [code][0m[30;3H[?1006l[?1015l[?1003l[?1002l[?1000l[?1049l starts correctly and renders cleanly