### PR TITLE
Add model field to custom providers for default model selection

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,7 +50,8 @@ Example (JSON):
     "local-vllm": {
       "provider_type": "openai",
       "base_url": "http://localhost:8000/v1",
-      "api_key_env": "VLLM_API_KEY"
+      "api_key_env": "VLLM_API_KEY",
+      "model": "gemma4"
     },
     "company-gateway": {
       "provider_type": "openai",

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -38,7 +38,13 @@ the `custom_providers` key in the config file:
     "local-vllm": {
       "provider_type": "openai",
       "base_url": "http://localhost:8000/v1",
-      "api_key_env": "VLLM_API_KEY"
+      "api_key_env": "VLLM_API_KEY",
+      "model": "gemma4"
+    },
+    "company-gateway": {
+      "provider_type": "openai",
+      "base_url": "https://gateway.example.com/v1",
+      "model": "glm"
     }
   }
 }
@@ -53,6 +59,7 @@ the `custom_providers` key in the config file:
 | `headers`                    | object  | Optional. HTTP headers to include in every request. Values support `${ENV_VAR}` expansion. |
 | `danger_accept_invalid_certs`| boolean | Optional. Disables TLS certificate verification (MITM risk — use with care). |
 | `timeout_secs`               | integer | Optional. Overrides the default HTTP timeout. |
+| `model`                      | string  | Optional. Default model name for this provider. Used when no model is specified via `--model` or `ZS_MODEL`. |
 
 ### Header variable expansion
 

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -1,11 +1,11 @@
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
-use crate::agent::tools::{
-    AskSender, EditArgs, EditBlock, EditOp, PermCheck, ToolError, check_perm_path,
-    edit_system, levenshtein_similarity, normalize_whitespace,
-};
 use crate::agent::tools::crc::crc32_hex;
+use crate::agent::tools::{
+    AskSender, EditArgs, EditBlock, EditOp, PermCheck, ToolError, check_perm_path, edit_system,
+    levenshtein_similarity, normalize_whitespace,
+};
 use crate::config::types::EditSystem;
 
 pub struct EditTool {
@@ -135,7 +135,8 @@ fn compute_byte_range(content: &str, norm_pos: usize, norm_len: usize) -> (usize
         }
 
         // CRLF edge case: original \r\n maps to a single \n in normalized
-        if b == b'\r' && norm_rem < content_norm.len() && content_norm.as_bytes()[norm_rem] == b'\n' {
+        if b == b'\r' && norm_rem < content_norm.len() && content_norm.as_bytes()[norm_rem] == b'\n'
+        {
             orig_pos += 1;
             continue;
         }
@@ -225,7 +226,11 @@ fn count_exact_matches(content: &str, search: &str) -> usize {
     content.match_indices(search).count()
 }
 
-async fn handle_similarity(path: &str, block: &str, content: &str) -> Result<(Vec<String>, Vec<(usize, usize, String)>), ToolError> {
+async fn handle_similarity(
+    path: &str,
+    block: &str,
+    content: &str,
+) -> Result<(Vec<String>, Vec<(usize, usize, String)>), ToolError> {
     let blocks = parse_blocks(block)?;
 
     struct ResolvedSim {
@@ -331,7 +336,7 @@ async fn handle_similarity(path: &str, block: &str, content: &str) -> Result<(Ve
 // ── V2: Hashedit (tag-based) ────────────────────────────────────────────
 
 fn parse_tagged_line(raw: &str) -> Option<(usize, String)> {
-    let stripped = raw.trim_start_matches(|c: char| c == ' ' || c == '\t');
+    let stripped = raw.trim_start_matches([' ', '\t']);
     let (num_tag, _content) = stripped.split_once(' ')?;
     let (num_str, tag) = num_tag.split_once('|')?;
     let line_num: usize = num_str.parse().ok()?;
@@ -367,7 +372,11 @@ fn extract_line_info(lines_raw: &str) -> Result<Vec<(usize, String)>, ToolError>
 fn validate_tag(content_lines: &[&str], line_num: usize, tag: &str) -> Result<(), ToolError> {
     let idx = line_num.saturating_sub(1);
     let actual = content_lines.get(idx).ok_or_else(|| {
-        ToolError::Msg(format!("Line {} is out of range (file has {} lines)", line_num, content_lines.len()))
+        ToolError::Msg(format!(
+            "Line {} is out of range (file has {} lines)",
+            line_num,
+            content_lines.len()
+        ))
     })?;
     let expected = crc32_hex(actual.as_bytes());
     if expected != tag {
@@ -379,7 +388,11 @@ fn validate_tag(content_lines: &[&str], line_num: usize, tag: &str) -> Result<()
     Ok(())
 }
 
-fn line_range_to_byte_range(content_lines: &[&str], start_line: usize, end_line: usize) -> (usize, usize) {
+fn line_range_to_byte_range(
+    content_lines: &[&str],
+    start_line: usize,
+    end_line: usize,
+) -> (usize, usize) {
     if content_lines.is_empty() || start_line == 0 || start_line > content_lines.len() {
         return (0, 0);
     }
@@ -437,9 +450,8 @@ async fn handle_hashedit(
                         label, single_line
                     ))
                 })?;
-                validate_tag(&content_lines, line_num, &tag).map_err(|e| {
-                    ToolError::Msg(format!("{}{}", label, e))
-                })?;
+                validate_tag(&content_lines, line_num, &tag)
+                    .map_err(|e| ToolError::Msg(format!("{}{}", label, e)))?;
 
                 let (byte_start, byte_end) =
                     line_range_to_byte_range(&content_lines, line_num, line_num);
@@ -448,9 +460,8 @@ async fn handle_hashedit(
             (None, Some(multi_lines)) => {
                 let entries = extract_line_info(multi_lines)?;
                 for &(line_num, ref tag) in &entries {
-                    validate_tag(&content_lines, line_num, tag).map_err(|e| {
-                        ToolError::Msg(format!("{}{}", label, e))
-                    })?;
+                    validate_tag(&content_lines, line_num, tag)
+                        .map_err(|e| ToolError::Msg(format!("{}{}", label, e)))?;
                 }
                 let start_line = entries[0].0;
                 let end_line = entries[entries.len() - 1].0;

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -1,4 +1,5 @@
 mod bash;
+pub(crate) mod crc;
 pub(crate) mod edit;
 mod find_files;
 mod grep;
@@ -7,7 +8,6 @@ mod normalize;
 pub(crate) mod read;
 mod todo;
 mod write;
-pub(crate) mod crc;
 
 pub(crate) use normalize::{levenshtein_similarity, normalize_whitespace};
 

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -2,7 +2,9 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use crate::agent::tools::crc::crc32_hex;
-use crate::agent::tools::{edit_system, AskSender, PermCheck, ReadArgs, ToolError, check_perm_path};
+use crate::agent::tools::{
+    AskSender, PermCheck, ReadArgs, ToolError, check_perm_path, edit_system,
+};
 use crate::config::types::EditSystem;
 
 const DEFAULT_MAX_TEXT_SIZE: u64 = 1024 * 1024;
@@ -102,7 +104,13 @@ impl Tool for ReadTool {
                         let line_num = offset + i + 1;
                         let tag = crc32_hex(line.as_bytes());
                         let line_num_width = if total_lines >= 1000 { 4 } else { 3 };
-                        format!("{:>width$}|{} {}", line_num, tag, line, width = line_num_width)
+                        format!(
+                            "{:>width$}|{} {}",
+                            line_num,
+                            tag,
+                            line,
+                            width = line_num_width
+                        )
                     })
                     .collect::<Vec<_>>()
                     .join("\n")

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -29,6 +29,8 @@ pub struct CustomProviderConfig {
     pub headers: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<CompactString>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -54,7 +56,10 @@ impl std::str::FromStr for EditSystem {
         match s {
             "similarity" => Ok(EditSystem::Similarity),
             "hashedit" => Ok(EditSystem::Hashedit),
-            _ => Err(format!("unknown edit system '{}' (valid: similarity, hashedit)", s)),
+            _ => Err(format!(
+                "unknown edit system '{}' (valid: similarity, hashedit)",
+                s
+            )),
         }
     }
 }

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -145,7 +145,15 @@ async fn run_prompt(
     cx: ConnectionTo<Client>,
 ) -> Result<(), agent_client_protocol::Error> {
     let provider_str = state.cli.resolve_provider(&state.cfg);
-    let model_str = state.cli.resolve_model(&state.cfg);
+    let mut model_str = state.cli.resolve_model(&state.cfg);
+
+    // Custom provider model override (if no explicit model set)
+    if (model_str.as_str() == "deepseek/deepseek-v4-flash" || state.cli.model.is_none())
+        && let Some(custom) = state.cfg.custom_providers_map().get(provider_str.as_str())
+        && let Some(ref custom_model) = custom.model
+    {
+        model_str = custom_model.clone();
+    }
 
     let client = crate::provider::create_client(
         &provider_str,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -16,13 +16,13 @@ pub fn expand_tilde(s: &str) -> String {
         }
         return s.to_string();
     }
-    if let Some(rest) = s.strip_prefix("$HOME/") {
-        if let Some(h) = home() {
-            return std::path::Path::new(&h)
-                .join(rest)
-                .to_string_lossy()
-                .to_string();
-        }
+    if let Some(rest) = s.strip_prefix("$HOME/")
+        && let Some(h) = home()
+    {
+        return std::path::Path::new(&h)
+            .join(rest)
+            .to_string_lossy()
+            .to_string();
     }
     s.to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,14 @@ async fn main() -> anyhow::Result<()> {
         model = qm.model.clone();
     }
 
+    // Custom provider model override (if no explicit model set)
+    if let Some(custom) = cfg.custom_providers_map().get(provider.as_str())
+        && (model.as_str() == "deepseek/deepseek-v4-flash" || cli.model.is_none())
+        && let Some(ref custom_model) = custom.model
+    {
+        model = custom_model.clone();
+    }
+
     let mut session = session::Session::new(&provider, &model, cfg.resolve_context_window());
 
     if cli.resume && cli.session.is_none() && !cli.continue_session {

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -324,7 +324,8 @@ impl PermissionChecker {
                 let expanded = crate::fs::expand_tilde(pat);
                 let abs = resolve_absolute(&expanded, &self.working_dir);
                 if abs != expanded {
-                    self.session_allowlist.push((tool.clone(), Pattern::new(&abs)));
+                    self.session_allowlist
+                        .push((tool.clone(), Pattern::new(&abs)));
                 }
             }
         }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -593,6 +593,7 @@ mod tests {
             api_style,
             headers: std::collections::HashMap::new(),
             timeout_secs: None,
+            model: None,
         }
     }
 

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -436,8 +436,7 @@ fn mcp_tool_simple_rule_is_respected() {
         mcp_tool: Some(ToolPerm::Simple(Action::Deny)),
         ..PermissionConfig::default()
     };
-    let mut checker =
-        PermissionChecker::new(&configs_from(config), SecurityMode::Standard, None);
+    let mut checker = PermissionChecker::new(&configs_from(config), SecurityMode::Standard, None);
     let result = checker.check("mcp_tool", "mcp_tool:filesystem:read_file");
     assert!(
         matches!(result, CheckResult::Denied(_)),
@@ -458,8 +457,7 @@ fn mcp_tool_granular_rules_respected() {
         )),
         ..PermissionConfig::default()
     };
-    let mut checker =
-        PermissionChecker::new(&configs_from(config), SecurityMode::Standard, None);
+    let mut checker = PermissionChecker::new(&configs_from(config), SecurityMode::Standard, None);
     assert_eq!(
         checker.check("mcp_tool", "mcp_tool:fs:allow_read"),
         CheckResult::Allowed

--- a/src/tests/edit_tests.rs
+++ b/src/tests/edit_tests.rs
@@ -1,6 +1,6 @@
 use crate::agent::tools::crc::crc32_hex;
+use crate::agent::tools::set_edit_system;
 use crate::agent::tools::{EditArgs, EditOp, edit};
-use crate::agent::tools::{set_edit_system};
 use crate::config::types::EditSystem;
 use rig::tool::Tool;
 
@@ -56,9 +56,7 @@ async fn test_sim_rejects_empty_search() {
     let result = tool
         .call(EditArgs {
             path: tmp.path().into(),
-            block: Some(
-                "<<<<<<< SEARCH\n=======\nreplacement\n>>>>>>> REPLACE".into(),
-            ),
+            block: Some("<<<<<<< SEARCH\n=======\nreplacement\n>>>>>>> REPLACE".into()),
             file_crc: None,
             edits: None,
         })
@@ -99,9 +97,7 @@ async fn test_sim_single_block_replacement() {
     let result = tool
         .call(EditArgs {
             path: tmp.path().into(),
-            block: Some(
-                "<<<<<<< SEARCH\nafter\n=======\nmiddle\n>>>>>>> REPLACE".into(),
-            ),
+            block: Some("<<<<<<< SEARCH\nafter\n=======\nmiddle\n>>>>>>> REPLACE".into()),
             file_crc: None,
             edits: None,
         })
@@ -155,9 +151,7 @@ async fn test_sim_multi_match_returns_error() {
     let result = tool
         .call(EditArgs {
             path: tmp.path().into(),
-            block: Some(
-                "<<<<<<< SEARCH\nhello\n=======\nbye\n>>>>>>> REPLACE".into(),
-            ),
+            block: Some("<<<<<<< SEARCH\nhello\n=======\nbye\n>>>>>>> REPLACE".into()),
             file_crc: None,
             edits: None,
         })
@@ -175,9 +169,7 @@ async fn test_sim_preserves_crlf_line_endings() {
     let tool = edit::EditTool::new(None, None);
     tool.call(EditArgs {
         path: tmp.path().into(),
-        block: Some(
-            "<<<<<<< SEARCH\nline2\n=======\nmodified\n>>>>>>> REPLACE".into(),
-        ),
+        block: Some("<<<<<<< SEARCH\nline2\n=======\nmodified\n>>>>>>> REPLACE".into()),
         file_crc: None,
         edits: None,
     })

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -132,10 +132,10 @@ async fn ensure_mcp_manager<'a>(
     mcp: &'a mut Option<McpClientManager>,
     cfg: &'a Config,
 ) -> Option<&'a McpClientManager> {
-    if mcp.is_none() {
-        if let Some(servers) = &cfg.mcp_servers {
-            *mcp = Some(McpClientManager::connect_all(servers).await);
-        }
+    if mcp.is_none()
+        && let Some(servers) = &cfg.mcp_servers
+    {
+        *mcp = Some(McpClientManager::connect_all(servers).await);
     }
     mcp.as_ref()
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -499,10 +499,7 @@ impl Renderer {
                         if break_at != idx {
                             end = break_at;
                             // Recalculate width for the shortened chunk
-                            w = chars[idx..end]
-                                .iter()
-                                .map(|&c| char_display_width(c))
-                                .sum();
+                            w = chars[idx..end].iter().map(|&c| char_display_width(c)).sum();
                         }
                     }
                     let chunk: String = chars[idx..end].iter().collect();

--- a/src/ui/slash/settings.rs
+++ b/src/ui/slash/settings.rs
@@ -133,8 +133,14 @@ async fn handle_editsys(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resul
     let current = tools::edit_system();
     if parts.len() < 2 {
         write_ok(ctx.renderer, format!("edit system: {}", current));
-        write_result(ctx.renderer, "  /editsys similarity   SEARCH/REPLACE with fuzzy matching");
-        write_result(ctx.renderer, "  /editsys hashedit     tag-based (CRC-32 line hashes)");
+        write_result(
+            ctx.renderer,
+            "  /editsys similarity   SEARCH/REPLACE with fuzzy matching",
+        );
+        write_result(
+            ctx.renderer,
+            "  /editsys hashedit     tag-based (CRC-32 line hashes)",
+        );
         return Ok(());
     }
     match parts[1] {
@@ -146,7 +152,10 @@ async fn handle_editsys(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resul
             tools::set_edit_system(EditSystem::Hashedit);
             write_ok(ctx.renderer, "edit system: hashedit (tag-based)");
         }
-        _ => write_error(ctx.renderer, format!("unknown: '{}' (similarity|hashedit)", parts[1])),
+        _ => write_error(
+            ctx.renderer,
+            format!("unknown: '{}' (similarity|hashedit)", parts[1]),
+        ),
     }
     Ok(())
 }


### PR DESCRIPTION
Custom providers can now specify a default model that overrides the system
default when no explicit model is set via CLI or environment variable.