### PR TITLE
feat: OSC 52 clipboard fallback when no external tool available

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -685,4 +685,29 @@ pub fn copy_to_clipboard(text: &str) {
             return;
         }
     }
+
+    // OSC 52 escape sequence — clipboard access via terminal emulator.
+    // Supported by Kitty, Alacritty, WezTerm, foot, iTerm2, Windows Terminal,
+    // and most other modern terminals. No external tools needed.
+    let encoded = base64_encode(text.as_bytes());
+    let mut stdout = std::io::stdout().lock();
+    let _ = write!(stdout, "\x1b]52;c;{encoded}\x07");
+    let _ = stdout.flush();
+}
+
+/// Minimal base64 encoder — avoids pulling in a crate just for clipboard support.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[(triple >> 18) & 63] as char);
+        out.push(ALPHABET[(triple >> 12) & 63] as char);
+        out.push(if chunk.len() > 1 { ALPHABET[(triple >> 6) & 63] } else { b'=' } as char);
+        out.push(if chunk.len() > 2 { ALPHABET[triple & 63] } else { b'=' } as char);
+    }
+    out
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -685,4 +685,81 @@ pub fn copy_to_clipboard(text: &str) {
             return;
         }
     }
+
+    // OSC 52 escape sequence — clipboard access via terminal emulator.
+    // Supported by Kitty, Alacritty, WezTerm, foot, iTerm2, Windows Terminal,
+    // and most other modern terminals. No external tools needed.
+    let encoded = base64_encode(text.as_bytes());
+    let mut stdout = std::io::stdout().lock();
+    let _ = write!(stdout, "\x1b]52;c;{encoded}\x07");
+    let _ = stdout.flush();
+}
+
+/// Minimal base64 encoder — avoids pulling in a crate just for clipboard support.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[(triple >> 18) & 63] as char);
+        out.push(ALPHABET[(triple >> 12) & 63] as char);
+        out.push(if chunk.len() > 1 { ALPHABET[(triple >> 6) & 63] } else { b'=' } as char);
+        out.push(if chunk.len() > 2 { ALPHABET[triple & 63] } else { b'=' } as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_encode_empty() {
+        assert_eq!(base64_encode(b""), "");
+    }
+
+    #[test]
+    fn base64_encode_single_byte() {
+        assert_eq!(base64_encode(b"f"), "Zg==");
+    }
+
+    #[test]
+    fn base64_encode_two_bytes() {
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+    }
+
+    #[test]
+    fn base64_encode_three_bytes() {
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+    }
+
+    #[test]
+    fn base64_encode_known_values() {
+        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
+        assert_eq!(base64_encode(b"Hi!"), "SGkh");
+        assert_eq!(base64_encode(b"ab"), "YWI=");
+        assert_eq!(base64_encode(b"abc"), "YWJj");
+        assert_eq!(base64_encode(b"Man"), "TWFu");
+    }
+
+    #[test]
+    fn base64_encode_long_input() {
+        let input = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+        let encoded = base64_encode(input.as_bytes());
+        assert!(encoded.len() > input.len());
+        assert!(encoded.ends_with('=') || !encoded.contains('='));
+    }
+
+    #[test]
+    fn copy_to_clipboard_does_not_panic() {
+        copy_to_clipboard("test text");
+    }
+
+    #[test]
+    fn copy_to_clipboard_empty_string() {
+        copy_to_clipboard("");
+    }
 }


### PR DESCRIPTION
When wl-copy/xclip/pbcopy/clip.exe are all absent, use OSC 52
escape sequences to copy selection to the system clipboard.

Works in most modern terminals (Kitty, Alacritty, WezTerm, foot,
iTerm2, Windows Terminal) without any external dependencies.

Includes a minimal inline base64 encoder with tests.