### PR TITLE
fix: default the model to the chosen provider (startup and /provider)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,16 +200,22 @@ impl Cli {
     }
 
     pub fn resolve_model(&self, cfg: &config::Config) -> CompactString {
-        self.model
-            .as_deref()
-            .or(cfg.model.as_deref())
-            .map(CompactString::new)
-            .unwrap_or_else(|| {
-                let qm = config::quick_models_map(cfg);
-                qm.get("deepseek-v4-flash")
-                    .map(|q| q.model.clone())
-                    .unwrap_or_else(|| CompactString::new("deepseek/deepseek-v4-flash"))
-            })
+        if let Some(m) = self.model.as_deref().or(cfg.model.as_deref()) {
+            return CompactString::new(m);
+        }
+        // No explicit model. If a provider was chosen explicitly, default to a
+        // model valid for it so `--provider anthropic` does not keep the
+        // OpenRouter default id; otherwise keep the historic deepseek default.
+        if (self.provider.is_some() || cfg.provider.is_some())
+            && let Some((model, _)) =
+                crate::provider::default_model_for_provider(&self.resolve_provider(cfg), cfg)
+        {
+            return CompactString::new(model);
+        }
+        let qm = config::quick_models_map(cfg);
+        qm.get("deepseek-v4-flash")
+            .map(|q| q.model.clone())
+            .unwrap_or_else(|| CompactString::new("deepseek/deepseek-v4-flash"))
     }
 
     pub fn resolve_provider(&self, cfg: &config::Config) -> CompactString {

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,15 +173,6 @@ async fn main() -> anyhow::Result<()> {
         model = qm.model.clone();
     }
 
-    // Custom provider model override (if no explicit model set)
-    if let Some(custom) = cfg.custom_providers_map().get(provider.as_str())
-        && cli.model.is_none()
-        && cfg.model.is_none()
-        && let Some(ref custom_model) = custom.model
-    {
-        model = custom_model.clone();
-    }
-
     let mut session = session::Session::new(&provider, &model, cfg.resolve_context_window());
 
     // Resolve input/output token costs from quick models or defaults

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -66,6 +66,46 @@ pub fn parse_provider(name: &str) -> Option<ProviderKind> {
     ProviderKind::from_name(name)
 }
 
+/// Pick a sensible default model when targeting `provider`. Priority:
+/// a custom gateway's configured `model`, then a quick model targeting this
+/// provider (carrying its pricing), then a built-in fallback. Returns
+/// (model, Option<(input_cost, output_cost)>), or None if `provider` is unknown
+/// and has no configured default. Used both by `/provider` and at startup so a
+/// chosen provider never keeps an id that is invalid on it.
+pub(crate) fn default_model_for_provider(
+    provider: &str,
+    cfg: &Config,
+) -> Option<(String, Option<(f64, f64)>)> {
+    if let Some(c) = cfg.custom_providers_map().get(provider)
+        && let Some(m) = &c.model
+    {
+        return Some((m.to_string(), None));
+    }
+    // Deterministic: prefer the alphabetically-first quick model for this provider
+    // (HashMap iteration order would otherwise be unstable).
+    let qm = crate::config::quick_models_map(cfg);
+    let mut names: Vec<&String> = qm.keys().collect();
+    names.sort();
+    for name in names {
+        let q = &qm[name];
+        if q.provider.as_str() == provider {
+            return Some((
+                q.model.to_string(),
+                Some((q.input_token_cost, q.output_token_cost)),
+            ));
+        }
+    }
+    let m = match provider {
+        "anthropic" => "claude-sonnet-4-6",
+        "openai" => "gpt-5.1",
+        "gemini" | "google" => "gemini-2.5-pro",
+        "openrouter" => "openrouter/auto", // OpenRouter's always-valid auto-router
+        "ollama" => "llama3.1",
+        _ => return None,
+    };
+    Some((m.to_string(), None))
+}
+
 fn resolve_base_url(config: &ProviderConfig) -> Option<String> {
     config.base_url.clone()
 }

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -33,12 +33,26 @@ async fn handle_provider(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
         );
         return Ok(());
     }
+    // Default the model to something valid for the new provider BEFORE rebuilding,
+    // since rebuild_agent_with_client reads session.model. Otherwise the old id
+    // (e.g. an OpenRouter id) is carried onto a provider where it is invalid.
+    if let Some((model, costs)) = crate::provider::default_model_for_provider(new_provider, ctx.cfg)
+    {
+        ctx.session.model = compact_str::CompactString::new(&model);
+        if let Some((inc, outc)) = costs {
+            ctx.session.input_token_cost = inc;
+            ctx.session.output_token_cost = outc;
+        }
+    }
     ctx.rebuild_agent_with_client(new_provider, *ctx.reasoning_enabled)
         .await?;
     ctx.session.provider = compact_str::CompactString::new(new_provider);
     write_ok(
         ctx.renderer,
-        format!("switched to provider: {}", new_provider),
+        format!(
+            "switched to provider: {} (model: {})",
+            new_provider, ctx.session.model
+        ),
     );
     Ok(())
 }


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/7435fd4a-85de-4dd6-9015-0b57be8b64e1

## Summary
Choosing a provider without also choosing a model left the model at the OpenRouter default id (`deepseek/deepseek-v4-flash`), which is invalid on every other provider. 
This happened in two places:
- **At startup**: `zerostack --provider anthropic` (or `provider` in config) with no `--model` kept the deepseek id, and the header banner showed it.
- **At runtime**: `/provider anthropic` kept the previous model id.

Both now derive a sensible default for the target provider, with this priority:
1. a custom gateway's configured `model`,
2. a quick model targeting that provider (carrying its pricing),
3. a built-in fallback.

Built-in fallbacks: anthropic to `claude-sonnet-4-6`, openai to `gpt-5.1`, gemini to `gemini-2.5-pro`, openrouter to `openrouter/auto`, ollama to `llama3.1`. 
A user's quick model or a custom gateway model for the provider always wins over these.

When no provider is chosen explicitly, the historic default (`deepseek/deepseek-v4-flash` on openrouter) is preserved unchanged.

## How it works
A single `default_model_for_provider` helper in `provider.rs` is the source of truth. 
`resolve_model` uses it so the startup banner, the status line, and the session all agree, and `handle_provider` uses it so a runtime switch reports the resulting model in its confirmation message.

## Commits
1. fix(provider): default to a sensible model when switching providers
2. fix(cli): default the model to the chosen provider at startup

## Testing
- `cargo build` clean (no warnings).
- `zerostack --provider anthropic` with no `--model` starts on `claude-sonnet-4-6` (header and status line agree); plain `zerostack` still starts on `deepseek/deepseek-v4-flash`.
- `/provider anthropic` at runtime switches the model and reports it.

## Notes
- Independent of the live-models / pickers PR. They share `provider.rs` and `slash/providers.rs` but edit different functions; a trial merge is clean, and the merged tree builds and passes tests, so the two can land in any order.
- Built-in fallback IDs drift with provider releases; adjust to taste. User quick models and custom gateway models take priority over them.
- Known limitation: the header banner reflects startup resolution, so after a runtime `/provider` switch, the banner keeps the startup model while the status line updates. This is pre-existing and left for a follow-up.