### PR TITLE
Send tracing output to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ fn build_permission_checker(
 #[cfg_attr(not(feature = "multithread"), tokio::main(flavor = "current_thread"))]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,rig=off")),


### PR DESCRIPTION
Closes #89.

One-line change in `src/main.rs`: add `.with_writer(std::io::stderr)` to the `tracing_subscriber::fmt()` builder so `RUST_LOG=... zerostack 2>file` captures logs as expected during interactive TUI sessions.

`tracing_subscriber::fmt::Subscriber` defaults to `io::stdout`, which crossterm also writes to for the TUI. The two streams overlap (logs flash briefly before being redrawn over) and the conventional `2>file` redirect captures nothing because no output is going through stderr. Pointing tracing at stderr explicitly fixes both. Headless `-p` mode is unaffected.

Tested locally: with the change, `RUST_LOG=rig=debug zerostack 2>/tmp/zs.err` produces a populated `zs.err` containing the expected rig events; without it, the file is empty.