### PR TITLE
fix: mutex safety, config validation, /loop startup, and test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
+debug = false

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -117,7 +117,7 @@ where
     AgentRunner { event_rx }
 }
 
-pub async fn run_print<M, P>(agent: &Agent<M, P>, prompt: &str) -> anyhow::Result<String>
+pub async fn run_print<M, P>(agent: &Agent<M, P>, prompt: &str, max_turns: usize) -> anyhow::Result<String>
 where
     M: CompletionModel + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
@@ -125,7 +125,7 @@ where
 {
     let mut stream = agent
         .stream_chat(prompt.to_string(), Vec::<Message>::new())
-        .multi_turn(100)
+        .multi_turn(max_turns)
         .await;
 
     let mut full_response = String::new();

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -182,6 +182,28 @@ impl Tool for EditTool {
 mod tests {
     use super::*;
 
+    struct TempFile(String);
+
+    impl TempFile {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir()
+                .join(format!("zerostack_test_{}", name))
+                .to_string_lossy()
+                .to_string();
+            TempFile(path)
+        }
+
+        fn path(&self) -> &str {
+            &self.0
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
     #[tokio::test]
     async fn test_rejects_empty_old_text() {
         let tool = EditTool::new(None, None);
@@ -202,5 +224,110 @@ mod tests {
             }
             _ => panic!("expected ToolError::Msg"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_old_text_not_found() {
+        let tmp = TempFile::new("notfound.txt");
+        std::fs::write(tmp.path(), "hello world").unwrap();
+        let tool = EditTool::new(None, None);
+        let result = tool
+            .call(EditArgs {
+                path: tmp.path().into(),
+                old_text: "not in file".into(),
+                new_text: "replacement".into(),
+                replace_all: None,
+            })
+            .await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("old_text not found"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_single_replacement() {
+        let tmp = TempFile::new("single.txt");
+        std::fs::write(tmp.path(), "before after done\n").unwrap();
+        let tool = EditTool::new(None, None);
+        let result = tool
+            .call(EditArgs {
+                path: tmp.path().into(),
+                old_text: "after".into(),
+                new_text: "middle".into(),
+                replace_all: None,
+            })
+            .await
+            .unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content, "before middle done\n");
+        assert!(result.contains("Applied edit"), "result: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_replace_all() {
+        let tmp = TempFile::new("replace_all.txt");
+        std::fs::write(tmp.path(), "a a a\n").unwrap();
+        let tool = EditTool::new(None, None);
+        let result = tool
+            .call(EditArgs {
+                path: tmp.path().into(),
+                old_text: "a".into(),
+                new_text: "b".into(),
+                replace_all: Some(true),
+            })
+            .await
+            .unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content, "b b b\n");
+        assert!(result.contains("3 replacements"), "result: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_multi_match_without_replace_all_returns_error() {
+        let tmp = TempFile::new("multi.txt");
+        std::fs::write(tmp.path(), "hello world, hello there\n").unwrap();
+        let tool = EditTool::new(None, None);
+        let result = tool
+            .call(EditArgs {
+                path: tmp.path().into(),
+                old_text: "hello".into(),
+                new_text: "bye".into(),
+                replace_all: None,
+            })
+            .await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("matched 2 times"), "msg: {msg}");
+        assert!(msg.contains("replaceAll: true"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_preserves_crlf_line_endings() {
+        let tmp = TempFile::new("crlf.txt");
+        std::fs::write(tmp.path(), "line1\r\nline2\r\nline3\r\n").unwrap();
+        let tool = EditTool::new(None, None);
+        tool.call(EditArgs {
+            path: tmp.path().into(),
+            old_text: "line2".into(),
+            new_text: "modified".into(),
+            replace_all: None,
+        })
+        .await
+        .unwrap();
+        let raw = std::fs::read(tmp.path()).unwrap();
+        assert!(
+            raw.windows(2).any(|w| w == b"\r\n"),
+            "CRLF should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_show_diff_basic() {
+        let diff = EditTool::show_diff("test.txt", "hello world\nfoo bar\nbaz\n", 12, "foo", "qux");
+        assert!(diff.contains("--- a/test.txt"), "diff: {diff}");
+        assert!(diff.contains("+++ b/test.txt"), "diff: {diff}");
+        assert!(diff.contains("-foo"), "diff: {diff}");
+        assert!(diff.contains("+qux"), "diff: {diff}");
+        assert!(diff.contains("@@"), "diff missing hunk header: {diff}");
     }
 }

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -114,7 +114,7 @@ async fn handle_ask_inner(
         Ok(UserDecision::AllowAlways(pattern)) => {
             permission
                 .lock()
-                .unwrap()
+                .unwrap_or_else(|e| e.into_inner())
                 .add_session_allowlist(tool.to_string(), &pattern);
             Ok(())
         }
@@ -132,7 +132,7 @@ pub async fn check_perm(
         return Ok(());
     };
     let result = {
-        let mut guard = perm.lock().unwrap();
+        let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
         guard.check(tool, input_key)
     };
     match result {
@@ -161,7 +161,7 @@ pub async fn check_perm_path(
         return Ok(());
     };
     let result = {
-        let mut guard = perm.lock().unwrap();
+        let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
         guard.check_path(tool, path)
     };
     match result {

--- a/src/agent/tools/todo.rs
+++ b/src/agent/tools/todo.rs
@@ -65,7 +65,7 @@ impl Tool for WriteTodoList {
     async fn call(&self, args: TodoWriteArgs) -> Result<String, ToolError> {
         check_perm(&self.permission, &self.ask_tx, "write_todo_list", "").await?;
 
-        let mut list = TODO_LIST.lock().unwrap();
+        let mut list = TODO_LIST.lock().unwrap_or_else(|e| e.into_inner());
         *list = args.todos;
 
         if list.is_empty() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,11 +84,9 @@ pub fn load() -> Config {
         });
         serde_json::from_str(&content).unwrap_or_else(|e| {
             eprintln!(
-                "error: {} contains invalid JSON at line {} column {}: {}\n\
+                "error: {} is not a valid config: {}\n\
                  Fix the file or remove it to use defaults.",
                 path.display(),
-                e.line(),
-                e.column(),
                 e,
             );
             std::process::exit(1);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -73,16 +73,25 @@ pub fn load() -> Config {
     let mut cfg: Config = if !path.exists() {
         Config::default()
     } else {
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("warning: failed to read config ({}): {}", path.display(), e);
-                return Config::default();
-            }
-        };
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            eprintln!(
+                "error: failed to read config file ({}): {}\n\
+                 Fix the file or remove it to use defaults.",
+                path.display(),
+                e,
+            );
+            std::process::exit(1);
+        });
         serde_json::from_str(&content).unwrap_or_else(|e| {
-            eprintln!("warning: invalid config JSON ({}): {}", path.display(), e);
-            Config::default()
+            eprintln!(
+                "error: {} contains invalid JSON at line {} column {}: {}\n\
+                 Fix the file or remove it to use defaults.",
+                path.display(),
+                e.line(),
+                e.column(),
+                e,
+            );
+            std::process::exit(1);
         })
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ async fn main() -> anyhow::Result<()> {
             #[cfg(feature = "mcp")] mcp_manager.as_ref(),
         ).await;
         let msg = cli.message.join(" ");
-        let response = agent.run_print(&msg).await?;
+        let response = agent.run_print(&msg, cli.resolve_max_agent_turns(&cfg)).await?;
         if !cli.no_session {
             session.add_message(MessageRole::User, &msg);
             session.add_message(MessageRole::Assistant, &response);
@@ -243,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_headless_loop(
     agent: crate::provider::AnyAgent,
     cli: &cli::Cli,
-    _cfg: &config::Config,
+    cfg: &config::Config,
     _context: &context::ContextFiles,
 ) -> anyhow::Result<()> {
     use std::path::PathBuf;
@@ -291,7 +291,7 @@ async fn run_headless_loop(
         eprintln!("=== {} ===", state.iteration_label());
         eprintln!();
 
-        let response = match agent.run_print(&iteration_prompt).await {
+        let response = match agent.run_print(&iteration_prompt, cli.resolve_max_agent_turns(cfg)).await {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("[loop] error in iteration {}: {}", state.iteration, e);
@@ -304,8 +304,10 @@ async fn run_headless_loop(
 
         let validation_output = if let Some(cmd) = &state.run_cmd {
             eprintln!("--- Validation: {} ---", cmd);
-            match tokio::process::Command::new("sh")
-                .arg("-c")
+            let shell = if cfg!(windows) { "powershell" } else { "sh" };
+            let shell_arg = if cfg!(windows) { "-Command" } else { "-c" };
+            match tokio::process::Command::new(shell)
+                .arg(shell_arg)
                 .arg(cmd)
                 .output()
                 .await
@@ -332,14 +334,16 @@ async fn run_headless_loop(
         };
         state.last_run_output = validation_output.clone();
 
-        let _ = loop_mod::transcript::save_iteration(
+        if let Err(e) = loop_mod::transcript::save_iteration(
             &session_id,
             state.iteration,
             &iteration_prompt,
             &response,
             validation_output.as_deref(),
             &summary,
-        );
+        ) {
+            eprintln!("[loop] warning: failed to save transcript: {}", e);
+        }
 
         eprintln!("--- iteration {} complete, looping ---\n", state.iteration);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ async fn main() -> anyhow::Result<()> {
             .iter()
             .map(|e| (e.tool.clone(), e.pattern.clone()))
             .collect();
-        perm.lock().unwrap().load_session_allowlist(&allowlist);
+        perm.lock().unwrap_or_else(|e| e.into_inner()).load_session_allowlist(&allowlist);
     }
 
     let completion_model = client.completion_model(model.to_string());
@@ -208,7 +208,7 @@ async fn main() -> anyhow::Result<()> {
         if !cli.resolve_no_tools(&cfg)
             && let Some(perm) = &permission {
                 let mode = resolve_mode(&cli, &cfg);
-                perm.lock().unwrap().set_mode(mode);
+                perm.lock().unwrap_or_else(|e| e.into_inner()).set_mode(mode);
             }
 
         let initial_msg = cli.message.join(" ");

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -349,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    fn standard_returns_ask_for_unknown_tool() {
+    fn standard_allows_unknown_tool_with_default() {
         let mut checker = make_checker(SecurityMode::Standard);
         // No rules for "some_tool" + default is Allow
         let result = checker.check("some_tool", "any input");
@@ -358,8 +358,16 @@ mod tests {
 
     #[test]
     fn accept_auto_allows_inside_working_dir() {
-        let mut checker = make_checker(SecurityMode::Accept);
-        // In Accept mode, Ask for path tools within CWD → Auto-Allow
+        // Set write to Ask so Accept mode's Ask→Allow conversion is actually exercised
+        let config = PermissionConfig {
+            write: Some(ToolPerm::Simple(Action::Ask)),
+            ..PermissionConfig::default()
+        };
+        let mut checker = PermissionChecker::new(
+            &config,
+            SecurityMode::Accept,
+            Some(std::path::PathBuf::from("/home/user/project")),
+        );
         let result = checker.check_path("write", "/home/user/project/src/main.rs");
         assert!(matches!(result, CheckResult::Allowed));
     }

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -7,7 +7,7 @@ use crate::permission::{Action, PermissionConfig, SecurityMode, ToolPerm};
 
 pub type PermCheck = Arc<Mutex<PermissionChecker>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckResult {
     Allowed,
     Ask,
@@ -314,5 +314,184 @@ fn resolve_absolute(path: &str, working_dir: &str) -> String {
             .join(p)
             .to_string_lossy()
             .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permission::{PermissionConfig, SecurityMode, ToolPerm};
+
+    fn make_checker(mode: SecurityMode) -> PermissionChecker {
+        PermissionChecker::new(
+            &PermissionConfig::default(),
+            mode,
+            Some(std::path::PathBuf::from("/home/user/project")),
+        )
+    }
+
+    // --- SecurityMode behavior ---
+
+    #[test]
+    fn yolo_allows_everything() {
+        let mut checker = make_checker(SecurityMode::Yolo);
+        assert_eq!(checker.check("bash", "rm -rf /"), CheckResult::Allowed);
+        assert_eq!(checker.check("write", "/etc/passwd"), CheckResult::Allowed);
+    }
+
+    #[test]
+    fn restrictive_makes_unconfigured_tool_ask() {
+        let mut checker = make_checker(SecurityMode::Restrictive);
+        // No explicit rule for "some_tool" + default is Allow →
+        // Restrictive promotes to Ask
+        let result = checker.check("some_tool", "any input");
+        assert!(matches!(result, CheckResult::Ask));
+    }
+
+    #[test]
+    fn standard_returns_ask_for_unknown_tool() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        // No rules for "some_tool" + default is Allow
+        let result = checker.check("some_tool", "any input");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    #[test]
+    fn accept_auto_allows_inside_working_dir() {
+        let mut checker = make_checker(SecurityMode::Accept);
+        // In Accept mode, Ask for path tools within CWD → Auto-Allow
+        let result = checker.check_path("write", "/home/user/project/src/main.rs");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    #[test]
+    fn accept_asks_for_external_path() {
+        let mut checker = make_checker(SecurityMode::Accept);
+        // Use an absolute path outside CWD. On Windows this must be a
+        // different drive; on Unix /etc is outside /home.
+        let external_path = if cfg!(windows) {
+            "D:\\outside\\file.txt"
+        } else {
+            "/etc/config.conf"
+        };
+        let result = checker.check_path("write", external_path);
+        assert!(
+            matches!(result, CheckResult::Ask),
+            "expected Ask, got {:?} for path: {}",
+            result,
+            external_path,
+        );
+    }
+
+    // --- Deny rules ---
+
+    #[test]
+    fn deny_rule_blocks_regardless_of_mode() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        // rm -rf /** is in the default deny list
+        let result = checker.check("bash", "rm -rf /home/user/project");
+        assert!(matches!(result, CheckResult::Denied(_)));
+    }
+
+    #[test]
+    fn deny_rule_not_blocked_by_yolo() {
+        // Yolo overrides everything, even deny rules
+        let mut checker = make_checker(SecurityMode::Yolo);
+        let result = checker.check("bash", "rm -rf /home/user/project");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    // --- Doom loop detection ---
+
+    #[test]
+    fn doom_loop_triggers_after_three_repeated_calls() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        checker.check("bash", "ls");
+        checker.check("bash", "ls");
+        let result = checker.check("bash", "ls"); // 3rd call
+        // default doom_loop_action is Ask
+        assert!(matches!(result, CheckResult::Ask));
+    }
+
+    #[test]
+    fn doom_loop_does_not_trigger_before_three() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        checker.check("bash", "ls");
+        let result = checker.check("bash", "ls"); // 2nd call
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    #[test]
+    fn doom_loop_resets_for_different_inputs() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        checker.check("bash", "ls");   // 1
+        checker.check("bash", "ls");   // 2
+        checker.check("bash", "pwd");  // different input, no doom loop
+        let result = checker.check("bash", "pwd");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    // --- Session allowlist ---
+
+    #[test]
+    fn session_allowlist_bypasses_rules() {
+        let mut checker = make_checker(SecurityMode::Restrictive);
+        checker.add_session_allowlist("bash".into(), "cargo test **");
+        // Restrictive would normally Ask, but allowlist makes it Allowed
+        let result = checker.check("bash", "cargo test --all");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    #[test]
+    fn session_allowlist_is_tool_specific() {
+        let mut checker = make_checker(SecurityMode::Restrictive);
+        // "read" is allowlisted with "**" (matches everything including /)
+        checker.add_session_allowlist("read".into(), "**");
+        assert!(matches!(checker.check("read", "/etc/passwd"), CheckResult::Allowed));
+        // "write" is not allowlisted → still Ask
+        assert!(matches!(checker.check("write", "some/file.txt"), CheckResult::Ask));
+    }
+
+    // --- External path detection ---
+
+    #[test]
+    fn external_absolute_path_outside_cwd_is_detected() {
+        let mut checker = make_checker(SecurityMode::Standard);
+        let external_path = if cfg!(windows) {
+            "D:\\outside\\secret.txt"
+        } else {
+            "/etc/shadow"
+        };
+        let result = checker.check_path("write", external_path);
+        assert!(
+            matches!(result, CheckResult::Ask),
+            "expected Ask, got {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn relative_path_is_not_external() {
+        let mut checker = make_checker(SecurityMode::Accept);
+        // Relative path resolves to inside working dir → internal
+        let result = checker.check_path("read", "src/lib.rs");
+        assert!(matches!(result, CheckResult::Allowed));
+    }
+
+    // --- Config-driven rules ---
+
+    #[test]
+    fn explicit_granular_rules_take_effect() {
+        let config = PermissionConfig {
+            read: Some(ToolPerm::Granular(
+                [("*.md".to_string(), Action::Allow), ("*.rs".to_string(), Action::Ask)]
+                    .into(),
+            )),
+            ..PermissionConfig::default()
+        };
+        let mut checker =
+            PermissionChecker::new(&config, SecurityMode::Standard, None);
+        assert_eq!(checker.check("read", "README.md"), CheckResult::Allowed);
+        assert_eq!(checker.check("read", "main.rs"), CheckResult::Ask);
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -232,13 +232,13 @@ pub enum AnyAgent {
 }
 
 impl AnyAgent {
-    pub async fn run_print(&self, prompt: &str) -> anyhow::Result<String> {
+    pub async fn run_print(&self, prompt: &str, max_turns: usize) -> anyhow::Result<String> {
         match self {
-            AnyAgent::OpenRouter(a) => runner::run_print(a, prompt).await,
-            AnyAgent::OpenAI(a) => runner::run_print(a, prompt).await,
-            AnyAgent::Anthropic(a) => runner::run_print(a, prompt).await,
-            AnyAgent::Gemini(a) => runner::run_print(a, prompt).await,
-            AnyAgent::Ollama(a) => runner::run_print(a, prompt).await,
+            AnyAgent::OpenRouter(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgent::OpenAI(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgent::Anthropic(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgent::Gemini(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgent::Ollama(a) => runner::run_print(a, prompt, max_turns).await,
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -474,7 +474,9 @@ pub async fn run_interactive(
                                         renderer.write_line(&format!("error: {}", e), C_ERROR)?;
                                     }
                                     Ok(_) => {
-                                        if let Err(e) = crate::session::storage::save_session(session) {
+                                        if !cli.no_session
+                                            && let Err(e) = crate::session::storage::save_session(session)
+                                        {
                                             renderer.write_line(
                                                 &format!("warning: failed to save session: {}", e),
                                                 C_ERROR,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -120,7 +120,7 @@ pub async fn run_interactive(
     let mut wt_return_path: Option<String> = None;
 
     let perm_mode = || -> Option<String> {
-        permission.as_ref().map(|p| p.lock().unwrap().mode().to_string())
+        permission.as_ref().map(|p| p.lock().unwrap_or_else(|e| e.into_inner()).mode().to_string())
     };
 
     render_session(&mut renderer, session, cli, cfg, context)?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -474,7 +474,12 @@ pub async fn run_interactive(
                                         renderer.write_line(&format!("error: {}", e), C_ERROR)?;
                                     }
                                     Ok(_) => {
-                                        let _ = crate::session::storage::save_session(session);
+                                        if let Err(e) = crate::session::storage::save_session(session) {
+                                            renderer.write_line(
+                                                &format!("warning: failed to save session: {}", e),
+                                                C_ERROR,
+                                            )?;
+                                        }
                                         #[cfg(feature = "loop")]
                                         if let Some(ref mut ls) = loop_state
                                             && ls.active && ls.iteration == 0 && !is_running
@@ -488,8 +493,13 @@ pub async fn run_interactive(
                                         }
                                     }
                                 }
-                                if !cli.no_session {
-                                    let _ = crate::session::storage::save_session(session);
+                                if !cli.no_session
+                                    && let Err(e) = crate::session::storage::save_session(session)
+                                {
+                                    renderer.write_line(
+                                        &format!("warning: failed to save session: {}", e),
+                                        C_ERROR,
+                                    )?;
                                 }
                             } else {
                                 for line in text.lines() {

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -220,7 +220,7 @@ impl FilePicker {
 
     fn load_files(&mut self) {
         let files = walk_files(".");
-        *self.file_cache.lock().unwrap() = files;
+        *self.file_cache.lock().unwrap_or_else(|e| e.into_inner()) = files;
     }
 
     pub fn char_input(&mut self, c: char) {
@@ -252,7 +252,7 @@ impl FilePicker {
     }
 
     fn filter(&mut self) {
-        let cache = self.file_cache.lock().unwrap();
+        let cache = self.file_cache.lock().unwrap_or_else(|e| e.into_inner());
         if cache.is_empty() {
             self.matches.clear();
             return;
@@ -292,7 +292,7 @@ impl FilePicker {
 
     #[cfg(test)]
     pub fn test_set_cache(&mut self, files: Vec<PathBuf>) {
-        *self.file_cache.lock().unwrap() = files;
+        *self.file_cache.lock().unwrap_or_else(|e| e.into_inner()) = files;
     }
 
     pub fn draw(&self) -> std::io::Result<()> {

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -540,7 +540,6 @@ pub async fn handle_slash(
                     let plan_file = std::path::PathBuf::from("LOOP_PLAN.md");
                     let ls = crate::extras::r#loop::LoopState::new(prompt, plan_file, None, None);
                     *loop_state = Some(ls);
-                    *is_running = true;
                     renderer.write_line(
                         "loop started — iteration 1 will run after this message",
                         C_AGENT,

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -308,7 +308,7 @@ pub async fn handle_slash(
         "/mode" => {
             let current_mode = permission
                 .as_ref()
-                .map(|p| p.lock().unwrap().mode())
+                .map(|p| p.lock().unwrap_or_else(|e| e.into_inner()).mode())
                 .unwrap_or(SecurityMode::Standard);
 
             if parts.len() < 2 {
@@ -331,7 +331,7 @@ pub async fn handle_slash(
                 match parts[1] {
                     "standard" => {
                         if let Some(p) = permission {
-                            p.lock().unwrap().set_mode(SecurityMode::Standard);
+                            p.lock().unwrap_or_else(|e| e.into_inner()).set_mode(SecurityMode::Standard);
                             renderer.write_line("security mode: standard", C_AGENT)?;
                         } else {
                             renderer.write_line("permission system not active", C_ERROR)?;
@@ -339,7 +339,7 @@ pub async fn handle_slash(
                     }
                     "restrictive" => {
                         if let Some(p) = permission {
-                            p.lock().unwrap().set_mode(SecurityMode::Restrictive);
+                            p.lock().unwrap_or_else(|e| e.into_inner()).set_mode(SecurityMode::Restrictive);
                             renderer.write_line("security mode: restrictive", C_AGENT)?;
                         } else {
                             renderer.write_line("permission system not active", C_ERROR)?;
@@ -347,7 +347,7 @@ pub async fn handle_slash(
                     }
                     "accept" => {
                         if let Some(p) = permission {
-                            p.lock().unwrap().set_mode(SecurityMode::Accept);
+                            p.lock().unwrap_or_else(|e| e.into_inner()).set_mode(SecurityMode::Accept);
                             renderer.write_line(
                                 "security mode: accept (auto-allow within CWD)",
                                 C_AGENT,
@@ -358,7 +358,7 @@ pub async fn handle_slash(
                     }
                     "yolo" => {
                         if let Some(p) = permission {
-                            p.lock().unwrap().set_mode(SecurityMode::Yolo);
+                            p.lock().unwrap_or_else(|e| e.into_inner()).set_mode(SecurityMode::Yolo);
                             renderer.write_line(
                                 "security mode: YOLO (all operations allowed)",
                                 C_AGENT,

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::session::Session;
 
 pub struct StatusLine;
@@ -23,10 +25,9 @@ impl StatusLine {
         perm_mode: Option<&str>,
     ) -> String {
         let state = if is_running { "running" } else { "ready" };
-        let dir = session
-            .working_dir
-            .split('/')
-            .next_back()
+        let dir = Path::new(&session.working_dir)
+            .file_name()
+            .and_then(|n| n.to_str())
             .unwrap_or(&session.working_dir);
 
         let ctx = session.context_window;


### PR DESCRIPTION
## Summary

  - Replace 14 .lock().unwrap() with poison-safe unwrap_or_else
  - Invalid config JSON now exits with a clear error instead of silent fallback
  - Fix /loop command never starting iteration 1
  - Fix status bar directory display on Windows (Path::file_name())
  - Pass configured max_agent_turns through run_print (was hardcoded 100)
  - Auto-detect shell for loop --run (powershell on Windows, sh elsewhere)
  - Replace let _ = with error reporting for session/transcript saves
  - Add 22 tests for PermissionChecker and EditTool
  - debug = false in release profile

  ## Test plan

  - [x] cargo check — zero errors
  - [x] cargo clippy — no new warnings
  - [x] cargo test — 29/29 passed