### PR TITLE
fix(models): seed picker from static catalog to avoid slow startup

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -1,0 +1,42 @@
+name: Update model catalog
+
+# Refreshes the embedded static model catalog (data/models.json) from
+# models.dev on a schedule. The committed JSON stays the single build-time
+# source of truth, so this only opens a PR when models.dev actually changes —
+# builds remain offline and reproducible. See scripts/gen-models-catalog.sh.
+
+on:
+  schedule:
+    # Weekly, Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Regenerate catalog
+        run: ./scripts/gen-models-catalog.sh
+
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'chore: refresh model catalog from models.dev'
+          title: 'chore: refresh model catalog from models.dev'
+          body: |
+            Automated refresh of `data/models.json` from https://models.dev/api.json
+            via `scripts/gen-models-catalog.sh`.
+
+            Review the diff for unexpected additions/removals before merging.
+          branch: chore/refresh-model-catalog
+          delete-branch: true
+          add-paths: data/models.json

--- a/data/models.json
+++ b/data/models.json
@@ -1,0 +1,1505 @@
+{
+  "anthropic": [
+    {
+      "id": "claude-haiku-4-5",
+      "name": "Claude Haiku 4.5 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-haiku-4-5-20251001",
+      "name": "Claude Haiku 4.5",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-0",
+      "name": "Claude Opus 4 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-1",
+      "name": "Claude Opus 4.1 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-1-20250805",
+      "name": "Claude Opus 4.1",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-20250514",
+      "name": "Claude Opus 4",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-5",
+      "name": "Claude Opus 4.5 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-5-20251101",
+      "name": "Claude Opus 4.5",
+      "context": 200000
+    },
+    {
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "context": 1000000
+    },
+    {
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "context": 1000000
+    },
+    {
+      "id": "claude-opus-4-8",
+      "name": "Claude Opus 4.8",
+      "context": 1000000
+    },
+    {
+      "id": "claude-sonnet-4-0",
+      "name": "Claude Sonnet 4 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-sonnet-4-20250514",
+      "name": "Claude Sonnet 4",
+      "context": 200000
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "claude-sonnet-4-5-20250929",
+      "name": "Claude Sonnet 4.5",
+      "context": 200000
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "context": 1000000
+    }
+  ],
+  "openai": [
+    {
+      "id": "gpt-3.5-turbo",
+      "name": "GPT-3.5-turbo",
+      "context": 16385
+    },
+    {
+      "id": "gpt-4",
+      "name": "GPT-4",
+      "context": 8192
+    },
+    {
+      "id": "gpt-4-turbo",
+      "name": "GPT-4 Turbo",
+      "context": 128000
+    },
+    {
+      "id": "gpt-4.1",
+      "name": "GPT-4.1",
+      "context": 1047576
+    },
+    {
+      "id": "gpt-4.1-mini",
+      "name": "GPT-4.1 mini",
+      "context": 1047576
+    },
+    {
+      "id": "gpt-4.1-nano",
+      "name": "GPT-4.1 nano",
+      "context": 1047576
+    },
+    {
+      "id": "gpt-4o",
+      "name": "GPT-4o",
+      "context": 128000
+    },
+    {
+      "id": "gpt-4o-2024-05-13",
+      "name": "GPT-4o (2024-05-13)",
+      "context": 128000
+    },
+    {
+      "id": "gpt-4o-2024-08-06",
+      "name": "GPT-4o (2024-08-06)",
+      "context": 128000
+    },
+    {
+      "id": "gpt-4o-2024-11-20",
+      "name": "GPT-4o (2024-11-20)",
+      "context": 128000
+    },
+    {
+      "id": "gpt-4o-mini",
+      "name": "GPT-4o mini",
+      "context": 128000
+    },
+    {
+      "id": "gpt-5",
+      "name": "GPT-5",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5-chat-latest",
+      "name": "GPT-5 Chat (latest)",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5-codex",
+      "name": "GPT-5-Codex",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5-mini",
+      "name": "GPT-5 Mini",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5-nano",
+      "name": "GPT-5 Nano",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5-pro",
+      "name": "GPT-5 Pro",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.1",
+      "name": "GPT-5.1",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.1-chat-latest",
+      "name": "GPT-5.1 Chat",
+      "context": 128000
+    },
+    {
+      "id": "gpt-5.1-codex",
+      "name": "GPT-5.1 Codex",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.1-codex-max",
+      "name": "GPT-5.1 Codex Max",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.1-codex-mini",
+      "name": "GPT-5.1 Codex mini",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.2",
+      "name": "GPT-5.2",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.2-chat-latest",
+      "name": "GPT-5.2 Chat",
+      "context": 128000
+    },
+    {
+      "id": "gpt-5.2-codex",
+      "name": "GPT-5.2 Codex",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.2-pro",
+      "name": "GPT-5.2 Pro",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.3-chat-latest",
+      "name": "GPT-5.3 Chat (latest)",
+      "context": 128000
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "name": "GPT-5.3 Codex",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.3-codex-spark",
+      "name": "GPT-5.3 Codex Spark",
+      "context": 128000
+    },
+    {
+      "id": "gpt-5.4",
+      "name": "GPT-5.4",
+      "context": 1050000
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "name": "GPT-5.4 mini",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.4-nano",
+      "name": "GPT-5.4 nano",
+      "context": 400000
+    },
+    {
+      "id": "gpt-5.4-pro",
+      "name": "GPT-5.4 Pro",
+      "context": 1050000
+    },
+    {
+      "id": "gpt-5.5",
+      "name": "GPT-5.5",
+      "context": 1050000
+    },
+    {
+      "id": "gpt-5.5-pro",
+      "name": "GPT-5.5 Pro",
+      "context": 1050000
+    },
+    {
+      "id": "o1",
+      "name": "o1",
+      "context": 200000
+    },
+    {
+      "id": "o1-mini",
+      "name": "o1-mini",
+      "context": 128000
+    },
+    {
+      "id": "o1-preview",
+      "name": "o1-preview",
+      "context": 128000
+    },
+    {
+      "id": "o1-pro",
+      "name": "o1-pro",
+      "context": 200000
+    },
+    {
+      "id": "o3",
+      "name": "o3",
+      "context": 200000
+    },
+    {
+      "id": "o3-deep-research",
+      "name": "o3-deep-research",
+      "context": 200000
+    },
+    {
+      "id": "o3-mini",
+      "name": "o3-mini",
+      "context": 200000
+    },
+    {
+      "id": "o3-pro",
+      "name": "o3-pro",
+      "context": 200000
+    },
+    {
+      "id": "o4-mini",
+      "name": "o4-mini",
+      "context": 200000
+    },
+    {
+      "id": "o4-mini-deep-research",
+      "name": "o4-mini-deep-research",
+      "context": 200000
+    }
+  ],
+  "gemini": [
+    {
+      "id": "gemini-2.0-flash",
+      "name": "Gemini 2.0 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-2.0-flash-lite",
+      "name": "Gemini 2.0 Flash-Lite",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-2.5-flash-image",
+      "name": "Nano Banana",
+      "context": 32768
+    },
+    {
+      "id": "gemini-2.5-flash-lite",
+      "name": "Gemini 2.5 Flash-Lite",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3-flash-preview",
+      "name": "Gemini 3 Flash Preview",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3-pro-preview",
+      "name": "Gemini 3 Pro Preview",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3.1-flash-image-preview",
+      "name": "Nano Banana 2",
+      "context": 65536
+    },
+    {
+      "id": "gemini-3.1-flash-lite",
+      "name": "Gemini 3.1 Flash Lite",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3.1-flash-lite-preview",
+      "name": "Gemini 3.1 Flash Lite Preview",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3.1-pro-preview",
+      "name": "Gemini 3.1 Pro Preview",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3.1-pro-preview-customtools",
+      "name": "Gemini 3.1 Pro Preview Custom Tools",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "name": "Gemini 3.5 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-flash-latest",
+      "name": "Gemini Flash Latest",
+      "context": 1048576
+    },
+    {
+      "id": "gemini-flash-lite-latest",
+      "name": "Gemini Flash-Lite Latest",
+      "context": 1048576
+    },
+    {
+      "id": "gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B A4B IT",
+      "context": 262144
+    },
+    {
+      "id": "gemma-4-31b-it",
+      "name": "Gemma 4 31B IT",
+      "context": 262144
+    }
+  ],
+  "openrouter": [
+    {
+      "id": "anthropic/claude-3-haiku",
+      "name": "Claude 3 Haiku",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-3.5-haiku",
+      "name": "Claude 3.5 Haiku",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-haiku-4.5",
+      "name": "Claude Haiku 4.5 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-opus-4",
+      "name": "Claude Opus 4",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-opus-4.1",
+      "name": "Claude Opus 4.1 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-opus-4.5",
+      "name": "Claude Opus 4.5 (latest)",
+      "context": 200000
+    },
+    {
+      "id": "anthropic/claude-opus-4.6",
+      "name": "Claude Opus 4.6",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-opus-4.6-fast",
+      "name": "Claude Opus 4.6 (Fast)",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-opus-4.7",
+      "name": "Claude Opus 4.7",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-opus-4.7-fast",
+      "name": "Claude Opus 4.7 (Fast)",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-opus-4.8",
+      "name": "Claude Opus 4.8",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-opus-4.8-fast",
+      "name": "Claude Opus 4.8 (Fast)",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-sonnet-4",
+      "name": "Claude Sonnet 4",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.5",
+      "name": "Claude Sonnet 4.5 (latest)",
+      "context": 1000000
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.6",
+      "name": "Claude Sonnet 4.6",
+      "context": 1000000
+    },
+    {
+      "id": "deepseek/deepseek-chat",
+      "name": "DeepSeek Chat",
+      "context": 128000
+    },
+    {
+      "id": "deepseek/deepseek-chat-v3-0324",
+      "name": "DeepSeek V3 0324",
+      "context": 163840
+    },
+    {
+      "id": "deepseek/deepseek-chat-v3.1",
+      "name": "DeepSeek V3.1",
+      "context": 163840
+    },
+    {
+      "id": "deepseek/deepseek-r1",
+      "name": "R1",
+      "context": 64000
+    },
+    {
+      "id": "deepseek/deepseek-r1-0528",
+      "name": "R1 0528",
+      "context": 163840
+    },
+    {
+      "id": "deepseek/deepseek-r1-distill-llama-70b",
+      "name": "R1 Distill Llama 70B",
+      "context": 131072
+    },
+    {
+      "id": "deepseek/deepseek-r1-distill-qwen-32b",
+      "name": "R1 Distill Qwen 32B",
+      "context": 32768
+    },
+    {
+      "id": "deepseek/deepseek-v3.1-terminus",
+      "name": "DeepSeek V3.1 Terminus",
+      "context": 163840
+    },
+    {
+      "id": "deepseek/deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "context": 128000
+    },
+    {
+      "id": "deepseek/deepseek-v3.2-exp",
+      "name": "DeepSeek V3.2 Exp",
+      "context": 163840
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro",
+      "name": "DeepSeek V4 Pro",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-flash-image",
+      "name": "Nano Banana",
+      "context": 32768
+    },
+    {
+      "id": "google/gemini-2.5-flash-lite",
+      "name": "Gemini 2.5 Flash-Lite",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-flash-lite-preview-09-2025",
+      "name": "Gemini 2.5 Flash Lite Preview 09-2025",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-pro-preview",
+      "name": "Gemini 2.5 Pro Preview 06-05",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-2.5-pro-preview-05-06",
+      "name": "Gemini 2.5 Pro Preview 05-06",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3-flash-preview",
+      "name": "Gemini 3 Flash Preview",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3-pro-image-preview",
+      "name": "Nano Banana Pro (Gemini 3 Pro Image Preview)",
+      "context": 65536
+    },
+    {
+      "id": "google/gemini-3.1-flash-image-preview",
+      "name": "Nano Banana 2",
+      "context": 65536
+    },
+    {
+      "id": "google/gemini-3.1-flash-lite",
+      "name": "Gemini 3.1 Flash Lite",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3.1-flash-lite-preview",
+      "name": "Gemini 3.1 Flash Lite Preview",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3.1-pro-preview",
+      "name": "Gemini 3.1 Pro Preview",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3.1-pro-preview-customtools",
+      "name": "Gemini 3.1 Pro Preview Custom Tools",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemini-3.5-flash",
+      "name": "Gemini 3.5 Flash",
+      "context": 1048576
+    },
+    {
+      "id": "google/gemma-2-27b-it",
+      "name": "Gemma 2 27B",
+      "context": 8192
+    },
+    {
+      "id": "google/gemma-3-12b-it",
+      "name": "Gemma 3 12B",
+      "context": 131072
+    },
+    {
+      "id": "google/gemma-3-27b-it",
+      "name": "Gemma 3 27B",
+      "context": 131072
+    },
+    {
+      "id": "google/gemma-3-4b-it",
+      "name": "Gemma 3 4B",
+      "context": 131072
+    },
+    {
+      "id": "google/gemma-3n-e4b-it",
+      "name": "Gemma 3n 4B",
+      "context": 32768
+    },
+    {
+      "id": "google/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B A4B IT",
+      "context": 262144
+    },
+    {
+      "id": "google/gemma-4-26b-a4b-it:free",
+      "name": "Gemma 4 26B A4B  (free)",
+      "context": 262144
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "name": "Gemma 4 31B IT",
+      "context": 262144
+    },
+    {
+      "id": "google/gemma-4-31b-it:free",
+      "name": "Gemma 4 31B (free)",
+      "context": 262144
+    },
+    {
+      "id": "google/lyria-3-clip-preview",
+      "name": "Lyria 3 Clip Preview",
+      "context": 1048576
+    },
+    {
+      "id": "google/lyria-3-pro-preview",
+      "name": "Lyria 3 Pro Preview",
+      "context": 1048576
+    },
+    {
+      "id": "meta-llama/llama-3-70b-instruct",
+      "name": "Llama 3 70B Instruct",
+      "context": 8192
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct",
+      "name": "Llama 3 8B Instruct",
+      "context": 8192
+    },
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct",
+      "name": "Llama 3.1 70B Instruct",
+      "context": 131072
+    },
+    {
+      "id": "meta-llama/llama-3.1-8b-instruct",
+      "name": "Llama 3.1 8B Instruct",
+      "context": 16384
+    },
+    {
+      "id": "meta-llama/llama-3.2-11b-vision-instruct",
+      "name": "Llama 3.2 11B Vision Instruct",
+      "context": 131072
+    },
+    {
+      "id": "meta-llama/llama-3.2-1b-instruct",
+      "name": "Llama 3.2 1B Instruct",
+      "context": 60000
+    },
+    {
+      "id": "meta-llama/llama-3.2-3b-instruct",
+      "name": "Llama 3.2 3B Instruct",
+      "context": 80000
+    },
+    {
+      "id": "meta-llama/llama-3.2-3b-instruct:free",
+      "name": "Llama 3.2 3B Instruct (free)",
+      "context": 131072
+    },
+    {
+      "id": "meta-llama/llama-3.3-70b-instruct",
+      "name": "Llama-3.3-70B-Instruct",
+      "context": 131072
+    },
+    {
+      "id": "meta-llama/llama-3.3-70b-instruct:free",
+      "name": "Llama 3.3 70B Instruct (free)",
+      "context": 65536
+    },
+    {
+      "id": "meta-llama/llama-4-maverick",
+      "name": "Llama 4 Maverick",
+      "context": 1048576
+    },
+    {
+      "id": "meta-llama/llama-4-scout",
+      "name": "Llama 4 Scout",
+      "context": 327680
+    },
+    {
+      "id": "meta-llama/llama-guard-3-8b",
+      "name": "Llama Guard 3 8B",
+      "context": 131072
+    },
+    {
+      "id": "meta-llama/llama-guard-4-12b",
+      "name": "Llama Guard 4 12B",
+      "context": 163840
+    },
+    {
+      "id": "mistralai/codestral-2508",
+      "name": "Codestral 2508",
+      "context": 256000
+    },
+    {
+      "id": "mistralai/devstral-2512",
+      "name": "Devstral 2",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/ministral-14b-2512",
+      "name": "Ministral 3 14B 2512",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/ministral-3b-2512",
+      "name": "Ministral 3 3B 2512",
+      "context": 131072
+    },
+    {
+      "id": "mistralai/ministral-8b-2512",
+      "name": "Ministral 3 8B 2512",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/mistral-large",
+      "name": "Mistral Large",
+      "context": 128000
+    },
+    {
+      "id": "mistralai/mistral-large-2407",
+      "name": "Mistral Large 2407",
+      "context": 131072
+    },
+    {
+      "id": "mistralai/mistral-large-2512",
+      "name": "Mistral Large 3",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/mistral-medium-3",
+      "name": "Mistral Medium 3",
+      "context": 131072
+    },
+    {
+      "id": "mistralai/mistral-medium-3-5",
+      "name": "Mistral Medium 3.5",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/mistral-medium-3.1",
+      "name": "Mistral Medium 3.1",
+      "context": 131072
+    },
+    {
+      "id": "mistralai/mistral-nemo",
+      "name": "Mistral Nemo",
+      "context": 131072
+    },
+    {
+      "id": "mistralai/mistral-saba",
+      "name": "Saba",
+      "context": 32768
+    },
+    {
+      "id": "mistralai/mistral-small-24b-instruct-2501",
+      "name": "Mistral Small 3",
+      "context": 32768
+    },
+    {
+      "id": "mistralai/mistral-small-2603",
+      "name": "Mistral Small 4",
+      "context": 262144
+    },
+    {
+      "id": "mistralai/mistral-small-3.1-24b-instruct",
+      "name": "Mistral Small 3.1 24B",
+      "context": 128000
+    },
+    {
+      "id": "mistralai/mistral-small-3.2-24b-instruct",
+      "name": "Mistral Small 3.2 24B",
+      "context": 128000
+    },
+    {
+      "id": "mistralai/mixtral-8x22b-instruct",
+      "name": "Mixtral 8x22B Instruct",
+      "context": 65536
+    },
+    {
+      "id": "mistralai/voxtral-small-24b-2507",
+      "name": "Voxtral Small 24B 2507",
+      "context": 32000
+    },
+    {
+      "id": "moonshotai/kimi-k2",
+      "name": "Kimi K2 0711",
+      "context": 131072
+    },
+    {
+      "id": "moonshotai/kimi-k2-0905",
+      "name": "Kimi K2 0905",
+      "context": 262144
+    },
+    {
+      "id": "moonshotai/kimi-k2-thinking",
+      "name": "Kimi K2 Thinking",
+      "context": 262144
+    },
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "name": "Kimi K2.5",
+      "context": 262144
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "name": "Kimi K2.6",
+      "context": 262144
+    },
+    {
+      "id": "moonshotai/kimi-k2.6:free",
+      "name": "Kimi K2.6 (free)",
+      "context": 262144
+    },
+    {
+      "id": "openai/gpt-3.5-turbo",
+      "name": "GPT-3.5-turbo",
+      "context": 16385
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-0613",
+      "name": "GPT-3.5 Turbo (older v0613)",
+      "context": 4095
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-16k",
+      "name": "GPT-3.5 Turbo 16k",
+      "context": 16385
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-instruct",
+      "name": "GPT-3.5 Turbo Instruct",
+      "context": 4095
+    },
+    {
+      "id": "openai/gpt-4",
+      "name": "GPT-4",
+      "context": 8191
+    },
+    {
+      "id": "openai/gpt-4-0314",
+      "name": "GPT-4 (older v0314)",
+      "context": 8191
+    },
+    {
+      "id": "openai/gpt-4-1106-preview",
+      "name": "GPT-4 Turbo (older v1106)",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4-turbo",
+      "name": "GPT-4 Turbo",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4-turbo-preview",
+      "name": "GPT-4 Turbo Preview",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4.1",
+      "name": "GPT-4.1",
+      "context": 1047576
+    },
+    {
+      "id": "openai/gpt-4.1-mini",
+      "name": "GPT-4.1 mini",
+      "context": 1047576
+    },
+    {
+      "id": "openai/gpt-4.1-nano",
+      "name": "GPT-4.1 nano",
+      "context": 1047576
+    },
+    {
+      "id": "openai/gpt-4o",
+      "name": "GPT-4o",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-2024-05-13",
+      "name": "GPT-4o (2024-05-13)",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-2024-08-06",
+      "name": "GPT-4o (2024-08-06)",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-2024-11-20",
+      "name": "GPT-4o (2024-11-20)",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "name": "GPT-4o mini",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-mini-2024-07-18",
+      "name": "GPT-4o-mini (2024-07-18)",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-mini-search-preview",
+      "name": "GPT-4o-mini Search Preview",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-4o-search-preview",
+      "name": "GPT-4o Search Preview",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-5",
+      "name": "GPT-5",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-chat",
+      "name": "GPT-5 Chat",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-5-codex",
+      "name": "GPT-5-Codex",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-image",
+      "name": "GPT-5 Image",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-image-mini",
+      "name": "GPT-5 Image Mini",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-mini",
+      "name": "GPT-5 Mini",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-nano",
+      "name": "GPT-5 Nano",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5-pro",
+      "name": "GPT-5 Pro",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.1",
+      "name": "GPT-5.1",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.1-chat",
+      "name": "GPT-5.1 Chat",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-5.1-codex",
+      "name": "GPT-5.1 Codex",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.1-codex-max",
+      "name": "GPT-5.1 Codex Max",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.1-codex-mini",
+      "name": "GPT-5.1 Codex mini",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.2",
+      "name": "GPT-5.2",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.2-chat",
+      "name": "GPT-5.2 Chat",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-5.2-codex",
+      "name": "GPT-5.2 Codex",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.2-pro",
+      "name": "GPT-5.2 Pro",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.3-chat",
+      "name": "GPT-5.3 Chat",
+      "context": 128000
+    },
+    {
+      "id": "openai/gpt-5.3-codex",
+      "name": "GPT-5.3 Codex",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.4",
+      "name": "GPT-5.4",
+      "context": 1050000
+    },
+    {
+      "id": "openai/gpt-5.4-image-2",
+      "name": "GPT-5.4 Image 2",
+      "context": 272000
+    },
+    {
+      "id": "openai/gpt-5.4-mini",
+      "name": "GPT-5.4 mini",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.4-nano",
+      "name": "GPT-5.4 nano",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-5.4-pro",
+      "name": "GPT-5.4 Pro",
+      "context": 1050000
+    },
+    {
+      "id": "openai/gpt-5.5",
+      "name": "GPT-5.5",
+      "context": 1050000
+    },
+    {
+      "id": "openai/gpt-5.5-pro",
+      "name": "GPT-5.5 Pro",
+      "context": 1050000
+    },
+    {
+      "id": "openai/gpt-chat-latest",
+      "name": "GPT Chat Latest",
+      "context": 400000
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "gpt-oss-120b",
+      "context": 131072
+    },
+    {
+      "id": "openai/gpt-oss-120b:free",
+      "name": "gpt-oss-120b (free)",
+      "context": 131072
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "name": "gpt-oss-20b",
+      "context": 131072
+    },
+    {
+      "id": "openai/gpt-oss-20b:free",
+      "name": "gpt-oss-20b (free)",
+      "context": 131072
+    },
+    {
+      "id": "openai/gpt-oss-safeguard-20b",
+      "name": "gpt-oss-safeguard-20b",
+      "context": 131072
+    },
+    {
+      "id": "openai/o1",
+      "name": "o1",
+      "context": 200000
+    },
+    {
+      "id": "openai/o1-pro",
+      "name": "o1-pro",
+      "context": 200000
+    },
+    {
+      "id": "openai/o3",
+      "name": "o3",
+      "context": 200000
+    },
+    {
+      "id": "openai/o3-deep-research",
+      "name": "o3-deep-research",
+      "context": 200000
+    },
+    {
+      "id": "openai/o3-mini",
+      "name": "o3-mini",
+      "context": 200000
+    },
+    {
+      "id": "openai/o3-mini-high",
+      "name": "o3 Mini High",
+      "context": 200000
+    },
+    {
+      "id": "openai/o3-pro",
+      "name": "o3-pro",
+      "context": 200000
+    },
+    {
+      "id": "openai/o4-mini",
+      "name": "o4-mini",
+      "context": 200000
+    },
+    {
+      "id": "openai/o4-mini-deep-research",
+      "name": "o4-mini-deep-research",
+      "context": 200000
+    },
+    {
+      "id": "openai/o4-mini-high",
+      "name": "o4 Mini High",
+      "context": 200000
+    },
+    {
+      "id": "qwen/qwen-2.5-72b-instruct",
+      "name": "Qwen2.5 72B Instruct",
+      "context": 32768
+    },
+    {
+      "id": "qwen/qwen-2.5-7b-instruct",
+      "name": "Qwen2.5 7B Instruct",
+      "context": 32768
+    },
+    {
+      "id": "qwen/qwen-2.5-coder-32b-instruct",
+      "name": "Qwen2.5 Coder 32B Instruct",
+      "context": 32768
+    },
+    {
+      "id": "qwen/qwen-plus",
+      "name": "Qwen-Plus",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen-plus-2025-07-28",
+      "name": "Qwen Plus 0728",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen-plus-2025-07-28:thinking",
+      "name": "Qwen Plus 0728 (thinking)",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen2.5-vl-72b-instruct",
+      "name": "Qwen2.5 VL 72B Instruct",
+      "context": 32000
+    },
+    {
+      "id": "qwen/qwen3-14b",
+      "name": "Qwen3 14B",
+      "context": 40960
+    },
+    {
+      "id": "qwen/qwen3-235b-a22b",
+      "name": "Qwen3 235B A22B",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-235b-a22b-2507",
+      "name": "Qwen3 235B A22B Instruct 2507",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-235b-a22b-thinking-2507",
+      "name": "Qwen3 235B A22B Thinking 2507",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-30b-a3b",
+      "name": "Qwen3 30B A3B",
+      "context": 40960
+    },
+    {
+      "id": "qwen/qwen3-30b-a3b-instruct-2507",
+      "name": "Qwen3 30B A3B Instruct 2507",
+      "context": 128000
+    },
+    {
+      "id": "qwen/qwen3-30b-a3b-thinking-2507",
+      "name": "Qwen3 30B A3B Thinking 2507",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-32b",
+      "name": "Qwen3 32B",
+      "context": 40960
+    },
+    {
+      "id": "qwen/qwen3-8b",
+      "name": "Qwen3 8B",
+      "context": 40960
+    },
+    {
+      "id": "qwen/qwen3-coder",
+      "name": "Qwen3 Coder 480B A35B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-coder-30b-a3b-instruct",
+      "name": "Qwen3 Coder 30B A3B Instruct",
+      "context": 160000
+    },
+    {
+      "id": "qwen/qwen3-coder-flash",
+      "name": "Qwen3 Coder Flash",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3-coder:free",
+      "name": "Qwen3 Coder 480B A35B (free)",
+      "context": 262000
+    },
+    {
+      "id": "qwen/qwen3-max",
+      "name": "Qwen3 Max",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-max-thinking",
+      "name": "Qwen3 Max Thinking",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-instruct",
+      "name": "Qwen3 Next 80B A3B Instruct",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-instruct:free",
+      "name": "Qwen3 Next 80B A3B Instruct (free)",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-thinking",
+      "name": "Qwen3 Next 80B A3B Thinking",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-235b-a22b-instruct",
+      "name": "Qwen3 VL 235B A22B Instruct",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3-vl-235b-a22b-thinking",
+      "name": "Qwen3 VL 235B A22B Thinking",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-30b-a3b-instruct",
+      "name": "Qwen3 VL 30B A3B Instruct",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-30b-a3b-thinking",
+      "name": "Qwen3 VL 30B A3B Thinking",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-32b-instruct",
+      "name": "Qwen3 VL 32B Instruct",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-8b-instruct",
+      "name": "Qwen3 VL 8B Instruct",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3-vl-8b-thinking",
+      "name": "Qwen3 VL 8B Thinking",
+      "context": 131072
+    },
+    {
+      "id": "qwen/qwen3.5-122b-a10b",
+      "name": "Qwen3.5-122B-A10B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.5-27b",
+      "name": "Qwen3.5-27B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.5-35b-a3b",
+      "name": "Qwen3.5-35B-A3B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.5-397b-a17b",
+      "name": "Qwen3.5 397B A17B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.5-9b",
+      "name": "Qwen3.5-9B",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.5-flash-02-23",
+      "name": "Qwen3.5-Flash",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.5-plus-02-15",
+      "name": "Qwen3.5 Plus 2026-02-15",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.5-plus-20260420",
+      "name": "Qwen3.5 Plus 2026-04-20",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.6-27b",
+      "name": "Qwen3.6 27B",
+      "context": 262140
+    },
+    {
+      "id": "qwen/qwen3.6-35b-a3b",
+      "name": "Qwen3.6 35B A3B",
+      "context": 262140
+    },
+    {
+      "id": "qwen/qwen3.6-flash",
+      "name": "Qwen3.6 Flash",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.6-max-preview",
+      "name": "Qwen3.6 Max Preview",
+      "context": 262144
+    },
+    {
+      "id": "qwen/qwen3.6-plus",
+      "name": "Qwen3.6 Plus",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen3.7 Max",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.7-plus",
+      "name": "Qwen3.7 Plus",
+      "context": 1000000
+    },
+    {
+      "id": "x-ai/grok-4.20",
+      "name": "Grok 4.20",
+      "context": 2000000
+    },
+    {
+      "id": "x-ai/grok-4.20-multi-agent",
+      "name": "Grok 4.20 Multi-Agent",
+      "context": 2000000
+    },
+    {
+      "id": "x-ai/grok-4.3",
+      "name": "Grok 4.3",
+      "context": 1000000
+    },
+    {
+      "id": "x-ai/grok-build-0.1",
+      "name": "Grok Build 0.1",
+      "context": 256000
+    },
+    {
+      "id": "z-ai/glm-4-32b",
+      "name": "GLM 4 32B ",
+      "context": 128000
+    },
+    {
+      "id": "z-ai/glm-4.5",
+      "name": "GLM-4.5",
+      "context": 131072
+    },
+    {
+      "id": "z-ai/glm-4.5-air",
+      "name": "GLM-4.5-Air",
+      "context": 131070
+    },
+    {
+      "id": "z-ai/glm-4.5-air:free",
+      "name": "GLM 4.5 Air (free)",
+      "context": 131072
+    },
+    {
+      "id": "z-ai/glm-4.5v",
+      "name": "GLM-4.5V",
+      "context": 65536
+    },
+    {
+      "id": "z-ai/glm-4.6",
+      "name": "GLM-4.6",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-4.6v",
+      "name": "GLM-4.6V",
+      "context": 131072
+    },
+    {
+      "id": "z-ai/glm-4.7",
+      "name": "GLM-4.7",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-4.7-flash",
+      "name": "GLM-4.7-Flash",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-5",
+      "name": "GLM-5",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-5-turbo",
+      "name": "GLM-5-Turbo",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-5.1",
+      "name": "GLM-5.1",
+      "context": 202752
+    },
+    {
+      "id": "z-ai/glm-5v-turbo",
+      "name": "GLM-5V-Turbo",
+      "context": 202752
+    }
+  ]
+}

--- a/scripts/gen-models-catalog.sh
+++ b/scripts/gen-models-catalog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Regenerates data/models.json — the static model catalog embedded into the
+# binary (see src/models_catalog.rs). Source: https://models.dev/api.json,
+# which lists every provider's model ids.
+#
+# The committed JSON is the single build-time source of truth, so the build
+# stays offline and reproducible. Run this (or let the scheduled CI workflow
+# .github/workflows/update-models.yml run it) to refresh the snapshot.
+#
+# Usage: scripts/gen-models-catalog.sh
+# Requires: curl, jq
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$SCRIPT_DIR/../data/models.json"
+SRC="https://models.dev/api.json"
+
+# Vendors kept for the curated OpenRouter subset (its full list is ~340 models;
+# the rest are reachable on demand via `/models refresh`).
+OPENROUTER_VENDORS='["anthropic","openai","google","deepseek","x-ai","meta-llama","mistralai","qwen","moonshotai","z-ai"]'
+
+# models.dev keeps the FULL history of each provider, including retired model ids
+# the provider's API now rejects. We can't read "retired" from the data, so we
+# drop ids whose last_updated/release_date is older than a per-vendor cutoff.
+#
+# Cutoffs below were derived by cross-checking models.dev against each provider's
+# LIVE /models API on 2026-06-04:
+#   anthropic  — retires aggressively; models.dev still lists the 2024 claude-3
+#                line (incl. claude-3-7-sonnet, 2025-02) that the API rejects.
+#                2025-04-01 drops those and keeps the claude-4.x line + aliases.
+#   openai/gemini/openrouter — ZERO stale ids found (these providers keep listed
+#                models valid, and openrouter prunes its own), so NO cutoff: a
+#                cutoff would only delete still-valid models (e.g. gemini-2.0-flash,
+#                gpt-4o). Keys are by zerostack provider name; "0000-00-00" = keep all.
+# This is a heuristic snapshot — the authoritative list is always the provider's
+# live API, reachable via `/models refresh`. Re-tune when a vendor retires a line.
+CUTOFFS='{"anthropic":"2025-04-01"}'
+
+echo "Fetching $SRC ... (cutoffs: $CUTOFFS)" >&2
+api="$(curl -fsSL --max-time 120 "$SRC")"
+
+# jq program:
+#  - `entry`  : project a models.dev model into our compact {id,name,context}.
+#  - `denied` : drop non-chat models (embeddings/audio/image/etc.) by id substring,
+#               mirroring crate::provider::is_agent_model's denylist, and keep only
+#               models that can output text.
+#  - emits keys by *zerostack* provider name (gemini <- models.dev "google").
+echo "$api" | jq --argjson orv "$OPENROUTER_VENDORS" --argjson cut "$CUTOFFS" '
+  def deny: [
+    "embedding","embed-","text-embedding","gemini-embedding","whisper","transcribe",
+    "tts","-audio","realtime","speech","dall-e","gpt-image","image-generation",
+    "imagen","sora","veo","moderation","rerank","aqa","davinci-002","babbage-002",
+    "stable-diffusion","flux"
+  ];
+  # ISO date strings compare correctly lexicographically; $c is the vendor cutoff.
+  def recent($c): select((.value.last_updated // .value.release_date // "0000") >= $c);
+  def chat($c):
+    select(.value.modalities.output | index("text"))
+    | select((.key | ascii_downcase) as $id | (deny | any(. as $d | $id | contains($d))) | not)
+    | recent($c);
+  def entry: {id: .value.id, name: .value.name, context: (.value.limit.context // null)};
+  def models_of($p; $c): ($p.models // {}) | to_entries | map(chat($c) | entry) | sort_by(.id);
+  {
+    anthropic:  models_of(.anthropic; ($cut.anthropic  // "0000-00-00")),
+    openai:     models_of(.openai;    ($cut.openai     // "0000-00-00")),
+    gemini:     models_of(.google;    ($cut.gemini     // "0000-00-00")),
+    openrouter: (
+      (.openrouter.models // {})
+      | to_entries
+      | map(chat($cut.openrouter // "0000-00-00")
+            | select((.key | split("/")[0]) as $v | $orv | index($v)) | entry)
+      | sort_by(.id)
+    )
+  }
+' > "$OUT"
+
+echo "Wrote $OUT" >&2
+jq -r 'to_entries[] | "  \(.key): \(.value | length) models"' "$OUT" >&2

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod docs;
 mod event;
 mod extras;
 mod fs;
+mod models_catalog;
 mod permission;
 mod pricing;
 mod provider;

--- a/src/models_catalog.rs
+++ b/src/models_catalog.rs
@@ -1,0 +1,91 @@
+//! Static, embedded model catalog.
+//!
+//! Model ids change rarely between releases, so instead of hitting each
+//! provider's `/models` endpoint at startup (slow — OpenRouter alone returns
+//! hundreds of entries and used to block the first frame), we bake a snapshot
+//! into the binary. The picker is seeded from this synchronously, with zero
+//! network. The live listing is still available on demand via `/models refresh`
+//! (see [`crate::ui::slash`]) and for providers not baked here (custom gateways,
+//! ollama).
+//!
+//! The data lives in `data/models.json`, keyed by *zerostack* provider name
+//! (so `gemini`, not models.dev's `google`). Refresh it with
+//! `scripts/gen-models-catalog.sh`.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use crate::provider::ModelEntry;
+
+const CATALOG_JSON: &str = include_str!("../data/models.json");
+
+#[derive(serde::Deserialize)]
+struct RawModel {
+    id: String,
+    name: String,
+    context: Option<u32>,
+}
+
+static CATALOG: LazyLock<HashMap<String, Vec<ModelEntry>>> = LazyLock::new(|| {
+    let raw: HashMap<String, Vec<RawModel>> = serde_json::from_str(CATALOG_JSON)
+        .expect("embedded data/models.json is malformed — run scripts/gen-models-catalog.sh");
+    raw.into_iter()
+        .map(|(provider, models)| {
+            let entries = models
+                .into_iter()
+                .map(|m| ModelEntry {
+                    id: m.id,
+                    display: m.name,
+                    context_length: m.context,
+                    kind: None,
+                })
+                .collect();
+            (provider, entries)
+        })
+        .collect()
+});
+
+/// Baked model entries for a provider, or `None` when the provider is not in the
+/// catalog (custom gateways, ollama — those resolve live).
+pub fn catalog_entries(provider: &str) -> Option<Vec<ModelEntry>> {
+    CATALOG.get(provider).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(provider: &str) -> Vec<String> {
+        catalog_entries(provider)
+            .unwrap_or_default()
+            .iter()
+            .map(|m| m.id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn catalog_parses_and_has_expected_providers() {
+        for p in ["anthropic", "openai", "gemini", "openrouter"] {
+            assert!(
+                !ids(p).is_empty(),
+                "missing or empty baked catalog for: {p}"
+            );
+        }
+    }
+
+    #[test]
+    fn openrouter_includes_default_model() {
+        // The default model (deepseek-v4-pro on openrouter) must be discoverable
+        // offline so the picker is useful on a fresh, network-blocked start.
+        assert!(
+            ids("openrouter").contains(&"deepseek/deepseek-v4-pro".to_string()),
+            "default model missing from baked openrouter catalog"
+        );
+    }
+
+    #[test]
+    fn unbaked_provider_has_no_catalog() {
+        // ollama resolves live (local), so it is intentionally not baked.
+        assert!(catalog_entries("ollama").is_none());
+    }
+}

--- a/src/ui/pickers/models.rs
+++ b/src/ui/pickers/models.rs
@@ -170,7 +170,7 @@ impl ModelsPicker {
             )?;
             write!(
                 stdout,
-                "{}  {}   (Tab to switch)",
+                "{}  {}   (Tab to switch · /models refresh for the latest)",
                 tab("Quick", self.quick.len(), self.group == 0),
                 tab("Provider", self.provider.len(), self.group == 1)
             )?;

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -23,6 +23,11 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
 static MODEL_CACHE: LazyLock<Mutex<HashMap<String, Vec<ModelEntry>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Returns the provider's models.
+///
+/// Network is only touched on `refresh`, for custom gateways, or for built-in
+/// providers that aren't baked (e.g. ollama). Baked built-ins are served from
+/// the embedded catalog with no network call — this is what keeps startup instant.
 pub(crate) async fn fetch_models_cached(
     provider: &str,
     is_custom: bool,
@@ -33,7 +38,18 @@ pub(crate) async fn fetch_models_cached(
 ) -> anyhow::Result<Vec<ModelEntry>> {
     if !refresh {
         if let Some(hit) = MODEL_CACHE.lock().unwrap().get(provider).cloned() {
-            return Ok(hit); // guard dropped here, NOT across the await below
+            return Ok(hit); // guard dropped here, NOT across any await
+        }
+        // No cache yet: serve the baked catalog for built-in providers — no network.
+        if !is_custom
+            && let Some(mut models) = crate::models_catalog::catalog_entries(provider)
+        {
+            models.retain(crate::provider::is_agent_model);
+            MODEL_CACHE
+                .lock()
+                .unwrap()
+                .insert(provider.to_string(), models.clone());
+            return Ok(models);
         }
     }
     let mut models = if is_custom {
@@ -204,65 +220,81 @@ async fn handle_models(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
     }
 
     // ---- list mode (+ optional refresh) ----
-    let mut sorted: Vec<&String> = qm.keys().collect();
-    sorted.sort();
-    write_ok(
-        ctx.renderer,
-        format!(
-            "quick models (current: {} | {}):",
-            ctx.session.provider, ctx.session.model
-        ),
-    );
-    if sorted.is_empty() {
-        write_result(ctx.renderer, "  (none — add with /models-add)");
-    }
-    for name in &sorted {
-        let q = &qm[name.as_str()];
-        write_result(
-            ctx.renderer,
-            format!(
-                "  {}  ({} / {})  ${:.4}/M in  ${:.4}/M out",
-                name, q.provider, q.model, q.input_token_cost, q.output_token_cost
-            ),
-        );
-    }
-
     match fetch_models_cached(&provider, is_custom, ctx.client, ctx.cli, ctx.cfg, refresh).await {
-        Ok(models) if !models.is_empty() => {
-            write_ok(
-                ctx.renderer,
-                format!("available from {} ({}):", provider, models.len()),
-            );
-            const CAP: usize = 50;
-            for m in models.iter().take(CAP) {
-                let ctx_win = m
-                    .context_length
-                    .map(|c| format!("  [{}k ctx]", c / 1000))
-                    .unwrap_or_default();
-                let label = if m.display == m.id {
-                    m.id.clone()
-                } else {
-                    format!("{} ({})", m.display, m.id)
-                };
-                write_result(ctx.renderer, format!("  {}{}", label, ctx_win));
-            }
-            if models.len() > CAP {
+        Ok(models) => {
+            ctx.input.set_live_model_names(cached_model_ids(&provider));
+            if refresh {
+                // Explicit refresh: just confirm with a count overview — the picker
+                // already holds the full list, so don't dump it to the scrollback.
+                // Dim (DarkGrey), matching the "loaded AGENTS.md" startup notices.
                 write_result(
                     ctx.renderer,
                     format!(
-                        "  … {} more — type /models <filter> or use the picker",
-                        models.len() - CAP
+                        "model list refreshed — quick models: {}, {} models: {}",
+                        qm.len(),
+                        provider,
+                        models.len()
                     ),
                 );
+            } else {
+                // Full listing: quick models, then the provider's available models.
+                let mut sorted: Vec<&String> = qm.keys().collect();
+                sorted.sort();
+                write_ok(
+                    ctx.renderer,
+                    format!(
+                        "quick models (current: {} | {}):",
+                        ctx.session.provider, ctx.session.model
+                    ),
+                );
+                if sorted.is_empty() {
+                    write_result(ctx.renderer, "  (none — add with /models-add)");
+                }
+                for name in &sorted {
+                    let q = &qm[name.as_str()];
+                    write_result(
+                        ctx.renderer,
+                        format!(
+                            "  {}  ({} / {})  ${:.4}/M in  ${:.4}/M out",
+                            name, q.provider, q.model, q.input_token_cost, q.output_token_cost
+                        ),
+                    );
+                }
+                if !models.is_empty() {
+                    write_ok(
+                        ctx.renderer,
+                        format!("available from {} ({}):", provider, models.len()),
+                    );
+                    const CAP: usize = 50;
+                    for m in models.iter().take(CAP) {
+                        let ctx_win = m
+                            .context_length
+                            .map(|c| format!("  [{}k ctx]", c / 1000))
+                            .unwrap_or_default();
+                        let label = if m.display == m.id {
+                            m.id.clone()
+                        } else {
+                            format!("{} ({})", m.display, m.id)
+                        };
+                        write_result(ctx.renderer, format!("  {}{}", label, ctx_win));
+                    }
+                    if models.len() > CAP {
+                        write_result(
+                            ctx.renderer,
+                            format!(
+                                "  … {} more — type /models <filter> or use the picker",
+                                models.len() - CAP
+                            ),
+                        );
+                    }
+                }
             }
-            ctx.input.set_live_model_names(cached_model_ids(&provider));
-        }
-        Ok(_) => {
-            ctx.input.set_live_model_names(cached_model_ids(&provider));
         }
         Err(e) => {
             tracing::debug!("model listing failed for {}: {}", provider, e);
-            if is_custom {
+            if refresh {
+                write_error(ctx.renderer, format!("model list refresh failed: {}", e));
+            } else if is_custom {
                 write_result(
                     ctx.renderer,
                     "  (live model list unavailable; type the model id directly)",


### PR DESCRIPTION
## Problem

The live model listing feature made startup fetch the active provider's `/models` over the network before the event loop ran. For the default OpenRouter provider this is a large request, and because it was awaited on the startup path it both blocked the first frame and left the model picker empty until a later prompt or slash command re-ran the warm step (the behavior noted in `5600b569`).

## Fix

Bake a static model catalog into the binary and seed the picker from it synchronously, with zero network. The authoritative live list is still available on demand via `/models refresh`, and providers that are not baked (custom gateways, ollama) still resolve live.

### Startup model list acquisition, OpenRouter (default provider)

macOS, 10 samples. Before = live `/models` fetch at startup; after = embedded catalog parsed at startup (release build).

| | Before (live `/models`) | After (embedded catalog) |
|---|---|---|
| Network at startup | yes (HTTP GET) | none |
| Payload | ~410 KB over the wire | 32 KB embedded in binary |
| Time (median of 10) | 441 ms (min 364 / max 512 / mean 438) | 0.076 ms (76 us) |
| Blocking startup | yes (unbounded on slow or offline links) | no |
| Picker populated on first frame | no (only after a later prompt) | yes |
| OpenRouter models listed | 344 (full live) | 220 (curated, full list via `/models refresh`) |

About 440 ms to under 0.1 ms (~5,800x), with zero network on the startup path.

## How the catalog stays accurate

`data/models.json` is derived from [models.dev](https://models.dev) and keyed by zerostack provider name. models.dev keeps the full history of each provider including retired ids, so a per vendor recency cutoff is applied. Cross checking each provider against its live `/models` API showed that only Anthropic retires aggressively:

| vendor | stale ids in models.dev | cutoff |
|---|---|---|
| anthropic | the 2024 claude 3 line (incl. `claude-3-7-sonnet`) | `2025-04-01` |
| gemini | none (a cutoff would drop live `gemini-2.0-flash`) | none |
| openai | none observed (keeps `gpt-4o` etc. valid) | none |
| openrouter | none of the curated set | none |

The baked list is a best effort starting point. Users always reach the exact current list with `/models refresh`.

## Mechanics

* `src/models_catalog.rs` embeds `data/models.json` via `include_str!` and exposes `catalog_entries()`. The build runs no script and no network.
* `scripts/gen-models-catalog.sh` regenerates the snapshot from models.dev (curl plus jq), with the per vendor cutoffs documented inline.
* `.github/workflows/update-models.yml` refreshes the snapshot weekly and opens a PR when it changes, so keys are never required and builds stay reproducible.
* `/models refresh` now prints a one line count summary instead of dumping the full list, and the model picker header shows a hint to refresh for the latest.

## Testing

* `cargo test` (254 passing, including catalog parse and default model presence).
* `cargo clippy` clean on the touched files.
* Verified cold start in a real terminal: picker populated on the first frame with zero network, and `/models refresh` replaces it with the full live list.
