### PR TITLE
fix(subagents): don't hard-fail when default subagent provider lacks a key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ async fn main() -> anyhow::Result<()> {
         let qm = config::quick_models_map(&cfg);
 
         // Resolve subagent model: subagent_model config > subagent_provider + model > deepseek-v4-flash quick model
-        let (sub_provider, sub_model) = if let Some(sa_model) = &cfg.subagent_model {
+        let (sub_provider, mut sub_model) = if let Some(sa_model) = &cfg.subagent_model {
             if let Some(q) = qm.get(sa_model.as_str()) {
                 (q.provider.clone(), q.model.clone())
             } else {
@@ -271,12 +271,32 @@ async fn main() -> anyhow::Result<()> {
         let sub_client = if sub_provider.as_str() == provider {
             client.clone()
         } else {
-            crate::provider::create_client(
+            match crate::provider::create_client(
                 &sub_provider,
                 cli.api_key.as_deref(),
                 &cfg.custom_providers_map(),
                 cfg.api_keys.as_ref(),
-            )?
+            ) {
+                Ok(c) => c,
+                Err(e) => {
+                    // The default subagent provider can differ from the main one
+                    // (the built-in `deepseek-v4-flash` default uses OpenRouter).
+                    // If its credentials are missing, don't abort the whole program:
+                    // fall back to the main agent's client and model so users on a
+                    // single provider (e.g. Anthropic-only) can still start.
+                    tracing::warn!(
+                        "Could not initialize subagent provider '{}' ({}); \
+                         falling back to main provider '{}'. \
+                         Set `subagent_provider`/`subagent_model` in config, or the \
+                         provider's API key, to silence this.",
+                        sub_provider,
+                        e,
+                        provider
+                    );
+                    sub_model = model.clone();
+                    client.clone()
+                }
+            }
         };
 
         crate::extras::subagents::init(


### PR DESCRIPTION
## What

Make subagent client creation non-fatal. When the subagent provider client cannot be created, log a warning and fall back to the main agent's client and model instead of aborting the whole program.

## Why

Fixes #76.

With the default `subagents` feature enabled and no `subagent_provider` or `subagent_model` configured, the subagent falls back to the built-in `deepseek-v4-flash` quick model, which is pinned to OpenRouter. The previous code propagated the client creation error with `?`, so any user on a different main provider (Anthropic, OpenAI, Gemini, Ollama) who did not also set `OPENROUTER_API_KEY` was hard blocked at startup with a misleading "No API key found ... OPENROUTER_API_KEY" error, even though they never opted into OpenRouter.

## Behavior after this change

* Single provider users start successfully. The subagent reuses the main provider's client and model, and a one line warning explains how to silence it.
* Users who have OpenRouter credentials are unaffected and keep the cheap `deepseek-v4-flash` default subagent.

## Testing

Built with default features. With `ANTHROPIC_API_KEY` set and `OPENROUTER_API_KEY` unset:

Before this change:
```
$ zerostack --provider=anthropic --model=claude-haiku-4-5
Error: No API key found. Set the OPENROUTER_API_KEY environment variable, ...
```

After this change:
```
$ zerostack --provider=anthropic --model=claude-haiku-4-5
WARN zerostack: Could not initialize subagent provider 'openrouter' (...); falling back to main provider 'anthropic'. ...
(runs normally)
```
