### PR TITLE
Add danger_accept_invalid_certs toggle for custom providers

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,6 +22,8 @@ pub struct CustomProviderConfig {
     pub provider_type: String,
     pub base_url: String,
     pub api_key_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub danger_accept_invalid_certs: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -45,6 +45,7 @@ pub struct ProviderInfo {
     pub kind: ProviderKind,
     pub base_url: Option<String>,
     pub api_key_env: Option<String>,
+    pub danger_accept_invalid_certs: bool,
 }
 
 pub fn resolve_provider_info(
@@ -57,6 +58,7 @@ pub fn resolve_provider_info(
             kind,
             base_url: Some(custom.base_url.clone()),
             api_key_env: custom.api_key_env.clone(),
+            danger_accept_invalid_certs: custom.danger_accept_invalid_certs.unwrap_or(false),
         });
     }
     let kind = parse_provider(name)?;
@@ -64,6 +66,7 @@ pub fn resolve_provider_info(
         kind,
         base_url: None,
         api_key_env: None,
+        danger_accept_invalid_certs: false,
     })
 }
 
@@ -310,23 +313,42 @@ pub fn create_client(
         }
     });
 
+    let http_client = if info.danger_accept_invalid_certs {
+        tracing::warn!(
+            "TLS certificate verification DISABLED for provider '{}' \
+             (danger_accept_invalid_certs = true). Connections are vulnerable to MITM.",
+            provider_name
+        );
+        reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()?
+    } else {
+        reqwest::Client::default()
+    };
+
     match info.kind {
         ProviderKind::OpenAI => {
-            let mut b = openai::CompletionsClient::builder().api_key(&key);
+            let mut b = openai::CompletionsClient::builder()
+                .api_key(&key)
+                .http_client(http_client.clone());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
             }
             Ok(AnyClient::OpenAI(b.build()?))
         }
         ProviderKind::Anthropic => {
-            let mut b = anthropic::Client::builder().api_key(&key);
+            let mut b = anthropic::Client::builder()
+                .api_key(&key)
+                .http_client(http_client.clone());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
             }
             Ok(AnyClient::Anthropic(b.build()?))
         }
         ProviderKind::Gemini => {
-            let mut b = gemini::Client::builder().api_key(&key);
+            let mut b = gemini::Client::builder()
+                .api_key(&key)
+                .http_client(http_client.clone());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
             }
@@ -334,14 +356,18 @@ pub fn create_client(
         }
         ProviderKind::Ollama => {
             let key: ollama::OllamaApiKey = key.as_str().into();
-            let mut b = ollama::Client::builder().api_key(key);
+            let mut b = ollama::Client::builder()
+                .api_key(key)
+                .http_client(http_client.clone());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
             }
             Ok(AnyClient::Ollama(b.build()?))
         }
         ProviderKind::OpenRouter => {
-            let mut b = openrouter::Client::builder().api_key(&key);
+            let mut b = openrouter::Client::builder()
+                .api_key(&key)
+                .http_client(http_client.clone());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
             }
@@ -355,6 +381,7 @@ pub fn create_client(
             })?;
             let b = openai::CompletionsClient::builder()
                 .api_key(&key)
+                .http_client(http_client)
                 .base_url(&base_url);
             Ok(AnyClient::Custom(b.build()?))
         }


### PR DESCRIPTION
Allows connecting to local inference providers that use selfsigned certs without messing around with CA storage