### PR TITLE
fix(markdown): clear acc after flushing in inline-code branch

### DIFF
--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -371,6 +371,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         Color::White
                     };
                     flush_acc(&acc, color, max_width, &mut result);
+                    acc.clear();
                     let code_text = format!("`{}`", t);
                     for chunk in word_wrap(&code_text, max_width) {
                         result.push(LineEntry {
@@ -656,6 +657,34 @@ mod tests {
             "inline code should have backticks"
         );
     }
+
+    #[test]
+    fn multiple_inline_codes_no_duplication() {
+        let styled = markdown_to_styled("foo `a` bar `b` baz", 80);
+        let joined: String = styled
+            .iter()
+            .map(|e| e.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        // "foo" should appear exactly once
+        assert_eq!(
+            joined.matches("foo").count(),
+            1,
+            "prose before first code must not duplicate: {joined}"
+        );
+        // "bar" between codes should appear exactly once
+        assert_eq!(
+            joined.matches("bar").count(),
+            1,
+            "prose between codes must not duplicate: {joined}"
+        );
+        assert_eq!(
+            joined.matches("baz").count(),
+            1,
+            "prose after last code must not duplicate: {joined}"
+        );
+    }
+
 
     #[test]
     fn inline_code_in_blockquote() {


### PR DESCRIPTION
Fixed #81 

### Problem

In `src/ui/markdown.rs`, the `Event::Code` branch calls `flush_acc(&acc, ...)` but never clears `acc`. Every other `flush_acc` call site in the file clears `acc` immediately after — only the inline-code branch forgets.

As a result, any paragraph containing inline code leaks its prose buffer forward, and the next flush re-emits everything from the start of the paragraph plus the new chunk. With n inline-code spans in a paragraph, the i-th prose segment gets emitted n−i+1 times.

### Repro

Prompt the agent for a paragraph with several inline-code spans, e.g.:

> Explain the difference between `Vec`, `Box`, `Rc`, and `Arc` in Rust memory management, in a single paragraph.

Before this fix, the prose preceding each backtick repeats and grows with every subsequent inline-code span.

### Fix

Add `acc.clear()` right after the `flush_acc` call in the `Event::Code` branch, matching the pattern used by every other `flush_acc` call site in the file.

### Tests

Added a regression test covering multiple inline-code spans in the same paragraph. The existing `inline_code_styled` test only covered a single span, which is why this slipped through.
