### PR TITLE
Allow API key env override to bypass API key resolution

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -105,7 +105,7 @@ fn resolve_api_key(
         return Ok(String::new());
     }
 
-    if kind == ProviderKind::Custom {
+    if kind == ProviderKind::Custom || api_key_env_override.is_some() {
         return Ok(String::new());
     }
 


### PR DESCRIPTION
```diff
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -105,7 +105,7 @@ fn resolve_api_key(
         return Ok(String::new());
     }
 
-    if kind == ProviderKind::Custom {
+    if kind == ProviderKind::Custom || api_key_env_override.is_some() {
         return Ok(String::new());
     }
 
```

This change allows custom providers (like `local-vllm` with `provider_type: "openai"`) to work without requiring an API key. Previously, only `ProviderKind::Custom` would allow empty keys, but when using a custom provider with `provider_type: "openai"`, the kind was resolved to `ProviderKind::OpenAI`, causing the authentication error. Now, any custom provider configuration with an `api_key_env` override can work with an empty/missing API key.

my example config.json
```json
{
  "provider": "local-vllm",
  "model": "local",
  "max_tokens": 8192,
  "custom_providers": {
    "local-vllm": {
      "provider_type": "openai",
      "base_url": "http://192.168.0.124:8888/v1",
      "api_key_env": "sk-dummy"
    }
  },
  "permission": {},
  "mcp_servers": {
    "semble": {"command": "uvx", "args": ["--from", "semble[mcp]", "semble"]},
    "context7": {
      "url": "https://mcp.context7.com/mcp",
      "headers": {
        "CONTEXT7_API_KEY": "ctx7sk-XXX"
      }
    }
  }
}
```