### PR TITLE
feat: live model discovery for /models plus interactive model and provider pickers

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use compact_str::CompactString;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rig::agent::Agent;
-use rig::client::CompletionClient;
+use rig::client::{CompletionClient, ModelListingClient};
 use rig::completion::{CompletionModel, Message};
 use rig::providers::{anthropic, gemini, ollama, openai, openrouter};
 use rig::streaming::StreamingChat;
@@ -184,6 +184,112 @@ impl AnyClient {
     }
 }
 
+#[derive(Clone)]
+pub struct ModelEntry {
+    pub id: String,
+    pub display: String,
+    pub context_length: Option<u32>,
+    pub kind: Option<String>, // rig Model.r#type (often None)
+}
+
+impl ModelEntry {
+    fn from_rig(m: &rig::model::listing::Model) -> Self {
+        Self {
+            id: m.id.clone(),
+            display: m.display_name().to_string(),
+            context_length: m.context_length,
+            kind: m.r#type.clone(),
+        }
+    }
+}
+
+/// Chat/completion model suitable as an agent (not embedding/image/audio/etc.)?
+pub fn is_agent_model(m: &ModelEntry) -> bool {
+    if let Some(t) = m.kind.as_deref() {
+        let t = t.to_lowercase();
+        if ["embed", "image", "audio", "video", "moderation", "rerank", "tts", "speech"]
+            .iter()
+            .any(|k| t.contains(k))
+        {
+            return false;
+        }
+    }
+    let id = m.id.to_lowercase();
+    const DENY: &[&str] = &[
+        "embedding", "embed-", "text-embedding", "gemini-embedding",
+        "whisper", "transcribe", "tts", "-audio", "realtime", "speech",
+        "dall-e", "gpt-image", "image-generation", "imagen", "sora", "veo",
+        "moderation", "rerank", "aqa", "davinci-002", "babbage-002",
+    ];
+    !DENY.iter().any(|d| id.contains(d))
+}
+
+impl AnyClient {
+    /// Built-in providers: rig's ModelListingClient.
+    pub async fn list_models(&self) -> anyhow::Result<Vec<ModelEntry>> {
+        let list = match self {
+            AnyClient::OpenAI(OpenAiClient::Responses(c)) => c.list_models().await?,
+            AnyClient::Anthropic(c) => c.list_models().await?,
+            AnyClient::OpenRouter(c) => c.list_models().await?,
+            AnyClient::Gemini(c) => c.list_models().await?,
+            AnyClient::Ollama(c) => c.list_models().await?,
+            // If any arm above does NOT impl ModelListingClient it won't compile —
+            // move it down here to the manual fallback.
+            AnyClient::OpenAI(OpenAiClient::Completions(_)) => {
+                anyhow::bail!("rig model listing unavailable for this client")
+            }
+        };
+        Ok(list.iter().map(ModelEntry::from_rig).collect())
+    }
+}
+
+/// Custom / OpenAI-compatible gateway: best-effort GET {base}/models.
+pub async fn list_models_manual(
+    provider_name: &str,
+    cli_key: Option<&str>,
+    custom_providers: &std::collections::HashMap<String, CustomProviderConfig>,
+    config_api_keys: Option<&std::collections::HashMap<String, String>>,
+) -> anyhow::Result<Vec<ModelEntry>> {
+    let config = resolve_provider_config(provider_name, custom_providers)?;
+    let base = config
+        .base_url
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no base_url"))?;
+    let key = AuthResolver::new(config.kind)
+        .with_cli_key(cli_key)
+        .with_env_override(config.api_key_env.as_deref())
+        .with_config_keys(config_api_keys)
+        .with_custom_provider_name(Some(provider_name))
+        .resolve()
+        .ok();
+    let custom = custom_providers.get(provider_name);
+    let http = build_http_client(provider_name, config.danger_accept_invalid_certs, custom)?;
+    let url = format!("{}/models", base.trim_end_matches('/'));
+    let mut req = http.get(url);
+    if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
+        req = req.bearer_auth(k);
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        data: Vec<Item>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Item {
+        id: String,
+    }
+    let resp: Resp = req.send().await?.error_for_status()?.json().await?;
+    Ok(resp
+        .data
+        .into_iter()
+        .map(|i| ModelEntry {
+            display: i.id.clone(),
+            id: i.id,
+            context_length: None,
+            kind: None,
+        })
+        .collect())
+}
+
 async fn summarize_with_model(model: AnyModel, prompt: String) -> anyhow::Result<String> {
     match model {
         AnyModel::OpenRouter(m) => run_summarizer(m, prompt).await,
@@ -337,7 +443,7 @@ fn expand_env(value: &str) -> anyhow::Result<String> {
 /// When the provider is not custom (`custom == None`) and TLS is not disabled,
 /// the resulting client is equivalent to `reqwest::Client::default()`, so the
 /// behavior of existing providers is unchanged.
-fn build_http_client(
+pub(crate) fn build_http_client(
     provider_name: &str,
     danger_accept_invalid_certs: bool,
     custom: Option<&CustomProviderConfig>,

--- a/src/tests/picker_tests.rs
+++ b/src/tests/picker_tests.rs
@@ -1,5 +1,47 @@
+use crate::ui::cmd_picker::ModelsPicker;
 use crate::ui::picker::FilePicker;
 use std::path::PathBuf;
+
+#[test]
+fn test_models_picker_starts_on_quick_group() {
+    let mut picker = ModelsPicker::new();
+    picker.set_groups(vec!["fast".to_string()], vec!["claude-opus-4-7".to_string()]);
+    picker.activate();
+    assert_eq!(picker.matches, vec!["fast".to_string()]);
+}
+
+#[test]
+fn test_models_picker_tab_toggles_to_provider_group() {
+    let mut picker = ModelsPicker::new();
+    picker.set_groups(vec!["fast".to_string()], vec!["claude-opus-4-7".to_string()]);
+    picker.activate();
+    picker.toggle_group();
+    assert_eq!(picker.matches, vec!["claude-opus-4-7".to_string()]);
+}
+
+#[test]
+fn test_models_picker_starts_on_provider_when_quick_empty() {
+    let mut picker = ModelsPicker::new();
+    picker.set_groups(Vec::new(), vec!["claude-opus-4-7".to_string()]);
+    picker.activate();
+    assert_eq!(picker.matches, vec!["claude-opus-4-7".to_string()]);
+}
+
+#[test]
+fn test_models_picker_fuzzy_subsequence_match() {
+    let mut picker = ModelsPicker::new();
+    picker.set_groups(
+        Vec::new(),
+        vec!["claude-opus-4-7".to_string(), "gpt-4o-mini".to_string()],
+    );
+    picker.activate();
+    // "o47" is a subsequence of "claude-opus-4-7" but not "gpt-4o-mini"
+    for c in "o47".chars() {
+        picker.char_input(c);
+    }
+    assert_eq!(picker.selected_name(), Some("claude-opus-4-7"));
+    assert!(!picker.matches.iter().any(|m| m == "gpt-4o-mini"));
+}
 
 #[test]
 fn test_backspace_empty_query() {

--- a/src/ui/cmd_picker.rs
+++ b/src/ui/cmd_picker.rs
@@ -366,7 +366,14 @@ impl PromptPicker {
                 "{}",
                 SetForegroundColor(self.color(Color::DarkGrey))
             )?;
-            write!(stdout, "no matches")?;
+            // The provider list is not exhaustive: built-ins plus configured custom
+            // gateways are shown, but a name typed here is still submitted as-is, so
+            // remind the user they can free-type a registered gateway name.
+            if self.prefix == "/provider " {
+                write!(stdout, "no matches  (type a registered custom gateway name)")?;
+            } else {
+                write!(stdout, "no matches")?;
+            }
             write!(stdout, "{}", ResetColor)?;
             stdout.flush()?;
             return Ok(());

--- a/src/ui/cmd_picker.rs
+++ b/src/ui/cmd_picker.rs
@@ -413,13 +413,68 @@ impl PromptPicker {
     }
 }
 
+fn fuzzy_score(item: &str, query: &str) -> Option<i32> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let item_l = item.to_lowercase();
+    let query_l = query.to_lowercase();
+    let is_boundary = |bytes: &[u8], pos: usize| -> bool {
+        pos == 0 || matches!(bytes.get(pos - 1), Some(b'-' | b'.' | b'/' | b'_' | b' ' | b':'))
+    };
+
+    // Tier 1: contiguous substring wins decisively over any scattered subsequence
+    // (so "gemini" ranks google/gemini-* above openai/gpt-…-mini).
+    if let Some(pos) = item_l.find(&query_l) {
+        let mut score = 1000;
+        if is_boundary(item_l.as_bytes(), pos) {
+            score += 200;
+        }
+        if pos == 0 {
+            score += 100;
+        }
+        score -= pos as i32; // earlier match better
+        score -= (item_l.chars().count() / 4) as i32; // shorter id better
+        return Some(score);
+    }
+
+    // Tier 2: scattered subsequence fallback (low band, never beats a substring)
+    let chars: Vec<char> = item_l.chars().collect();
+    let mut score = 0i32;
+    let mut idx = 0usize;
+    let mut last: Option<usize> = None;
+    for qc in query_l.chars() {
+        let mut pos = None;
+        while idx < chars.len() {
+            if chars[idx] == qc {
+                pos = Some(idx);
+                break;
+            }
+            idx += 1;
+        }
+        let pos = pos?;
+        if last == Some(pos.wrapping_sub(1)) {
+            score += 5;
+        }
+        if pos == 0 || matches!(chars.get(pos - 1), Some('-' | '.' | '/' | '_' | ' ' | ':')) {
+            score += 3;
+        }
+        last = Some(pos);
+        idx = pos + 1;
+    }
+    score -= (chars.len() / 20) as i32;
+    Some(score)
+}
+
 pub struct ModelsPicker {
     pub active: bool,
     pub query: String,
     pub cursor: usize,
     pub matches: Vec<String>,
     pub selected: usize,
-    items: Vec<String>,
+    quick: Vec<String>,
+    provider: Vec<String>,
+    group: usize,
     monochrome: bool,
 }
 
@@ -431,7 +486,9 @@ impl ModelsPicker {
             cursor: 0,
             matches: Vec::new(),
             selected: 0,
-            items: Vec::new(),
+            quick: Vec::new(),
+            provider: Vec::new(),
+            group: 0,
             monochrome: false,
         }
     }
@@ -440,8 +497,9 @@ impl ModelsPicker {
         self.monochrome = monochrome;
     }
 
-    pub fn set_items(&mut self, items: Vec<String>) {
-        self.items = items;
+    pub fn set_groups(&mut self, quick: Vec<String>, provider: Vec<String>) {
+        self.quick = quick;
+        self.provider = provider;
     }
 
     fn color(&self, color: Color) -> Color {
@@ -454,11 +512,23 @@ impl ModelsPicker {
         self.cursor = 0;
         self.matches.clear();
         self.selected = 0;
+        // start on Provider if there are no quick presets to show
+        self.group = if self.quick.is_empty() && !self.provider.is_empty() {
+            1
+        } else {
+            0
+        };
         self.filter();
     }
 
     pub fn deactivate(&mut self) {
         self.active = false;
+    }
+
+    pub fn toggle_group(&mut self) {
+        self.group = 1 - self.group;
+        self.selected = 0;
+        self.filter();
     }
 
     pub fn char_input(&mut self, c: char) {
@@ -488,14 +558,17 @@ impl ModelsPicker {
     }
 
     fn filter(&mut self) {
-        let query_lower = self.query.to_lowercase();
-        self.matches = self
-            .items
+        let src = if self.group == 0 {
+            &self.quick
+        } else {
+            &self.provider
+        };
+        let mut scored: Vec<(i32, &String)> = src
             .iter()
-            .filter(|name| name.to_lowercase().contains(&query_lower))
-            .take(50)
-            .cloned()
+            .filter_map(|n| fuzzy_score(n, &self.query).map(|s| (s, n)))
             .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        self.matches = scored.into_iter().take(50).map(|(_, n)| n.clone()).collect();
         self.selected = 0;
     }
 
@@ -526,7 +599,35 @@ impl ModelsPicker {
         let (cols, rows) = crossterm::terminal::size()?;
         let mut stdout = std::io::stdout();
 
-        let max_items = (rows.saturating_sub(4)).min(10) as usize;
+        let max_items = (rows.saturating_sub(5)).min(10) as usize;
+        let list_height = max_items.min(self.matches.len().max(1));
+        let top_row = rows.saturating_sub(3).saturating_sub(list_height as u16);
+
+        // tab header showing the two groups (skip on very short terminals)
+        if rows >= 8 {
+            let header_row = top_row.saturating_sub(1);
+            stdout.execute(MoveTo(0, header_row))?;
+            write!(
+                stdout,
+                "{}",
+                Clear(crossterm::terminal::ClearType::CurrentLine)
+            )?;
+            let tab = |label: &str, count: usize, active: bool| {
+                if active {
+                    format!("[{} {}]", label, count)
+                } else {
+                    format!(" {} {} ", label, count)
+                }
+            };
+            write!(stdout, "{}", SetForegroundColor(self.color(Color::DarkGrey)))?;
+            write!(
+                stdout,
+                "{}  {}   (Tab to switch)",
+                tab("Quick", self.quick.len(), self.group == 0),
+                tab("Provider", self.provider.len(), self.group == 1)
+            )?;
+            write!(stdout, "{}", ResetColor)?;
+        }
 
         if self.matches.is_empty() {
             let r = rows.saturating_sub(3);
@@ -542,14 +643,11 @@ impl ModelsPicker {
             return Ok(());
         }
 
-        let list_height = max_items.min(self.matches.len());
         let start_idx = self
             .selected
             .saturating_sub(list_height / 2)
             .min(self.matches.len().saturating_sub(list_height));
         let end_idx = (start_idx + list_height).min(self.matches.len());
-
-        let top_row = rows.saturating_sub(3).saturating_sub(list_height as u16);
 
         for i in start_idx..end_idx {
             let render_row = top_row + (i - start_idx) as u16;

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -31,6 +31,7 @@ pub struct InputEditor {
     theme_names: Vec<String>,
     quick_model_names: Vec<String>,
     live_model_names: Vec<String>,
+    provider_names: Vec<String>,
     editor: Option<String>,
     kill_ring: Vec<CompactString>,
     yank_pos: Option<usize>,
@@ -51,6 +52,7 @@ impl InputEditor {
             theme_names: Vec::new(),
             quick_model_names: Vec::new(),
             live_model_names: Vec::new(),
+            provider_names: Vec::new(),
             editor: None,
             kill_ring: Vec::with_capacity(MAX_KILL_RING),
             yank_pos: None,
@@ -64,6 +66,10 @@ impl InputEditor {
 
     pub fn set_live_model_names(&mut self, names: Vec<String>) {
         self.live_model_names = names;
+    }
+
+    pub fn set_provider_names(&mut self, names: Vec<String>) {
+        self.provider_names = names;
     }
 
     pub fn set_editor(&mut self, editor: String) {
@@ -117,6 +123,16 @@ impl InputEditor {
         self.picker = Some(Picker::Models(picker));
     }
 
+    pub fn start_provider_picker(&mut self) {
+        let mut picker = PromptPicker::with_prefix("/provider ");
+        picker.set_monochrome(self.monochrome);
+        if !self.provider_names.is_empty() {
+            picker.set_items(self.provider_names.clone());
+        }
+        picker.activate();
+        self.picker = Some(Picker::Prompt(picker));
+    }
+
     pub fn start_prompt_picker(&mut self) {
         let mut picker = PromptPicker::new();
         picker.set_monochrome(self.monochrome);
@@ -160,6 +176,7 @@ impl InputEditor {
                     &self.theme_names,
                     &self.quick_model_names,
                     &self.live_model_names,
+                    &self.provider_names,
                     p,
                     key,
                 );
@@ -504,6 +521,21 @@ impl InputEditor {
                             self.start_theme_picker();
                             if let Some(Picker::Theme(ref mut tp)) = self.picker {
                                 tp.char_input(c);
+                            }
+                        }
+                    }
+                }
+                if (self.picker.is_none() || !self.picker.as_ref().is_some_and(|p| p.active()))
+                    && self.buffer.starts_with("/provider ")
+                {
+                    let after_prefix: String =
+                        self.buffer.chars().skip("/provider ".len()).collect();
+                    if !after_prefix.is_empty() && c != ' ' {
+                        let query_len = after_prefix.len();
+                        if query_len == 1 {
+                            self.start_provider_picker();
+                            if let Some(Picker::Prompt(ref mut pp)) = self.picker {
+                                pp.char_input(c);
                             }
                         }
                     }

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -112,9 +112,7 @@ impl InputEditor {
     pub fn start_models_picker(&mut self) {
         let mut picker = ModelsPicker::new();
         picker.set_monochrome(self.monochrome);
-        if !self.quick_model_names.is_empty() {
-            picker.set_items(self.quick_model_names.clone());
-        }
+        picker.set_groups(self.quick_model_names.clone(), self.live_model_names.clone());
         picker.activate();
         self.picker = Some(Picker::Models(picker));
     }
@@ -161,6 +159,7 @@ impl InputEditor {
                     &self.prompt_names,
                     &self.theme_names,
                     &self.quick_model_names,
+                    &self.live_model_names,
                     p,
                     key,
                 );

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -30,6 +30,7 @@ pub struct InputEditor {
     prompt_names: Vec<String>,
     theme_names: Vec<String>,
     quick_model_names: Vec<String>,
+    live_model_names: Vec<String>,
     editor: Option<String>,
     kill_ring: Vec<CompactString>,
     yank_pos: Option<usize>,
@@ -49,6 +50,7 @@ impl InputEditor {
             prompt_names: Vec::new(),
             theme_names: Vec::new(),
             quick_model_names: Vec::new(),
+            live_model_names: Vec::new(),
             editor: None,
             kill_ring: Vec::with_capacity(MAX_KILL_RING),
             yank_pos: None,
@@ -58,6 +60,10 @@ impl InputEditor {
 
     pub fn set_quick_model_names(&mut self, names: Vec<String>) {
         self.quick_model_names = names;
+    }
+
+    pub fn set_live_model_names(&mut self, names: Vec<String>) {
+        self.live_model_names = names;
     }
 
     pub fn set_editor(&mut self, editor: String) {

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -152,6 +152,7 @@ pub fn handle_command_picker_key(
     theme_names: &[String],
     quick_model_names: &[String],
     live_model_names: &[String],
+    provider_names: &[String],
     picker: &mut CommandPicker,
     key: KeyEvent,
 ) -> (bool, Option<Picker>) {
@@ -282,6 +283,13 @@ pub fn handle_command_picker_key(
                     tp.set_items(theme_names.to_vec());
                     tp.activate();
                     return (true, Some(Picker::Theme(tp)));
+                }
+                if selected == "/provider" && !provider_names.is_empty() {
+                    picker.deactivate();
+                    let mut pp = PromptPicker::with_prefix("/provider ");
+                    pp.set_items(provider_names.to_vec());
+                    pp.activate();
+                    return (true, Some(Picker::Prompt(pp)));
                 }
                 if selected == "/queue" {
                     // Open a second-level picker for the queue subcommands so

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -151,6 +151,7 @@ pub fn handle_command_picker_key(
     prompt_names: &[String],
     theme_names: &[String],
     quick_model_names: &[String],
+    live_model_names: &[String],
     picker: &mut CommandPicker,
     key: KeyEvent,
 ) -> (bool, Option<Picker>) {
@@ -266,10 +267,12 @@ pub fn handle_command_picker_key(
                     pp.activate();
                     return (true, Some(Picker::Prompt(pp)));
                 }
-                if selected == "/models" && !quick_model_names.is_empty() {
+                if selected == "/models"
+                    && !(quick_model_names.is_empty() && live_model_names.is_empty())
+                {
                     picker.deactivate();
                     let mut mp = ModelsPicker::new();
-                    mp.set_items(quick_model_names.to_vec());
+                    mp.set_groups(quick_model_names.to_vec(), live_model_names.to_vec());
                     mp.activate();
                     return (true, Some(Picker::Models(mp)));
                 }
@@ -390,15 +393,9 @@ pub fn handle_models_picker_key(
                 true
             }
         }
-        KeyCode::Tab => {
-            if key
-                .modifiers
-                .contains(crossterm::event::KeyModifiers::SHIFT)
-            {
-                picker.select_prev();
-            } else {
-                picker.select_next();
-            }
+        // Tab switches between the Quick and Provider groups; Up/Down navigate.
+        KeyCode::Tab | KeyCode::BackTab => {
+            picker.toggle_group();
             true
         }
         KeyCode::Up => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -303,6 +303,15 @@ pub async fn run_interactive(
         input.set_editor(editor.clone());
     }
     input.set_quick_model_names(config::quick_models_map(cfg).into_keys().collect());
+    {
+        // fixed built-in providers plus any custom gateways from config
+        let mut providers: Vec<String> = ["anthropic", "openai", "gemini", "openrouter", "ollama"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        providers.extend(cfg.custom_providers_map().keys().cloned());
+        input.set_provider_names(providers);
+    }
     input.load_global_history();
     // pre-warm the current provider's live models into the picker (best-effort)
     {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -304,6 +304,13 @@ pub async fn run_interactive(
     }
     input.set_quick_model_names(config::quick_models_map(cfg).into_keys().collect());
     input.load_global_history();
+    // pre-warm the current provider's live models into the picker (best-effort)
+    {
+        let provider = session.provider.to_string();
+        let is_custom = cfg.custom_providers_map().contains_key(&provider);
+        let ids = crate::ui::slash::warm_model_cache(&provider, is_custom, &client, cli, cfg).await;
+        input.set_live_model_names(ids);
+    }
     let mut is_running = false;
     let mut agent_rx: Option<mpsc::Receiver<AgentEvent>> = None;
     // Abort handle for the single in-flight main run. Enforces "at most one main
@@ -874,6 +881,13 @@ pub async fn run_interactive(
                                 } else {
                                     handle_slash(&text, &mut agent, &mut client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut reasoning_enabled, &mut is_running, &mut input, &permission, &ask_tx, &mut todo_tools_enabled, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_ref).await
                                 };
+                                // provider may have changed via /provider or /models — re-warm the picker's live list
+                                {
+                                    let provider = session.provider.to_string();
+                                    let is_custom = cfg.custom_providers_map().contains_key(&provider);
+                                    let ids = crate::ui::slash::warm_model_cache(&provider, is_custom, &client, cli, cfg).await;
+                                    input.set_live_model_names(ids);
+                                }
                                 match result {
                                 Err(e) if e.to_string().starts_with("DEFER_COMPRESS:") => {
                                     let err_msg = e.to_string();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,4 @@
-mod cmd_picker;
+pub(crate) mod cmd_picker;
 mod event_handler;
 pub(crate) mod events;
 pub(crate) mod input;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -8,6 +8,8 @@ mod providers;
 mod session;
 mod settings;
 
+pub(crate) use providers::warm_model_cache;
+
 use smallvec::SmallVec;
 
 use crate::cli::Cli;

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -1,4 +1,9 @@
-use crate::config;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use crate::cli::Cli;
+use crate::config::{self, Config};
+use crate::provider::{AnyClient, ModelEntry, list_models_manual};
 use crate::ui::slash::{SlashCtx, write_error, write_ok, write_result};
 
 pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
@@ -13,6 +18,85 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         "/models-subagent" => handle_models_subagent(parts, ctx).await,
         _ => Ok(()),
     }
+}
+
+static MODEL_CACHE: LazyLock<Mutex<HashMap<String, Vec<ModelEntry>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) async fn fetch_models_cached(
+    provider: &str,
+    is_custom: bool,
+    client: &AnyClient,
+    cli: &Cli,
+    cfg: &Config,
+    refresh: bool,
+) -> anyhow::Result<Vec<ModelEntry>> {
+    if !refresh {
+        if let Some(hit) = MODEL_CACHE.lock().unwrap().get(provider).cloned() {
+            return Ok(hit); // guard dropped here, NOT across the await below
+        }
+    }
+    let mut models = if is_custom {
+        list_models_manual(
+            provider,
+            cli.api_key.as_deref(),
+            &cfg.custom_providers_map(),
+            cfg.api_keys.as_ref(),
+        )
+        .await?
+    } else {
+        client.list_models().await?
+    };
+    models.retain(crate::provider::is_agent_model);
+    MODEL_CACHE
+        .lock()
+        .unwrap()
+        .insert(provider.to_string(), models.clone());
+    Ok(models)
+}
+
+/// sync read for the picker (no await)
+pub(crate) fn cached_model_ids(provider: &str) -> Vec<String> {
+    MODEL_CACHE
+        .lock()
+        .unwrap()
+        .get(provider)
+        .map(|v| v.iter().map(|m| m.id.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// best-effort warm; returns id list (empty on failure, never errors)
+pub(crate) async fn warm_model_cache(
+    provider: &str,
+    is_custom: bool,
+    client: &AnyClient,
+    cli: &Cli,
+    cfg: &Config,
+) -> Vec<String> {
+    let _ = fetch_models_cached(provider, is_custom, client, cli, cfg, false).await;
+    cached_model_ids(provider)
+}
+
+async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
+    let new_model = compact_str::CompactString::new(model_id);
+    let model = ctx.client.completion_model(new_model.to_string());
+    *ctx.agent = Some(
+        crate::provider::build_agent(
+            model,
+            ctx.cli,
+            ctx.cfg,
+            ctx.context,
+            ctx.permission.clone(),
+            ctx.ask_tx.clone(),
+            ctx.sandbox.clone(),
+            *ctx.reasoning_enabled,
+            #[cfg(feature = "mcp")]
+            ctx.mcp_manager,
+        )
+        .await,
+    );
+    ctx.session.model = new_model.clone();
+    write_ok(ctx.renderer, format!("switched to model: {}", new_model));
 }
 
 async fn handle_provider(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
@@ -76,69 +160,99 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
 
 async fn handle_models(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     let qm = config::quick_models_map(ctx.cfg);
-    let mut sorted: Vec<&String> = qm.keys().collect();
-    sorted.sort();
-    if parts.len() < 2 {
-        if sorted.is_empty() {
-            write_ok(ctx.renderer, "no quick models defined");
-        } else {
-            write_ok(
+    let provider = ctx.session.provider.to_string();
+    let is_custom = ctx.cfg.custom_providers_map().contains_key(&provider);
+
+    let refresh = parts.get(1).map(|s| s.trim()) == Some("refresh");
+
+    // /models <name-or-id> — quick-model name first, else raw model id for current provider
+    if parts.len() >= 2 && !refresh {
+        let arg = parts[1].trim();
+        if let Some(q) = qm.get(arg) {
+            ctx.rebuild_agent_with_client(&q.provider, *ctx.reasoning_enabled)
+                .await?;
+            apply_model(ctx, &q.model).await;
+            ctx.session.provider = compact_str::CompactString::new(&q.provider);
+            // preserve v1.4.x pricing/cost tracking
+            ctx.session.input_token_cost = q.input_token_cost;
+            ctx.session.output_token_cost = q.output_token_cost;
+            write_result(
                 ctx.renderer,
                 format!(
-                    "quick models (current: {} | {}):",
-                    ctx.session.provider, ctx.session.model
+                    "  quick model {} — ${:.4}/M in  ${:.4}/M out",
+                    arg, q.input_token_cost, q.output_token_cost
                 ),
             );
-            for name in &sorted {
-                let q = &qm[name.as_str()];
+            return Ok(());
+        }
+        apply_model(ctx, arg).await;
+        return Ok(());
+    }
+
+    // ---- list mode (+ optional refresh) ----
+    let mut sorted: Vec<&String> = qm.keys().collect();
+    sorted.sort();
+    write_ok(
+        ctx.renderer,
+        format!(
+            "quick models (current: {} | {}):",
+            ctx.session.provider, ctx.session.model
+        ),
+    );
+    if sorted.is_empty() {
+        write_result(ctx.renderer, "  (none — add with /models-add)");
+    }
+    for name in &sorted {
+        let q = &qm[name.as_str()];
+        write_result(
+            ctx.renderer,
+            format!(
+                "  {}  ({} / {})  ${:.4}/M in  ${:.4}/M out",
+                name, q.provider, q.model, q.input_token_cost, q.output_token_cost
+            ),
+        );
+    }
+
+    match fetch_models_cached(&provider, is_custom, ctx.client, ctx.cli, ctx.cfg, refresh).await {
+        Ok(models) if !models.is_empty() => {
+            write_ok(
+                ctx.renderer,
+                format!("available from {} ({}):", provider, models.len()),
+            );
+            const CAP: usize = 50;
+            for m in models.iter().take(CAP) {
+                let ctx_win = m
+                    .context_length
+                    .map(|c| format!("  [{}k ctx]", c / 1000))
+                    .unwrap_or_default();
+                let label = if m.display == m.id {
+                    m.id.clone()
+                } else {
+                    format!("{} ({})", m.display, m.id)
+                };
+                write_result(ctx.renderer, format!("  {}{}", label, ctx_win));
+            }
+            if models.len() > CAP {
                 write_result(
                     ctx.renderer,
                     format!(
-                        "  {}  ({} / {})  ${:.4}/M in  ${:.4}/M out",
-                        name, q.provider, q.model, q.input_token_cost, q.output_token_cost
+                        "  … {} more — type /models <filter> or use the picker",
+                        models.len() - CAP
                     ),
                 );
             }
+            ctx.input.set_live_model_names(cached_model_ids(&provider));
         }
-    } else {
-        let name = parts[1].trim();
-        if let Some(q) = qm.get(name) {
-            ctx.rebuild_agent_with_client(&q.provider, *ctx.reasoning_enabled)
-                .await?;
-            let model = ctx.client.completion_model(q.model.to_string());
-            *ctx.agent = Some(
-                crate::provider::build_agent(
-                    model,
-                    ctx.cli,
-                    ctx.cfg,
-                    ctx.context,
-                    ctx.permission.clone(),
-                    ctx.ask_tx.clone(),
-                    ctx.sandbox.clone(),
-                    *ctx.reasoning_enabled,
-                    #[cfg(feature = "mcp")]
-                    ctx.mcp_manager,
-                )
-                .await,
-            );
-            ctx.session.provider = compact_str::CompactString::new(&q.provider);
-            ctx.session.model = compact_str::CompactString::new(&q.model);
-            ctx.session.input_token_cost = q.input_token_cost;
-            ctx.session.output_token_cost = q.output_token_cost;
-            write_ok(
-                ctx.renderer,
-                format!(
-                    "switched to quick model: {} ({} / {})  ${:.4}/M in  ${:.4}/M out",
-                    name, q.provider, q.model, q.input_token_cost, q.output_token_cost
-                ),
-            );
-        } else {
-            write_error(ctx.renderer, format!("unknown quick model: '{}'", name));
-            if !sorted.is_empty() {
-                write_ok(ctx.renderer, "available quick models:");
-                for n in &sorted {
-                    write_result(ctx.renderer, format!("  {}", n));
-                }
+        Ok(_) => {
+            ctx.input.set_live_model_names(cached_model_ids(&provider));
+        }
+        Err(e) => {
+            tracing::debug!("model listing failed for {}: {}", provider, e);
+            if is_custom {
+                write_result(
+                    ctx.renderer,
+                    "  (live model list unavailable; type the model id directly)",
+                );
             }
         }
     }


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/66e2b0c2-0b62-4a8f-b955-a6cbb3d111bd

## Summary
Make model and provider selection discoverable instead of memorized.
- **/models lists the current provider's live models** via rig's `GET {base}/models`. Non-agent models (embeddings, image, audio, tts, moderation, rerank, ...) are filtered out. Results are cached per provider per process; `/models refresh` re-fetches.
- **Interactive model picker**: two groups (Quick presets / live Provider catalog), Tab to switch, arrow keys to navigate, two-tier fuzzy search per process; `/models refresh` re-fetches.
- **Interactive model picker**: two groups (Quick presets / live Provider catalog), Tab to switch, arrow keys to navigate, two-tier fuzzy search (substring first). Live IDs show their context window; quick presets show pricing.
- **Interactive /provider picker**: fixed built-in providers plus custom gateways. The list is not exhaustive, so a name typed in the picker is still submitted as-is; when nothing matches it hints that a registered custom gateway name can be typed directly.
- Pricing/cost tracking and `/models-subagent` behavior are preserved.

## Commits
1. feat(models): list live provider models in /models
2. feat(picker): two-group model picker with fuzzy search
3. feat(picker): add /provider selection picker

## Testing
- `cargo build` clean (no warnings).
- `cargo test picker` gives 11 passed.
- Manually verified live `/models` for Anthropic, OpenAI, Gemini, OpenRouter; the `/provider` picker lists all built-ins; see the demo above.
- No API-key-gated tests; model listing is verified manually.

## Notes / follow-ups
- Ollama (`/api/tags` vs `/v1/models`) and the custom-gateway manual path are not yet live-tested.
- Defaulting the model on provider switch is a separate, independent follow-up.