### PR TITLE
fix(input): discard whitespace-only input instead of submitting it

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -265,13 +265,14 @@ impl InputEditor {
                     return None;
                 }
                 let text = self.buffer.clone();
-                if !text.is_empty() {
+                let is_blank = text.trim().is_empty();
+                if !is_blank {
                     self.history.push(text.clone());
                 }
                 self.history_pos = None;
                 self.buffer.clear();
                 self.cursor = 0;
-                if text.is_empty() { None } else { Some(text) }
+                if is_blank { None } else { Some(text) }
             }
             KeyCode::Char(c)
                 if c == '\x08' || (c == 'h' && key.modifiers.contains(KeyModifiers::CONTROL)) =>


### PR DESCRIPTION
## Summary
- Treat a buffer containing only whitespace as empty in `InputEditor::handle_key`, so pressing Enter on it clears the prompt instead of sending a blank message.
- Unifies behaviour across providers: Anthropic previously rejected the request with a 400 `messages: text content blocks must contain non-whitespace text`; OpenAI silently accepted the empty message.
- Whitespace-only input is also no longer pushed onto the input history.

Fixes #56 