### PR TITLE
fix: eliminate cursor and input area flicker during rendering

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -588,8 +588,16 @@ pub async fn run_interactive(
                                     );
                                 }
                             }
+                            refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        } else if is_running {
+                            refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        } else {
+                            let status = StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref());
+                            renderer.draw_bottom(&input.buffer, input.cursor, &status, is_running)?;
+                            if let Some(ref picker) = input.picker {
+                                picker.draw()?;
+                            }
                         }
-                        refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
                     }
                 }
             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use compact_str::CompactString;
 use crossterm::ExecutableCommand;
-use crossterm::cursor::MoveTo;
+use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::style::{Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor};
 use crossterm::terminal::{Clear, ClearType, ScrollUp};
 
@@ -252,6 +252,7 @@ impl Renderer {
         let visible = rows.saturating_sub(2) as usize;
         let total = self.buffer.len();
         let mut stdout = io::stdout();
+        write!(stdout, "{}", Hide)?;
 
         let start = if self.scroll_offset == 0 {
             total.saturating_sub(visible)
@@ -659,6 +660,7 @@ impl Renderer {
             (rows.saturating_sub(2) - visible_line_count as u16 + 1) + cursor_render_idx as u16;
         let cursor_x = (prompt_width + cursor_col.saturating_sub(h_scroll)) as u16;
         stdout.execute(MoveTo(cursor_x, cursor_row))?;
+        write!(stdout, "{}", Show)?;
         stdout.flush()?;
         Ok(())
     }


### PR DESCRIPTION
Fixes two sources of flicker:

1. Cursor flicker on empty lines - terminal hardware cursor was visible during render_viewport as it moved through column 0 of every row. Now hidden via crossterm cursor Hide during rendering and only shown after the cursor reaches its correct input-area position.

2. Input area and status line flicker during typing - every keystroke triggered a full render_viewport (chat area redraw) even though only the input buffer changed. Now skips the viewport for input-only edits when agent is idle. Falls back to full redraw when agent is streaming (is_running) to ensure latest tokens remain visible.