### PR TITLE
fix(ui): prevent silently orphaning the running agent run (single-flight + real Ctrl-C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,29 @@ This is a list of the most important slash commands:
 - `/loop` — Schedule recurring prompts
 - `/prompt` — List or change the agent's prompt
 - `/mode` — Set the permission system's mode
+- `/queue` — Manage input queued while the agent is busy
 
 To see all of the commands, use `/help`.
+
+## Input queue
+
+You can keep typing while the agent is running. Plain text is not sent right
+away and never starts a second concurrent run; it is queued and replayed as the
+next prompt once the current run finishes. Each queued line is shown as
+`queued: <text>`.
+
+Manage the queue with `/queue`, which works even while a run is active:
+
+- `/queue ls` lists the pending inputs (bare `/queue` does the same)
+- `/queue clear` empties the queue
+- `/queue pop` removes the last queued input, to undo a mis-typed line
+
+Selecting `/queue` in the command picker opens a second-level menu with these
+three subcommands, so you do not need to remember them.
+
+Commands (input starting with `/`, `.`, or `!`) are not queued while a run is
+active: wait for it to finish, or press Ctrl-C. Ctrl-C cancels the running agent
+for real, including any child processes it spawned, and clears the queue.
 
 ## Session management
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -11,6 +11,10 @@ use crate::session::{MessageRole, Session};
 
 pub struct AgentRunner {
     pub event_rx: mpsc::Receiver<AgentEvent>,
+    /// Cancels the underlying agent task. Without this a superseded or
+    /// interrupted run keeps driving its stream — and therefore keeps executing
+    /// tools (edit/write/bash) — invisibly. Aborting stops it for real.
+    pub abort_handle: tokio::task::AbortHandle,
 }
 
 pub fn convert_history(session: &Session) -> Vec<Message> {
@@ -48,7 +52,7 @@ where
     #[cfg(feature = "subagents")]
     crate::extras::subagents::set_subagent_event_tx(event_tx.clone());
 
-    tokio::spawn(async move {
+    let join = tokio::spawn(async move {
         // Clone prompt and history so they're available for a potential retry
         // when the model returns an empty final response.
         let retry_prompt = prompt.clone();
@@ -149,7 +153,10 @@ where
         }
     });
 
-    AgentRunner { event_rx }
+    AgentRunner {
+        event_rx,
+        abort_handle: join.abort_handle(),
+    }
 }
 
 pub async fn run_print<M, P>(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -51,6 +51,7 @@ impl Sandbox {
         if !self.enabled {
             let mut cmd = Command::new(&self.shell);
             cmd.arg("-c").arg(command);
+            cmd.kill_on_drop(true);
             return cmd;
         }
 
@@ -61,6 +62,7 @@ impl Sandbox {
                 tracing::warn!("sandbox: zerobox not found, running unsandboxed");
                 let mut cmd = Command::new(&self.shell);
                 cmd.arg("-c").arg(command);
+                cmd.kill_on_drop(true);
                 return cmd;
             }
             let mut cmd = Command::new("zerobox");
@@ -70,6 +72,7 @@ impl Sandbox {
             cmd.arg(&self.shell);
             cmd.arg("-c");
             cmd.arg(command);
+            cmd.kill_on_drop(true);
             return cmd;
         }
 
@@ -77,6 +80,7 @@ impl Sandbox {
             tracing::warn!("sandbox: bwrap not found, running unsandboxed");
             let mut cmd = Command::new(&self.shell);
             cmd.arg("-c").arg(command);
+            cmd.kill_on_drop(true);
             return cmd;
         }
 
@@ -110,6 +114,7 @@ impl Sandbox {
             "-c",
             command,
         ]);
+        cmd.kill_on_drop(true);
         cmd
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,8 @@ mod input_tests;
 mod memory_tests;
 #[cfg(test)]
 mod picker_tests;
+#[cfg(test)]
+mod singleflight_tests;
 #[cfg(all(test, feature = "subagents"))]
 mod subagents_tests;
 #[cfg(all(test, feature = "git-worktree"))]

--- a/src/tests/singleflight_tests.rs
+++ b/src/tests/singleflight_tests.rs
@@ -1,0 +1,68 @@
+//! Tests for the single-flight submission policy that prevents orphaning a
+//! running main agent run.
+
+use crate::ui::{SubmitAction, allowed_while_running, classify_submission};
+
+#[test]
+fn idle_runs_immediately() {
+    assert_eq!(classify_submission(false, "hello"), SubmitAction::Run);
+    assert_eq!(classify_submission(false, "/help"), SubmitAction::Run);
+}
+
+#[test]
+fn running_plain_text_is_queued() {
+    // The whole point: typing while busy must NOT spawn a second run.
+    assert_eq!(classify_submission(true, "ok"), SubmitAction::Queue);
+    assert_eq!(
+        classify_submission(true, "compile this"),
+        SubmitAction::Queue
+    );
+    assert_eq!(
+        classify_submission(true, "  leading space"),
+        SubmitAction::Queue
+    );
+}
+
+#[test]
+fn running_commands_are_rejected_not_queued() {
+    // Commands not on the `allowed_while_running` whitelist are rejected while a
+    // run is active (they can't be cleanly queued/replayed).
+    assert_eq!(
+        classify_submission(true, "/model gpt"),
+        SubmitAction::RejectWhileRunning
+    );
+    assert_eq!(
+        classify_submission(true, ".prompt"),
+        SubmitAction::RejectWhileRunning
+    );
+    assert_eq!(
+        classify_submission(true, "!ls"),
+        SubmitAction::RejectWhileRunning
+    );
+    assert_eq!(
+        classify_submission(true, "   /compress"),
+        SubmitAction::RejectWhileRunning
+    );
+}
+
+#[test]
+fn whitelisted_commands_pass_through_while_running() {
+    // /queue manages the queue and must work while a run is active, so it
+    // classifies as Run (falls through to its handler) instead of being gated.
+    assert!(allowed_while_running("/queue"));
+    assert!(allowed_while_running("/queue ls"));
+    assert!(allowed_while_running("/queue clear"));
+    assert!(allowed_while_running("  /queue pop"));
+    assert!(!allowed_while_running("/model gpt"));
+    assert!(!allowed_while_running("hello"));
+
+    assert_eq!(classify_submission(true, "/queue"), SubmitAction::Run);
+    assert_eq!(classify_submission(true, "/queue ls"), SubmitAction::Run);
+    assert_eq!(classify_submission(true, "/queue clear"), SubmitAction::Run);
+}
+
+#[test]
+fn running_empty_is_ignored() {
+    assert_eq!(classify_submission(true, ""), SubmitAction::Ignore);
+    assert_eq!(classify_submission(true, "   "), SubmitAction::Ignore);
+}

--- a/src/ui/cmd_picker.rs
+++ b/src/ui/cmd_picker.rs
@@ -45,6 +45,7 @@ const COMMANDS: &[&str] = &[
     "/wt-merge",
     "/wt-exit",
     "/btw",
+    "/queue",
 ];
 
 pub struct CommandPicker {

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -280,6 +280,19 @@ pub fn handle_command_picker_key(
                     tp.activate();
                     return (true, Some(Picker::Theme(tp)));
                 }
+                if selected == "/queue" {
+                    // Open a second-level picker for the queue subcommands so
+                    // they don't clutter the top-level command list.
+                    picker.deactivate();
+                    let mut qp = PromptPicker::with_prefix("/queue ");
+                    qp.set_items(vec![
+                        "ls".to_string(),
+                        "clear".to_string(),
+                        "pop".to_string(),
+                    ]);
+                    qp.activate();
+                    return (true, Some(Picker::Prompt(qp)));
+                }
             }
             picker.deactivate();
             (true, None)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -166,6 +166,104 @@ async fn ensure_mcp_manager<'a>(
     mcp.as_ref()
 }
 
+/// What to do with a submitted line, given whether a main run is already active.
+/// Pure decision so it can be unit-tested without a TUI/agent.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SubmitAction {
+    /// Idle: start a run now.
+    Run,
+    /// Running + plain text: queue and replay after the current run finishes.
+    Queue,
+    /// Running + a command (`/`, `.`, `!`): can't queue meaningfully — tell the
+    /// user to wait or Ctrl-C.
+    RejectWhileRunning,
+    /// Empty submit: ignore.
+    Ignore,
+}
+
+/// Commands that are safe to run *even while a main run is active* because they
+/// don't spawn or mutate the main run — the single "bypass" whitelist. Add
+/// future parallel-safe commands here. Currently: `/queue` (queue management).
+pub(crate) fn allowed_while_running(text: &str) -> bool {
+    let t = text.trim_start();
+    t == "/queue" || t.starts_with("/queue ")
+}
+
+pub(crate) fn classify_submission(is_running: bool, text: &str) -> SubmitAction {
+    // Idle, or a whitelisted parallel-safe command → let it through to its
+    // handler. Everything else, while running, is gated.
+    if !is_running || allowed_while_running(text) {
+        return SubmitAction::Run;
+    }
+    let t = text.trim_start();
+    if t.is_empty() {
+        SubmitAction::Ignore
+    } else if t.starts_with('/') || t.starts_with('.') || t.starts_with('!') {
+        SubmitAction::RejectWhileRunning
+    } else {
+        SubmitAction::Queue
+    }
+}
+
+/// Starts a single main agent run for `text` and records its abort handle.
+/// The ONLY place that sets `agent_rx`/`is_running` for user-driven runs, so the
+/// "at most one main run" invariant is enforced in one spot. Callers must ensure
+/// no run is already active (otherwise the previous one would be orphaned).
+#[allow(clippy::too_many_arguments)]
+async fn start_main_run(
+    text: &str,
+    agent: &mut Option<AnyAgent>,
+    client: &AnyClient,
+    session: &mut Session,
+    cli: &Cli,
+    cfg: &Config,
+    context: &ContextFiles,
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    sandbox: &Sandbox,
+    reasoning_enabled: bool,
+    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
+    main_abort: &mut Option<tokio::task::AbortHandle>,
+    is_running: &mut bool,
+    #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
+) {
+    #[cfg(feature = "mcp")]
+    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
+    ensure_agent(
+        agent,
+        client,
+        session,
+        cli,
+        cfg,
+        context,
+        permission,
+        ask_tx,
+        sandbox,
+        reasoning_enabled,
+        #[cfg(feature = "mcp")]
+        mcp_ref,
+    )
+    .await;
+    let history = crate::agent::runner::convert_history(session);
+    let runner = agent
+        .as_ref()
+        .unwrap()
+        .clone()
+        .spawn_runner(text.to_string(), history);
+    *agent_rx = Some(runner.event_rx);
+    *main_abort = Some(runner.abort_handle);
+    *is_running = true;
+    session.add_message(MessageRole::User, text);
+    if !cli.no_session {
+        let _ = crate::session::chat_history::append_entry(
+            &crate::session::chat_history::ChatHistoryEntry {
+                content: text.to_string(),
+                timestamp: session.updated_at.clone(),
+            },
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_interactive(
     mut client: AnyClient,
@@ -208,6 +306,13 @@ pub async fn run_interactive(
     input.load_global_history();
     let mut is_running = false;
     let mut agent_rx: Option<mpsc::Receiver<AgentEvent>> = None;
+    // Abort handle for the single in-flight main run. Enforces "at most one main
+    // run" and lets Ctrl-C actually cancel it (not just stop listening).
+    let mut main_abort: Option<tokio::task::AbortHandle> = None;
+    // Inputs submitted while a main run is active are queued here and replayed
+    // when it finishes — instead of silently spawning a second run that would
+    // orphan the first.
+    let mut pending_inputs: std::collections::VecDeque<String> = std::collections::VecDeque::new();
     let mut agent_line_started = false;
     let mut response_buf = String::new();
     let mut response_start_line: Option<usize> = None;
@@ -363,6 +468,7 @@ pub async fn run_interactive(
             .clone()
             .spawn_runner(trigger_msg.to_string(), history);
         agent_rx = Some(runner.event_rx);
+        main_abort = Some(runner.abort_handle);
         is_running = true;
         session.add_message(MessageRole::User, trigger_msg);
     }
@@ -433,8 +539,15 @@ pub async fn run_interactive(
                             && key.modifiers.contains(KeyModifiers::CONTROL);
                         if is_ctrl_c || is_ctrl_d {
                             if is_running {
+                                // Actually cancel the run's task (not just stop
+                                // listening), so it stops executing tools. bash
+                                // children are killed via kill_on_drop.
+                                if let Some(h) = main_abort.take() {
+                                    h.abort();
+                                }
                                 is_running = false;
                                 agent_rx = None;
+                                pending_inputs.clear();
                                 #[cfg(feature = "loop")]
                                 if let Some(ref mut ls) = loop_state {
                                     ls.active = false;
@@ -452,7 +565,10 @@ pub async fn run_interactive(
                                         guard.restore_user_mode();
                                     }
                                 }
-                                renderer.write_line("interrupted", C_ERROR)?;
+                                renderer.write_line(
+                                    "interrupted (changes may be partial; review with git diff)",
+                                    C_ERROR,
+                                )?;
                                 refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
                             } else {
                                 break;
@@ -578,6 +694,66 @@ pub async fn run_interactive(
                             if renderer.is_scrolling() {
                                 renderer.scroll_to_bottom()?;
                             }
+                            // A main run is active: never spawn a second one (that
+                            // would silently orphan the running one — it would keep
+                            // executing tools, changing files, with no history).
+                            // Whitelisted parallel-safe commands (see
+                            // `allowed_while_running`) classify as `Run` and fall
+                            // through to their handlers below.
+                            match classify_submission(is_running, &text) {
+                                SubmitAction::Run => {}
+                                SubmitAction::Ignore => {
+                                    refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    continue;
+                                }
+                                SubmitAction::RejectWhileRunning => {
+                                    renderer.write_line(
+                                        "agent is running — wait for it to finish or press Ctrl-C before running a command",
+                                        C_ERROR,
+                                    )?;
+                                    refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    continue;
+                                }
+                                SubmitAction::Queue => {
+                                    pending_inputs.push_back(text.to_string());
+                                    renderer.write_line(&format!("queued: {}", sanitize_output(&text)), C_TOOL)?;
+                                    refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    continue;
+                                }
+                            }
+                            // Bypass-slot handlers — commands allowed while running
+                            // (see `allowed_while_running`). Add future
+                            // parallel-safe command handlers here.
+                            {
+                                let t = text.trim_start();
+                                if t == "/queue" || t.starts_with("/queue ") {
+                                    let arg = t.strip_prefix("/queue").unwrap_or("").trim();
+                                    match arg {
+                                        "clear" => {
+                                            let n = pending_inputs.len();
+                                            pending_inputs.clear();
+                                            renderer.write_line(&format!("queue cleared ({} removed)", n), C_TOOL)?;
+                                        }
+                                        "pop" => match pending_inputs.pop_back() {
+                                            Some(x) => renderer.write_line(&format!("unqueued: {}", sanitize_output(&x)), C_TOOL)?,
+                                            None => renderer.write_line("queue is empty", C_TOOL)?,
+                                        },
+                                        "" | "ls" | "list" => {
+                                            if pending_inputs.is_empty() {
+                                                renderer.write_line("queue is empty", C_TOOL)?;
+                                            } else {
+                                                renderer.write_line(&format!("queued ({}):", pending_inputs.len()), C_TOOL)?;
+                                                for (i, q) in pending_inputs.iter().enumerate() {
+                                                    renderer.write_line(&format!("  {}. {}", i + 1, sanitize_output(q)), C_TOOL)?;
+                                                }
+                                            }
+                                        }
+                                        _ => renderer.write_line("usage: /queue [ls|clear|pop]", C_ERROR)?,
+                                    }
+                                    refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    continue;
+                                }
+                            }
                             let mut is_dot_cmd = false;
                             if text.starts_with('.') {
                                 is_dot_cmd = true;
@@ -690,6 +866,7 @@ pub async fn run_interactive(
                                             history,
                                         );
                                         agent_rx = Some(runner.event_rx);
+                                        main_abort = Some(runner.abort_handle);
                                         is_running = true;
                                         btw_active = true;
                                         Ok(())
@@ -773,6 +950,7 @@ pub async fn run_interactive(
                                             ).await;
                                             let runner = agent.as_ref().unwrap().clone().spawn_runner(prompt, history);
                                             agent_rx = Some(runner.event_rx);
+                                            main_abort = Some(runner.abort_handle);
                                             is_running = true;
                                             wt_return_path = Some(main_path);
                                         }
@@ -821,6 +999,7 @@ pub async fn run_interactive(
                                         let history = crate::agent::runner::convert_history(session);
                                         let runner = agent.as_ref().unwrap().clone().spawn_runner(prompt, history);
                                         agent_rx = Some(runner.event_rx);
+                                        main_abort = Some(runner.abort_handle);
                                         is_running = true;
                                     }
                                     Err(e) if e.to_string().starts_with("DEFER_EDITOR:") => {
@@ -876,6 +1055,7 @@ pub async fn run_interactive(
                                             ).await;
                                             let runner = agent.as_ref().unwrap().clone().spawn_runner(prompt, Vec::new());
                                             agent_rx = Some(runner.event_rx);
+                                            main_abort = Some(runner.abort_handle);
                                             is_running = true;
                                             loop_label = Some(ls.iteration_label());
                                         }
@@ -950,30 +1130,14 @@ pub async fn run_interactive(
                                 }
                                 renderer.write_line("", Color::White)?;
 
-                                #[cfg(feature = "mcp")]
-                                let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
-                                ensure_agent(
-                                    &mut agent, &client, session, cli, cfg, context,
+                                // Guaranteed not running here (the is_running gate
+                                // above returns early), so this never orphans a run.
+                                start_main_run(
+                                    &text, &mut agent, &client, session, cli, cfg, context,
                                     &permission, &ask_tx, &sandbox, reasoning_enabled,
-                                    #[cfg(feature = "mcp")] mcp_ref,
+                                    &mut agent_rx, &mut main_abort, &mut is_running,
+                                    #[cfg(feature = "mcp")] &mut mcp_manager,
                                 ).await;
-                                let history = crate::agent::runner::convert_history(session);
-                                let runner = agent.as_ref().unwrap().clone().spawn_runner(
-                                    text.to_string(),
-                                    history,
-                                );
-                                agent_rx = Some(runner.event_rx);
-                                is_running = true;
-
-                                session.add_message(MessageRole::User, &text);
-                                if !cli.no_session {
-                                    let _ = crate::session::chat_history::append_entry(
-                                        &crate::session::chat_history::ChatHistoryEntry {
-                                            content: text.to_string(),
-                                            timestamp: session.updated_at.clone(),
-                                        },
-                                    );
-                                }
                             }
                             }
                             refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
@@ -1029,6 +1193,23 @@ pub async fn run_interactive(
                     if let Some(perm) = &permission {
                         let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                         guard.restore_user_mode();
+                    }
+                }
+                // Run finished: drop its (now-dead) abort handle and, if the user
+                // queued input while it ran, replay the next one as a new run.
+                if !is_running {
+                    main_abort = None;
+                    if let Some(next) = pending_inputs.pop_front() {
+                        for line in next.lines() {
+                            renderer.write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
+                        }
+                        renderer.write_line("", Color::White)?;
+                        start_main_run(
+                            &next, &mut agent, &client, session, cli, cfg, context,
+                            &permission, &ask_tx, &sandbox, reasoning_enabled,
+                            &mut agent_rx, &mut main_abort, &mut is_running,
+                            #[cfg(feature = "mcp")] &mut mcp_manager,
+                        ).await;
                     }
                 }
                 refresh_display(&mut renderer, &input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;


### PR DESCRIPTION
Fixes #78.

## Problem
Submitting any input while a main agent run is active spawned a **second** run and overwrote `agent_rx`, orphaning the first. The orphan was never aborted, so it kept driving its stream and executing tools (`edit`/`write`/`bash`) to completion. Its result was never written to the session, so files changed on disk with nothing recorded in history. Ctrl-C did not actually cancel a run either; it only dropped the receiver while the run (and its child processes) kept going.

In practice: a long compile is running, you reflexively type `ok`, and the compile is orphaned. It may still be editing files, invisibly, and you cannot tell what it did.

## Fix
A one-line `if is_running { reject }` is not enough, because Ctrl-C would still be a fake interrupt. This enforces a single-flight invariant plus real cancellation:

- **Abort handle.** `AgentRunner` now carries `tokio::task::AbortHandle`; `spawn_agent` returns `join.abort_handle()`. The UI holds the in-flight run's handle.
- **Single-flight submission.** `classify_submission` / `allowed_while_running` decide per submission: idle or the whitelisted `/queue` runs now; plain text typed while running is **queued and replayed** as the next prompt when the run finishes (Claude-Code style); other commands are rejected with a "wait or Ctrl-C" hint. `start_main_run` is the single place that sets `agent_rx`/`main_abort`/`is_running`, so no path can bare-spawn over a live run.
- **Real Ctrl-C.** Ctrl-C now `abort()`s the run's task and clears the queue, and reports that changes may be partial.
- **Child process cleanup.** `Sandbox::wrap_command` sets `kill_on_drop(true)` on every return path, including the two unsandboxed fallbacks added in v1.4.2 (when `bwrap`/`zerobox` are missing), so an aborted run's bash child is killed instead of leaking.
- **`/queue` management.** `/queue ls` (or bare `/queue`) lists, `/queue clear` empties, `/queue pop` removes the last queued line. Selecting `/queue` in the command picker opens a second-level menu with the three subcommands.

## Commits
- `feat(agent): add abort handle to AgentRunner`
- `fix(sandbox): kill child processes on drop`
- `fix(ui): stop silently orphaning the running agent run`
- `docs(readme): document the /queue command and input queue`

Each commit builds on its own.

## Testing
- `cargo build`: clean, no warnings.
- `cargo test`: 281 passed, 0 failed (includes 5 new tests in `src/tests/singleflight_tests.rs` covering `classify_submission` / `allowed_while_running`).

## Notes / out of scope
- A half-written `edit` cannot be rolled back; abort only stops subsequent actions. The Ctrl-C message points the user to `git diff`.
- Appending an "interrupted" marker to history (suggested-fix item 4 in #78) is left for a follow-up.
- Rebased from the original research base `ecf798e` onto `ad3c8c3` (v1.4.2); the sandbox rework and a `dot_prompt_restore` change in the Ctrl-C handler were reconciled.
