### PR TITLE
feat: parallel, read-only /btw side questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ This is a list of the most important slash commands:
 - `/prompt` — List or change the agent's prompt
 - `/mode` — Set the permission system's mode
 - `/queue` — Manage input queued while the agent is busy
+- `/btw` — Ask a quick side question in parallel without interrupting the agent
 
 To see all of the commands, use `/help`.
 
@@ -200,6 +201,23 @@ three subcommands, so you do not need to remember them.
 Commands (input starting with `/`, `.`, or `!`) are not queued while a run is
 active: wait for it to finish, or press Ctrl-C. Ctrl-C cancels the running agent
 for real, including any child processes it spawned, and clears the queue.
+
+## Side questions (`/btw`)
+
+`/btw <message>` asks a quick "by the way" question in parallel with the main
+agent, without interrupting it. Like `/queue`, it works even while the agent is
+busy. It forks the current context (including a trace of the agent's in-flight
+turn, when one is running) and answers using four read-only tools (`read`,
+`grep`, `find_files`, `list_dir`); it cannot write files or run commands. It then
+prints the reply inline.
+Nothing is written to conversation history, and its token usage is tracked
+separately in the status bar as `btw:…`. Press Ctrl-C to cancel an in-flight
+`/btw` without disturbing the main agent.
+
+You can point a question at a specific file with `@`: pick `/btw` from the
+command menu, then type `@` to open the file picker (for example `/btw` then
+`@src/main.rs` then "how does this work?"), and `/btw` reads the file you
+reference.
 
 ## Session management
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,7 +104,7 @@ You are in read-only mode. Only read files and explore.
 | `/editsys` | Show the current edit system mode (similarity or hashedit). |
 | `/editsys similarity` | Use SEARCH/REPLACE with fuzzy matching for edits (default). |
 | `/editsys hashedit` | Use CRC-32 tag-based edits (token-efficient, CAS-guarded). |
-| `/btw <message>` | Ask the agent a question without adding it to the chat history. Neither the question nor the response is saved. |
+| `/btw <message>` | Ask a quick side question in parallel, without touching the main conversation. It forks the current context (including the main agent's in-flight turn, if any), answers using read-only tools (read/grep/find_files/list_dir, no writes or bash), and prints the answer inline. Works even while the main agent is running. Nothing is written to history; its token cost is shown separately as `btw:$…`. Ctrl-C cancels an in-flight `/btw` without disturbing the main agent. |
 | `/reasoning` | Toggle LLM reasoning on/off (requires model support). |
 | `/thinking` | Alias for `/reasoning`. |
 | `/toggle` | Show available toggleable features. |

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -205,6 +205,135 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     }
 }
 
+/// Dedicated system prompt for the `/btw` side-assistant. Deliberately NOT the
+/// main coding `SYSTEM_PROMPT`: that one is all about using read/write/bash
+/// tools, so pairing it with "you have no tools" made the model refuse and tell
+/// the user to wait for the main agent. This prompt frames `/btw` as a quick,
+/// read-only Q&A helper whose only job is to answer the user's question.
+const BTW_SYSTEM_PROMPT: &str = "\
+You are a fast side-assistant for quick \"by the way\" questions during a coding \
+session. The user pressed /btw to ask you something in parallel with the main \
+assistant, WITHOUT interrupting it.
+
+Your only job: answer the user's question directly, briefly, and helpfully, using \
+the conversation so far and the project context below. Reply in the user's \
+language.
+
+Match your length to the question: greetings, thanks, or yes/no questions get a \
+ONE-LINE reply. Do NOT volunteer project setup, build, run, or test instructions \
+unless the user explicitly asks how to build or run. The project context below is \
+background for answering; it is NOT a script to recite.
+
+This is a read-only side channel: you have read-only tools (read, grep, \
+find_files, list_dir) to look things up, but you CANNOT write files, run \
+commands, or change anything, and your reply is NOT saved to the conversation. \
+Use the read tools when answering needs a file you do not already have in \
+context, and keep it to what the question asks. Do NOT attempt or plan the main \
+task, and do NOT tell the user to wait for the main assistant; just answer what \
+they asked.";
+
+/// Max model turns for a `/btw` side question. Higher than 1 so it can read a
+/// file (or grep) and then answer, but small to keep side questions quick.
+const BTW_MAX_TURNS: usize = 8;
+
+/// Builds the isolated `/btw` agent: a lightweight read-only Q&A helper with the
+/// project context for reference, NO tools, and a single turn. Never mutates the
+/// session.
+#[allow(clippy::too_many_arguments)]
+pub fn build_btw_agent_inner<M: CompletionModel + 'static>(
+    model: M,
+    cli: &Cli,
+    cfg: &Config,
+    context: &ContextFiles,
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    _reasoning_enabled: bool,
+) -> Agent<M> {
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    let mut preamble = String::new();
+    preamble.push_str(BTW_SYSTEM_PROMPT);
+
+    // Project context, for reference only — NOT instructions to act on.
+    let has_ctx = context.agents.as_deref().is_some_and(|s| !s.is_empty()) || !cwd.is_empty();
+    if has_ctx {
+        preamble.push_str("\n\n## Project context (for reference)\n");
+    }
+    if let Some(agents) = context.agents.as_deref()
+        && !agents.is_empty()
+    {
+        preamble.push_str("\n");
+        preamble.push_str(agents);
+    }
+    #[cfg(feature = "archmd")]
+    if let Some(arch) = context.architecture.as_deref()
+        && !arch.is_empty()
+    {
+        preamble.push_str("\n\n");
+        preamble.push_str(arch);
+    }
+    if let Some(p) = context.current_prompt.as_deref()
+        && !p.is_empty()
+    {
+        preamble.push_str("\n\n");
+        preamble.push_str(p);
+    }
+    if !cwd.is_empty() {
+        preamble.push_str("\n\nCurrent working directory: ");
+        preamble.push_str(&cwd);
+    }
+    #[cfg(feature = "memory")]
+    crate::extras::memory::append_memory_block(&mut preamble, context.memory.as_deref());
+
+    let max_tokens = cli.resolve_max_tokens(cfg);
+
+    // Honor --no-tools: fall back to a pure-context, single-turn answer.
+    if cli.resolve_no_tools(cfg) {
+        let mut builder = AgentBuilder::new(model)
+            .preamble(&preamble)
+            .default_max_turns(1)
+            .max_tokens(max_tokens);
+        if let Some(temp) = cli.temperature {
+            builder = builder.temperature(temp.clamp(0.0, 2.0));
+        }
+        return builder.build();
+    }
+
+    // Read-only tools only (read/grep/find_files/list_dir): a side question can
+    // look things up, but has no write/edit/bash, so it still has no side
+    // effects to roll back and never mutates the session. Allow multiple turns
+    // so it can read then answer.
+    let max_text_file_size = cfg.max_text_file_size;
+    let read_tools: Vec<Box<dyn rig::tool::ToolDyn>> = vec![
+        Box::new(tools::ReadTool::new(
+            permission.clone(),
+            ask_tx.clone(),
+            max_text_file_size,
+        )),
+        Box::new(tools::GrepTool::new(permission.clone(), ask_tx.clone())),
+        Box::new(tools::FindFilesTool::new(
+            permission.clone(),
+            ask_tx.clone(),
+        )),
+        Box::new(tools::ListDirTool::new(permission.clone(), ask_tx.clone())),
+    ];
+
+    let mut builder = AgentBuilder::new(model)
+        .preamble(&preamble)
+        .default_max_turns(BTW_MAX_TURNS)
+        .max_tokens(max_tokens)
+        .tools(read_tools);
+
+    if let Some(temp) = cli.temperature {
+        builder = builder.temperature(temp.clamp(0.0, 2.0));
+    }
+
+    builder.build()
+}
+
 #[allow(dead_code)]
 pub fn create_client(api_key: Option<&str>) -> anyhow::Result<openrouter::Client> {
     let key = api_key

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -6,7 +6,7 @@ use rig::message::ToolResultContent;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingChat};
 use tokio::sync::mpsc;
 
-use crate::event::AgentEvent;
+use crate::event::{AgentEvent, BtwEvent};
 use crate::session::{MessageRole, Session};
 
 pub struct AgentRunner {
@@ -15,6 +15,81 @@ pub struct AgentRunner {
     /// interrupted run keeps driving its stream — and therefore keeps executing
     /// tools (edit/write/bash) — invisibly. Aborting stops it for real.
     pub abort_handle: tokio::task::AbortHandle,
+}
+
+/// Handle to an in-flight `/btw` side-question task. The `abort_handle` lets the
+/// UI cancel the side question (e.g. on Ctrl-C) without touching the main agent.
+pub struct BtwRunner {
+    pub abort_handle: tokio::task::AbortHandle,
+}
+
+/// Spawn an isolated, single-turn, tool-less side-question run. The full result
+/// is delivered as a single [`BtwEvent::Done`] (or [`BtwEvent::Error`]) tagged
+/// with `id`. Unlike [`spawn_agent`], it never registers a subagent event sink
+/// and never mutates the session.
+pub fn spawn_btw<M, P>(
+    agent: Agent<M, P>,
+    prompt: String,
+    history: Vec<Message>,
+    event_tx: mpsc::Sender<BtwEvent>,
+    id: u32,
+) -> BtwRunner
+where
+    M: CompletionModel + 'static,
+    M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
+    P: rig::agent::PromptHook<M> + 'static,
+{
+    let join = tokio::spawn(async move {
+        let mut stream = agent.stream_chat(prompt, history).await;
+        let mut acc = String::new();
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(
+                    text,
+                ))) => acc.push_str(&text.text),
+                Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                    let response_text = res.response();
+                    let usage = res.usage();
+                    let response = if response_text.is_empty() {
+                        CompactString::from(acc.as_str())
+                    } else {
+                        CompactString::from(response_text)
+                    };
+                    let _ = event_tx
+                        .send(BtwEvent::Done {
+                            id,
+                            response,
+                            input_tokens: usage.input_tokens,
+                            output_tokens: usage.output_tokens,
+                        })
+                        .await;
+                    return;
+                }
+                Err(e) => {
+                    let _ = event_tx
+                        .send(BtwEvent::Error {
+                            id,
+                            message: CompactString::new(e.to_string()),
+                        })
+                        .await;
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        let _ = event_tx
+            .send(BtwEvent::Error {
+                id,
+                message: CompactString::new("side question ended without a response"),
+            })
+            .await;
+    });
+
+    BtwRunner {
+        abort_handle: join.abort_handle(),
+    }
 }
 
 pub fn convert_history(session: &Session) -> Vec<Message> {
@@ -39,6 +114,28 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
     }
 
     messages
+}
+
+/// Builds the forked context for a `/btw` side question: the committed
+/// conversation history, plus — when the main agent is mid-task — a synthesized
+/// note describing the in-flight turn so the side question can see what the
+/// agent is doing right now. The returned messages are a by-value snapshot; the
+/// session is never mutated, so there is nothing to roll back afterwards.
+pub fn build_btw_snapshot(
+    session: &Session,
+    turn_trace: &[CompactString],
+    main_running: bool,
+) -> Vec<Message> {
+    let mut snapshot = convert_history(session);
+    if main_running && !turn_trace.is_empty() {
+        snapshot.push(Message::user(format!(
+            "(Context only — the main assistant is working in parallel right now. \
+Its progress so far this turn:\n{}\nThe last step may still be running. Use this \
+only if the user's question is about what the main assistant is doing.)",
+            turn_trace.join("\n")
+        )));
+    }
+    snapshot
 }
 
 pub fn spawn_agent<M, P>(agent: Agent<M, P>, prompt: String, history: Vec<Message>) -> AgentRunner

--- a/src/event.rs
+++ b/src/event.rs
@@ -24,6 +24,24 @@ pub enum AgentEvent {
     },
 }
 
+/// Events emitted by an isolated `/btw` side-question run. Kept as a separate
+/// type from [`AgentEvent`] so that a side-question result can never be routed
+/// through `handle_agent_event` (which mutates the session): the type system
+/// enforces that `/btw` leaves no trace in conversation history.
+#[derive(Debug, Clone)]
+pub enum BtwEvent {
+    Done {
+        id: u32,
+        response: CompactString,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
+    Error {
+        id: u32,
+        message: CompactString,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub enum UserEvent {
     Key(crossterm::event::KeyEvent),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -485,6 +485,25 @@ impl AnyAgent {
             AnyAgent::Ollama(a) => runner::spawn_agent(a, prompt, history),
         }
     }
+
+    pub fn spawn_btw(
+        self,
+        prompt: String,
+        history: Vec<Message>,
+        event_tx: mpsc::Sender<crate::event::BtwEvent>,
+        id: u32,
+    ) -> crate::agent::runner::BtwRunner {
+        match self {
+            AnyAgent::OpenRouter(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+            AnyAgent::OpenAI(a) => match a {
+                OpenAiAgent::Responses(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+                OpenAiAgent::Completions(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+            },
+            AnyAgent::Anthropic(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+            AnyAgent::Gemini(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+            AnyAgent::Ollama(a) => runner::spawn_btw(a, prompt, history, event_tx, id),
+        }
+    }
 }
 
 /// Expands a value that is exactly "${VAR}" to the environment variable's value;
@@ -808,5 +827,77 @@ pub async fn build_agent(
             )
             .await,
         ),
+    }
+}
+
+/// Builds the isolated, tool-less `/btw` agent for the active provider.
+pub fn build_btw_agent(
+    model: AnyModel,
+    cli: &Cli,
+    cfg: &Config,
+    context: &ContextFiles,
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    reasoning_enabled: bool,
+) -> AnyAgent {
+    match model {
+        AnyModel::OpenRouter(m) => AnyAgent::OpenRouter(builder::build_btw_agent_inner(
+            m,
+            cli,
+            cfg,
+            context,
+            permission,
+            ask_tx,
+            reasoning_enabled,
+        )),
+        AnyModel::OpenAI(m) => AnyAgent::OpenAI(match m {
+            OpenAiModel::Responses(m) => OpenAiAgent::Responses(builder::build_btw_agent_inner(
+                m,
+                cli,
+                cfg,
+                context,
+                permission,
+                ask_tx,
+                reasoning_enabled,
+            )),
+            OpenAiModel::Completions(m) => {
+                OpenAiAgent::Completions(builder::build_btw_agent_inner(
+                    m,
+                    cli,
+                    cfg,
+                    context,
+                    permission,
+                    ask_tx,
+                    reasoning_enabled,
+                ))
+            }
+        }),
+        AnyModel::Anthropic(m) => AnyAgent::Anthropic(builder::build_btw_agent_inner(
+            m,
+            cli,
+            cfg,
+            context,
+            permission,
+            ask_tx,
+            reasoning_enabled,
+        )),
+        AnyModel::Gemini(m) => AnyAgent::Gemini(builder::build_btw_agent_inner(
+            m,
+            cli,
+            cfg,
+            context,
+            permission,
+            ask_tx,
+            reasoning_enabled,
+        )),
+        AnyModel::Ollama(m) => AnyAgent::Ollama(builder::build_btw_agent_inner(
+            m,
+            cli,
+            cfg,
+            context,
+            permission,
+            ask_tx,
+            reasoning_enabled,
+        )),
     }
 }

--- a/src/tests/btw_tests.rs
+++ b/src/tests/btw_tests.rs
@@ -1,0 +1,73 @@
+//! Tests for the parallel, tool-less `/btw` side question.
+//!
+//! The behavioural guarantees we care about are about the *snapshot*: a side
+//! question forks the committed history (plus an in-flight turn trace when the
+//! main agent is busy) and never mutates the session. The network round-trip
+//! itself is not exercised here.
+
+use compact_str::CompactString;
+
+use crate::agent::runner::build_btw_snapshot;
+use crate::session::{MessageRole, Session};
+
+fn sample_session() -> Session {
+    let mut s = Session::new("anthropic", "claude-test", 200_000);
+    s.add_message(MessageRole::User, "hello");
+    s.add_message(MessageRole::Assistant, "hi there");
+    s
+}
+
+#[test]
+fn snapshot_without_trace_matches_history() {
+    let session = sample_session();
+    let snapshot = build_btw_snapshot(&session, &[], false);
+    // Two committed messages, no trace appended.
+    assert_eq!(snapshot.len(), 2);
+}
+
+#[test]
+fn trace_is_appended_only_while_main_is_running() {
+    let session = sample_session();
+    let trace = [
+        CompactString::from("→ bash: npm test"),
+        CompactString::from("← running…"),
+    ];
+
+    // Mid-task: the in-flight trace is folded in as one extra message.
+    let running = build_btw_snapshot(&session, &trace, true);
+    assert_eq!(running.len(), 3);
+
+    // Not running: a stale trace must not leak into the snapshot.
+    let idle = build_btw_snapshot(&session, &trace, false);
+    assert_eq!(idle.len(), 2);
+}
+
+#[test]
+fn empty_trace_while_running_adds_nothing() {
+    let session = sample_session();
+    let snapshot = build_btw_snapshot(&session, &[], true);
+    assert_eq!(snapshot.len(), 2);
+}
+
+#[test]
+fn snapshot_does_not_mutate_session() {
+    let mut session = sample_session();
+    let before_len = session.messages.len();
+    let before_in = session.total_input_tokens;
+    let before_out = session.total_output_tokens;
+    let before_cost = session.total_cost;
+
+    let trace = [CompactString::from("→ read: src/main.rs")];
+    let _ = build_btw_snapshot(&session, &trace, true);
+
+    // The forked snapshot is by value; the session is untouched. This is the
+    // core safety property that replaces the old "append then roll back" path.
+    assert_eq!(session.messages.len(), before_len);
+    assert_eq!(session.total_input_tokens, before_in);
+    assert_eq!(session.total_output_tokens, before_out);
+    assert_eq!(session.total_cost, before_cost);
+
+    // touch `session` mutably so the binding is legitimately `mut`.
+    session.add_message(MessageRole::User, "again");
+    assert_eq!(session.messages.len(), before_len + 1);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,8 @@ mod archmd_tests;
 #[cfg(test)]
 mod auth_tests;
 #[cfg(test)]
+mod btw_tests;
+#[cfg(test)]
 mod checker_tests;
 #[cfg(test)]
 mod crc_tests;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,7 +72,9 @@ pub(super) const C_AGENT: Color = Color::White;
 pub(super) const C_ERROR: Color = Color::Red;
 pub(super) const C_TOOL: Color = Color::Yellow;
 pub(super) const C_PERM: Color = Color::Magenta;
+pub(super) const C_BTW: Color = Color::Cyan;
 
+#[allow(clippy::too_many_arguments)]
 fn refresh_display(
     renderer: &mut Renderer,
     input: &mut InputEditor,
@@ -81,9 +83,22 @@ fn refresh_display(
     loop_label: Option<&str>,
     prompt_name: Option<&str>,
     perm_mode: Option<&str>,
+    btw_cost: f64,
+    btw_in: u64,
+    btw_out: u64,
 ) -> io::Result<()> {
     renderer.render_viewport()?;
-    let status = StatusLine::render(session, is_running, 0, loop_label, prompt_name, perm_mode);
+    let status = StatusLine::render(
+        session,
+        is_running,
+        0,
+        loop_label,
+        prompt_name,
+        perm_mode,
+        btw_cost,
+        btw_in,
+        btw_out,
+    );
     renderer.draw_bottom(&input.buffer, input.cursor, &status, is_running)?;
     if let Some(ref mut picker) = input.picker {
         picker.draw()?;
@@ -182,10 +197,11 @@ pub(crate) enum SubmitAction {
 
 /// Commands that are safe to run *even while a main run is active* because they
 /// don't spawn or mutate the main run — the single "bypass" whitelist. Add
-/// future parallel-safe commands here. Currently: `/queue` (queue management).
+/// future parallel-safe commands here. Currently: `/queue` (queue management)
+/// and `/btw` (isolated, tool-less side question on its own event stream).
 pub(crate) fn allowed_while_running(text: &str) -> bool {
     let t = text.trim_start();
-    t == "/queue" || t.starts_with("/queue ")
+    t == "/queue" || t.starts_with("/queue ") || t == "/btw" || t.starts_with("/btw ")
 }
 
 pub(crate) fn classify_submission(is_running: bool, text: &str) -> SubmitAction {
@@ -341,11 +357,21 @@ pub async fn run_interactive(
     let mut loop_state: Option<crate::extras::r#loop::LoopState> = None;
     #[cfg(feature = "git-worktree")]
     let mut wt_return_path: Option<String> = None;
-    let mut btw_active = false;
-    let mut btw_msg_count: usize = 0;
-    let mut btw_input_tokens: u64 = 0;
-    let mut btw_output_tokens: u64 = 0;
-    let mut btw_cost: f64 = 0.0;
+    // `/btw` side questions run on an independent event stream — they never
+    // touch `agent_rx`/`is_running`/`session`, so they can run in parallel with
+    // the main agent and leave no trace in conversation history.
+    let (btw_tx, mut btw_rx) = mpsc::channel::<crate::event::BtwEvent>(32);
+    let mut btw_abort: Vec<(u32, tokio::task::AbortHandle)> = Vec::new();
+    let mut btw_inflight: usize = 0;
+    let mut btw_next_id: u32 = 0;
+    let mut btw_total_cost: f64 = 0.0;
+    let mut btw_total_in: u64 = 0;
+    let mut btw_total_out: u64 = 0;
+    // Running trace of the main agent's current (in-flight) turn, so a parallel
+    // `/btw` fired mid-task can see what the agent is doing right now (the
+    // session itself only records the final assistant text per turn).
+    let mut turn_trace: Vec<compact_str::CompactString> = Vec::new();
+    const TURN_TRACE_MAX: usize = 64;
     let mut dot_prompt_restore: Option<String> = None;
 
     let perm_mode = || -> Option<String> {
@@ -376,6 +402,9 @@ pub async fn run_interactive(
         None,
         context.current_prompt_name.as_deref(),
         perm_mode().as_deref(),
+        btw_total_cost,
+        btw_total_in,
+        btw_total_out,
     )?;
 
     #[cfg(feature = "git-worktree")]
@@ -498,17 +527,17 @@ pub async fn run_interactive(
                 match ev {
                     UserEvent::Resize => {
                         renderer.resize();
-                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
                     UserEvent::ScrollUp => {
                         renderer.scroll_line_up();
-                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
                     UserEvent::ScrollDown => {
                         renderer.scroll_line_down();
-                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
                     UserEvent::MouseDown { row, col: _ } => {
@@ -517,7 +546,7 @@ pub async fn run_interactive(
                                 renderer.selection_active = true;
                                 renderer.selection_start = Some(idx);
                                 renderer.selection_end = Some(idx);
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             }
                         continue;
                     }
@@ -525,7 +554,7 @@ pub async fn run_interactive(
                         if renderer.selection_active
                             && let Some(idx) = renderer.buffer_line_at_row(row) {
                                 renderer.selection_end = Some(idx);
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             }
                         continue;
                     }
@@ -538,13 +567,13 @@ pub async fn run_interactive(
                                 copy_to_clipboard(&text);
                             }
                             renderer.clear_selection();
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         }
                         continue;
                     }
                     UserEvent::Paste(data) => {
                         input.handle_paste(data);
-                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
                     UserEvent::Key(key) => {
@@ -553,7 +582,16 @@ pub async fn run_interactive(
                         let is_ctrl_d = key.code == KeyCode::Char('d')
                             && key.modifiers.contains(KeyModifiers::CONTROL);
                         if is_ctrl_c || is_ctrl_d {
-                            if is_running {
+                            if btw_inflight > 0 {
+                                // Cancel in-flight side questions first, without
+                                // disturbing the main agent.
+                                for (_, h) in btw_abort.drain(..) {
+                                    h.abort();
+                                }
+                                btw_inflight = 0;
+                                renderer.write_line("btw cancelled", C_ERROR)?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                            } else if is_running {
                                 // Actually cancel the run's task (not just stop
                                 // listening), so it stops executing tools. bash
                                 // children are killed via kill_on_drop.
@@ -562,6 +600,7 @@ pub async fn run_interactive(
                                 }
                                 is_running = false;
                                 agent_rx = None;
+                                turn_trace.clear();
                                 pending_inputs.clear();
                                 #[cfg(feature = "loop")]
                                 if let Some(ref mut ls) = loop_state {
@@ -584,7 +623,7 @@ pub async fn run_interactive(
                                     "interrupted (changes may be partial; review with git diff)",
                                     C_ERROR,
                                 )?;
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             } else {
                                 break;
                             }
@@ -597,12 +636,12 @@ pub async fn run_interactive(
                                 renderer.write_line("copied selection", Color::Green)?;
                             }
                             renderer.clear_selection();
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
                         if renderer.selection_active && key.code == KeyCode::Esc {
                             renderer.clear_selection();
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
 
@@ -614,29 +653,29 @@ pub async fn run_interactive(
                                 &format!("reasoning visibility: {}", if show_reasoning { "on" } else { "off" }),
                                 Color::White,
                             )?;
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
 
                         match key.code {
                             KeyCode::PageUp => {
                                 renderer.scroll_page_up();
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             KeyCode::PageDown => {
                                 renderer.scroll_page_down();
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             KeyCode::Home => {
                                 renderer.scroll_to_top();
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             KeyCode::End => {
                                 renderer.scroll_to_bottom()?;
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             _ => {}
@@ -644,7 +683,7 @@ pub async fn run_interactive(
 
                         if input.picker.as_ref().is_some_and(|p| p.active())
                             && input.handle_picker_key(key) {
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
 
@@ -659,7 +698,7 @@ pub async fn run_interactive(
                             user_tx = new_tx;
                             user_rx = new_rx;
                             event_handle = Some(spawn_event_thread(user_tx.clone(), running.clone()));
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
 
@@ -673,7 +712,7 @@ pub async fn run_interactive(
                                     "warning: lazygit not found — install it (https://github.com/jesseduffield/lazygit)",
                                     C_ERROR,
                                 )?;
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             if let Some(h) = event_handle.take() {
@@ -695,7 +734,7 @@ pub async fn run_interactive(
                             user_tx = new_tx;
                             user_rx = new_rx;
                             event_handle = Some(spawn_event_thread(user_tx.clone(), running.clone()));
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
 
@@ -703,7 +742,7 @@ pub async fn run_interactive(
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
                                 renderer.write_line("loop active: /loop stop to cancel", C_ERROR)?;
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
                             if renderer.is_scrolling() {
@@ -718,7 +757,7 @@ pub async fn run_interactive(
                             match classify_submission(is_running, &text) {
                                 SubmitAction::Run => {}
                                 SubmitAction::Ignore => {
-                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
                                 SubmitAction::RejectWhileRunning => {
@@ -726,13 +765,13 @@ pub async fn run_interactive(
                                         "agent is running — wait for it to finish or press Ctrl-C before running a command",
                                         C_ERROR,
                                     )?;
-                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
                                 SubmitAction::Queue => {
                                     pending_inputs.push_back(text.to_string());
                                     renderer.write_line(&format!("queued: {}", sanitize_output(&text)), C_TOOL)?;
-                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
                             }
@@ -765,7 +804,44 @@ pub async fn run_interactive(
                                         }
                                         _ => renderer.write_line("usage: /queue [ls|clear|pop]", C_ERROR)?,
                                     }
-                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                                    continue;
+                                }
+                            }
+                            // `/btw`: fork an isolated, tool-less, single-turn side
+                            // question. The snapshot is taken by value here and never
+                            // written to the session, so there is nothing to roll
+                            // back. It runs on its own `btw_tx`/`btw_rx` stream and
+                            // never touches `agent_rx`/`is_running`/`session`, so it
+                            // works in parallel whether or not the main run is busy.
+                            {
+                                let t = text.trim_start();
+                                if t == "/btw" || t.starts_with("/btw ") {
+                                    for line in text.lines() {
+                                        renderer.write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
+                                    }
+                                    renderer.write_line("", Color::White)?;
+                                    let btw_text = t.strip_prefix("/btw").map(|s| s.trim()).unwrap_or("");
+                                    if btw_text.is_empty() {
+                                        renderer.write_line("usage: /btw <message>", C_AGENT)?;
+                                    } else {
+                                        let id = btw_next_id;
+                                        btw_next_id = btw_next_id.wrapping_add(1);
+                                        let snapshot = crate::agent::runner::build_btw_snapshot(
+                                            session, &turn_trace, is_running,
+                                        );
+                                        let model = client.completion_model(session.model.to_string());
+                                        let btw_agent = crate::provider::build_btw_agent(
+                                            model, cli, cfg, context, &permission, &ask_tx, reasoning_enabled,
+                                        );
+                                        let runner = btw_agent.spawn_btw(
+                                            btw_text.to_string(), snapshot, btw_tx.clone(), id,
+                                        );
+                                        btw_abort.push((id, runner.abort_handle));
+                                        btw_inflight += 1;
+                                        renderer.write_line(&format!("[btw #{}] thinking...", id), C_BTW)?;
+                                    }
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
                             }
@@ -860,35 +936,10 @@ pub async fn run_interactive(
                                 renderer.write_line("", Color::White)?;
                                 #[cfg(feature = "mcp")]
                                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
-                                let result = if text.starts_with("/btw") {
-                                    let btw_text = text.strip_prefix("/btw").map(|s| s.trim()).unwrap_or("");
-                                    if btw_text.is_empty() {
-                                        renderer.write_line("usage: /btw <message>", C_AGENT)?;
-                                        Ok(())
-                                    } else {
-                                        btw_msg_count = session.messages.len();
-                                        btw_input_tokens = session.total_input_tokens;
-                                        btw_output_tokens = session.total_output_tokens;
-                                        btw_cost = session.total_cost;
-                                        ensure_agent(
-                                            &mut agent, &client, session, cli, cfg, context,
-                                            &permission, &ask_tx, &sandbox, reasoning_enabled,
-                                            #[cfg(feature = "mcp")] mcp_ref,
-                                        ).await;
-                                        let history = crate::agent::runner::convert_history(session);
-                                        let runner = agent.as_ref().unwrap().clone().spawn_runner(
-                                            btw_text.to_string(),
-                                            history,
-                                        );
-                                        agent_rx = Some(runner.event_rx);
-                                        main_abort = Some(runner.abort_handle);
-                                        is_running = true;
-                                        btw_active = true;
-                                        Ok(())
-                                    }
-                                } else {
-                                    handle_slash(&text, &mut agent, &mut client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut reasoning_enabled, &mut is_running, &mut input, &permission, &ask_tx, &mut todo_tools_enabled, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_ref).await
-                                };
+                                // `/btw` is handled earlier in the bypass-slot (it
+                                // runs in parallel and never goes through the main
+                                // run), so it never reaches here.
+                                let result = handle_slash(&text, &mut agent, &mut client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut reasoning_enabled, &mut is_running, &mut input, &permission, &ask_tx, &mut todo_tools_enabled, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_ref).await;
                                 // provider may have changed via /provider or /models — re-warm the picker's live list
                                 {
                                     let provider = session.provider.to_string();
@@ -1162,11 +1213,11 @@ pub async fn run_interactive(
                                 ).await;
                             }
                             }
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         } else if is_running {
-                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         } else {
-                            let status = StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref());
+                            let status = StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out);
                             renderer.draw_bottom(&input.buffer, input.cursor, &status, is_running)?;
                             if let Some(ref mut picker) = input.picker {
                                 picker.draw()?;
@@ -1178,6 +1229,29 @@ pub async fn run_interactive(
             Some(event) = async {
                 agent_rx.as_mut()?.recv().await
             } => {
+                // Accumulate a live trace of the current turn so a parallel
+                // `/btw` can report what the agent is doing right now. The
+                // session itself only stores the final assistant text per turn.
+                match &event {
+                    AgentEvent::ToolCall { name, args } => {
+                        if turn_trace.len() < TURN_TRACE_MAX {
+                            turn_trace.push(compact_str::CompactString::from(format!(
+                                "→ {}",
+                                crate::ui::utils::format_tool_call_summary(name, args)
+                            )));
+                        }
+                    }
+                    AgentEvent::ToolResult { output, .. } => {
+                        if turn_trace.len() < TURN_TRACE_MAX {
+                            turn_trace.push(compact_str::CompactString::from(format!(
+                                "← {}",
+                                crate::extras::truncate::truncate_cjk(output, 500, "…")
+                            )));
+                        }
+                    }
+                    AgentEvent::Done { .. } | AgentEvent::Error(_) => turn_trace.clear(),
+                    _ => {}
+                }
                 #[cfg(feature = "mcp")]
                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
                 handle_agent_event(
@@ -1191,18 +1265,6 @@ pub async fn run_interactive(
                     #[cfg(feature = "git-worktree")] &mut wt_return_path,
                     #[cfg(feature = "mcp")] mcp_ref,
                 ).await?;
-                if btw_active && !is_running {
-                    while session.messages.len() > btw_msg_count {
-                        session.messages.pop();
-                    }
-                    session.total_input_tokens = btw_input_tokens;
-                    session.total_output_tokens = btw_output_tokens;
-                    session.total_cost = btw_cost;
-                    if !cli.no_session {
-                        let _ = crate::session::storage::save_session(session);
-                    }
-                    btw_active = false;
-                }
                 if !is_running
                     && let Some(restore_name) = dot_prompt_restore.take()
                 {
@@ -1234,7 +1296,7 @@ pub async fn run_interactive(
                         ).await;
                     }
                 }
-                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
             }
             Some(ask_req) = async {
                 ask_rx.as_mut()?.recv().await
@@ -1243,10 +1305,37 @@ pub async fn run_interactive(
                     ask_req, &mut renderer, session, cli,
                     &mut user_rx, &mut agent_line_started, &mut was_reasoning,
                 ).await?;
-                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+            }
+            Some(bev) = btw_rx.recv() => {
+                // Parallel side-question result. Rendered as a single block; it is
+                // NEVER written to the session (cost is tracked separately).
+                match bev {
+                    crate::event::BtwEvent::Done { id, response, input_tokens, output_tokens } => {
+                        btw_total_cost += crate::pricing::estimate_cost(
+                            input_tokens, output_tokens,
+                            session.input_token_cost, session.output_token_cost,
+                        );
+                        btw_total_in = btw_total_in.saturating_add(input_tokens);
+                        btw_total_out = btw_total_out.saturating_add(output_tokens);
+                        btw_abort.retain(|(i, _)| *i != id);
+                        btw_inflight = btw_inflight.saturating_sub(1);
+                        renderer.write_line(&format!("[btw #{}] answer:", id), C_BTW)?;
+                        for line in response.lines() {
+                            renderer.write_line(&sanitize_output(line), C_AGENT)?;
+                        }
+                        renderer.write_line("", Color::White)?;
+                    }
+                    crate::event::BtwEvent::Error { id, message } => {
+                        btw_abort.retain(|(i, _)| *i != id);
+                        btw_inflight = btw_inflight.saturating_sub(1);
+                        renderer.write_line(&format!("[btw #{}] error: {}", id, sanitize_output(&message)), C_ERROR)?;
+                    }
+                }
+                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
             }
             _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)), if is_running => {
-                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref())?;
+                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
             }
             else => {
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -23,6 +23,9 @@ impl StatusLine {
         loop_label: Option<&str>,
         prompt_name: Option<&str>,
         perm_mode: Option<&str>,
+        btw_cost: f64,
+        btw_in: u64,
+        btw_out: u64,
     ) -> String {
         let state = if is_running { "running" } else { "ready" };
         let dir = Path::new(&session.working_dir)
@@ -36,6 +39,24 @@ impl StatusLine {
 
         let cost_str = if session.total_cost > 0.0 {
             format!(" ${:.4}", session.total_cost)
+        } else {
+            String::new()
+        };
+
+        // Side-question (`/btw`) usage is tracked and shown separately so it
+        // never pollutes the main session totals. Shown once `/btw` is used;
+        // cost is added only when the model has per-token pricing configured.
+        let btw_badge = if btw_in > 0 || btw_out > 0 {
+            if btw_cost > 0.0 {
+                format!(
+                    " btw:${:.4} ({}/{})",
+                    btw_cost,
+                    fmt_tokens(btw_in),
+                    fmt_tokens(btw_out)
+                )
+            } else {
+                format!(" btw:{}/{}", fmt_tokens(btw_in), fmt_tokens(btw_out))
+            }
         } else {
             String::new()
         };
@@ -72,9 +93,10 @@ impl StatusLine {
         };
 
         format!(
-            "{}{} | {}{} | {}/{} ({}%) | {}msgs{}{} | {}{}{}",
+            "{}{}{} | {}{} | {}/{} ({}%) | {}msgs{}{} | {}{}{}",
             dir,
             cost_str,
+            btw_badge,
             session.model,
             loop_badge,
             fmt_tokens(used),


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/9ce594fb-1684-4cd5-9073-a111ce8627ea

## Summary
`/btw <message>` now runs a "by the way" question in parallel with the main agent instead of orphaning it, with read-only tools and no writes to the session.

- **Independent event stream**: `/btw` gets its own btw_tx/btw_rx and never touches agent_rx/is_running/session, so it runs in parallel whether or not the main run is busy. It is wired into the single-flight gate's bypass-slot next to `/queue`.
- **Read-only tools, multi-turn**: a dedicated lightweight Q&A system prompt (not the `list_dir`), so a side question can look things up but cannot write files or run commands. `--no-tools` keeps it fully tool-less. You can also point a question at a file with `@` (for example `/btw` then `@src/main.rs` then "how does this work?").
- **No rollback by construction**: a separate `BtwEvent` type makes it impossible for a side-question result to reach `handle_agent_event` (which mutates the session), so nothing is written to history and there is nothing to roll back.
- **Sees the main agent's work**: a `turn_trace` of the in-flight turn's tool calls and completed results is forked into the snapshot, so a mid-task `/btw` can report what the agent is doing right now.
- **Separate accounting**: token usage and cost show as a `btw:` badge so side questions never pollute the main session totals.
- **Ctrl-C cancels an in-flight `/btw` first**, without disturbing the main agent.

## Testing
- `cargo build` and `cargo build --features memory`: clean, no warnings.
- `cargo test`: all green, including 4 btw snapshot tests.
- Manually verified: a `/btw` fired mid-task does not interrupt the main run, reads a referenced file to answer, reports current activity, shows the `btw:` badge, and leaves session token/cost/messages untouched; Ctrl-C cancels only the side question.

## Notes
- The side question sees completed tools' results in the current turn (each truncated to 500 bytes, up to 64 trace entries); only the tool executing at the moment `/btw` fires is not yet visible.
- Read-only tools respect the existing permission system (the same permission and ask channel as the main agent), so reads are auto-allowed or prompted exactly as configured.
- Follow-up idea (not in this PR): reselecting past `/btw` questions via the picker.