### PR TITLE
Convert compaction summary to Assistant role for strict chat templates

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -98,9 +98,20 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
     let extra = if summary.is_some() { 1 } else { 0 };
     let mut messages = Vec::with_capacity(remaining + extra);
 
+    // The compaction summary is emitted as an Assistant message rather
+    // than a System message: the agent already has a System preamble
+    // (SYSTEM_PROMPT + mode prompt + context files), and some model chat
+    // templates (notably Qwen 3.x) refuse any System message past
+    // position 0. Assistant role also produces clean User↔Assistant
+    // alternation when the next user prompt arrives, which reads as
+    // "the agent recaps what it did, then the user continues" — a
+    // natural resumed-conversation shape. The "[Recap of my prior work
+    // in this conversation]" prefix labels the message as a self-recap
+    // so the agent doesn't treat it as a fresh continuation of its own
+    // voice.
     if let Some(summary) = summary {
-        messages.push(Message::system(format!(
-            "[Previous conversation summary]\n{}",
+        messages.push(Message::assistant(format!(
+            "[Recap of my prior work in this conversation]\n{}",
             summary
         )));
     }
@@ -109,7 +120,12 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
         match msg.role {
             MessageRole::User => messages.push(Message::user(msg.content.to_string())),
             MessageRole::Assistant => messages.push(Message::assistant(msg.content.to_string())),
-            MessageRole::System => messages.push(Message::system(msg.content.to_string())),
+            // Convert any persisted System messages to Assistant for the
+            // same reason as the summary above: the templates that reject
+            // mid-stream System tolerate Assistant, and code-symmetry with
+            // the summary push keeps the resumed-conversation shape
+            // consistent.
+            MessageRole::System => messages.push(Message::assistant(msg.content.to_string())),
         }
     }
 


### PR DESCRIPTION
Closes #93.

Quick diagnosis: in `convert_history` (`src/agent/runner.rs`), the compaction summary was being pushed as `Message::system`. Since the agent preamble is already a System message, requests ended up with two System messages stacked at positions 0 and 1. Qwen 3.x's chat template raises on the second one.

Fix: emit the summary as `Message::assistant`, framed with a `[Recap of my prior work in this conversation]` prefix so the agent reads the content as a self-recap rather than as a fresh turn it's about to continue word-for-word. Assistant role has two advantages over the obvious alternative of User:

- It produces clean User↔Assistant alternation when the next user prompt arrives, matching the standard resumed-conversation shape every chat template expects.
- It reads naturally as "the agent recaps what it did, then the user continues," which is closer to the actual semantic of compaction.

Any persisted `MessageRole::System` entries elsewhere in `session.messages` (a defense-in-depth case — `add_message` doesn't currently produce them, but old sessions or future code paths might) get the same Assistant treatment for code-symmetry with the summary push.

Zerostack's actual system prompt still goes through the rig preamble, which is correctly at position 0. So a typical request now looks like `[System(preamble), Assistant(summary), ...kept, User(latest)]` — one System at position 0, exactly what Qwen's template expects, and clean alternation through the rest.

Tested locally against Qwen 3.6 35B-A3B: `/compact` succeeds and the conversation continues. Without the change, the Jinja exception in #93 reproduces every time.

I'd expect this to also help other strict-template models with the "System at position 0 only" convention — Mistral and some Llama 3.x variants come to mind — but I haven't verified those.