### PR TITLE
Disable reqwest connection pooling

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -523,7 +523,15 @@ pub(crate) fn build_http_client(
     danger_accept_invalid_certs: bool,
     custom: Option<&CustomProviderConfig>,
 ) -> anyhow::Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder();
+    // Disable connection pooling. Local LLM servers (notably llama.cpp's
+    // cpp-httplib) close idle keep-alive connections far faster than
+    // reqwest's default 90s pool_idle_timeout, leaving stale half-closed
+    // sockets in the pool. Reusing one of those manifests as
+    // "error sending request" with no corresponding entry server-side
+    // because no request actually reaches the server. TCP setup time is
+    // negligible compared to inference time, so fresh connections per
+    // request are a strict win for this workload.
+    let mut builder = reqwest::Client::builder().pool_max_idle_per_host(0);
 
     if let Some(cfg) = custom {
         if !cfg.headers.is_empty() {


### PR DESCRIPTION
Closes #91.

The diagnosis: cpp-httplib (which llama.cpp uses) has a short keepalive timeout — typically a handful of seconds. reqwest's connection pool defaults to a 90s `pool_idle_timeout`. When zerostack has a quiet stretch (user typing, summarizer running, subagent dispatch), pooled connections sit idle past llama.cpp's threshold and the server quietly half-closes them from its side. reqwest doesn't notice until the next request tries to write to one of those sockets — at which point it reports "error sending request" and llama.cpp's log shows nothing, because nothing actually arrived.

Fix is one line in `build_http_client`: `.pool_max_idle_per_host(0)`. Every API call gets a fresh TCP connection, the stale-socket window disappears, problem stops.

The tradeoff is a TCP handshake per request — sub-millisecond on localhost, low single-digit milliseconds against a hosted provider. Against typical LLM inference times (hundreds of ms to many seconds), it's noise. Worth it for the failure mode to go away.

Tested locally: previously could reproduce the failure within ~30 minutes of sustained use. With the change, I've run multi-hour sessions without seeing it again.