### PR TITLE
Configurable per-tool output limits with optional local-limits-config sidecar

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -130,11 +130,17 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         builder.build()
     } else {
         let max_text_file_size = cfg.max_text_file_size;
+        let max_read_lines = cfg.resolve_max_read_lines();
+        let max_bash_output_lines = cfg.resolve_max_bash_output_lines();
+        let max_grep_results = cfg.resolve_max_grep_results();
+        let max_find_results = cfg.resolve_max_find_results();
+        let max_list_dir_entries = cfg.resolve_max_list_dir_entries();
         let base_tools: SmallVec<[Box<dyn rig::tool::ToolDyn>; 8]> = SmallVec::from_buf([
             Box::new(tools::ReadTool::new(
                 permission.clone(),
                 ask_tx.clone(),
                 max_text_file_size,
+                max_read_lines,
             )),
             Box::new(tools::WriteTool::new(
                 permission.clone(),
@@ -146,13 +152,23 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 permission.clone(),
                 ask_tx.clone(),
                 sandbox.clone(),
+                max_bash_output_lines,
             )),
-            Box::new(tools::GrepTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(tools::GrepTool::new(
+                permission.clone(),
+                ask_tx.clone(),
+                max_grep_results,
+            )),
             Box::new(tools::FindFilesTool::new(
                 permission.clone(),
                 ask_tx.clone(),
+                max_find_results,
             )),
-            Box::new(tools::ListDirTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(tools::ListDirTool::new(
+                permission.clone(),
+                ask_tx.clone(),
+                max_list_dir_entries,
+            )),
             Box::new(tools::WriteTodoList::new(
                 permission.clone(),
                 ask_tx.clone(),
@@ -302,18 +318,32 @@ pub fn build_btw_agent_inner<M: CompletionModel + 'static>(
     // effects to roll back and never mutates the session. Allow multiple turns
     // so it can read then answer.
     let max_text_file_size = cfg.max_text_file_size;
+    let max_read_lines = cfg.resolve_max_read_lines();
+    let max_grep_results = cfg.resolve_max_grep_results();
+    let max_find_results = cfg.resolve_max_find_results();
+    let max_list_dir_entries = cfg.resolve_max_list_dir_entries();
     let read_tools: Vec<Box<dyn rig::tool::ToolDyn>> = vec![
         Box::new(tools::ReadTool::new(
             permission.clone(),
             ask_tx.clone(),
             max_text_file_size,
+            max_read_lines,
         )),
-        Box::new(tools::GrepTool::new(permission.clone(), ask_tx.clone())),
+        Box::new(tools::GrepTool::new(
+            permission.clone(),
+            ask_tx.clone(),
+            max_grep_results,
+        )),
         Box::new(tools::FindFilesTool::new(
             permission.clone(),
             ask_tx.clone(),
+            max_find_results,
         )),
-        Box::new(tools::ListDirTool::new(permission.clone(), ask_tx.clone())),
+        Box::new(tools::ListDirTool::new(
+            permission.clone(),
+            ask_tx.clone(),
+            max_list_dir_entries,
+        )),
     ];
 
     let mut builder = AgentBuilder::new(model)

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -3,6 +3,7 @@ use rig::tool::Tool;
 use tokio::time::{Duration, timeout};
 
 use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm};
+use crate::extras::truncate::head_lines;
 use crate::sandbox::Sandbox;
 
 fn split_bash_commands(input: &str) -> Vec<String> {
@@ -80,14 +81,23 @@ pub struct BashTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub sandbox: Sandbox,
+    /// `None` = no truncation (matches the historical behaviour). `Some(n)`
+    /// = head-only truncation after `n` lines with a recovery hint.
+    pub max_output_lines: Option<u64>,
 }
 
 impl BashTool {
-    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>, sandbox: Sandbox) -> Self {
+    pub fn new(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        sandbox: Sandbox,
+        max_output_lines: Option<u64>,
+    ) -> Self {
         BashTool {
             permission,
             ask_tx,
             sandbox,
+            max_output_lines,
         }
     }
 }
@@ -150,9 +160,28 @@ impl Tool for BashTool {
         if exit_code != 0 {
             result.push_str(&format!("\nExit code: {}", exit_code));
         }
-        if let Some(msg) = coaching {
-            result = format!("{}\n\n{}", msg, result);
-        }
+
+        let result = if let Some(cap) = self.max_output_lines {
+            let cap = cap as usize;
+            let (head, total) = head_lines(&result, cap);
+            if total > cap {
+                format!(
+                    "{}\n\n[truncated after {} lines — {} more lines elided; re-run with a narrower invocation or pipe through `tail`/`grep` to see trailing output]",
+                    head,
+                    cap,
+                    total - cap,
+                )
+            } else {
+                result
+            }
+        } else {
+            result
+        };
+
+        let result = match coaching {
+            Some(msg) => format!("{}\n\n{}", msg, result),
+            None => result,
+        };
         Ok(result)
     }
 }

--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -4,17 +4,26 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use crate::agent::tools::{
-    AskSender, FindFilesArgs, MAX_FIND_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
+    AskSender, FindFilesArgs, PermCheck, ToolError, check_perm, is_skip_dir,
 };
 
 pub struct FindFilesTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub max_results: u64,
 }
 
 impl FindFilesTool {
-    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        FindFilesTool { permission, ask_tx }
+    pub fn new(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        max_results: u64,
+    ) -> Self {
+        FindFilesTool {
+            permission,
+            ask_tx,
+            max_results,
+        }
     }
 }
 
@@ -79,7 +88,7 @@ impl Tool for FindFilesTool {
             let fname = entry.file_name().to_string_lossy();
             if re.is_match(&fname) {
                 results.push(entry.path().to_string_lossy().to_string());
-                if results.len() >= MAX_FIND_RESULTS {
+                if (results.len() as u64) >= self.max_results {
                     break;
                 }
             }
@@ -96,13 +105,15 @@ impl Tool for FindFilesTool {
         results.sort();
 
         let total = results.len();
-        let result = if total >= MAX_FIND_RESULTS {
+        let max_results = self.max_results as usize;
+        let result = if total >= max_results {
             format!(
-                "{} files found (showing first {}):\n{}\n\n... and {} more",
+                "{} files found (showing first {}):\n{}\n\n[truncated after {} entries — {} more; narrow the pattern or path]",
                 total,
-                MAX_FIND_RESULTS,
-                results[..MAX_FIND_RESULTS].join("\n"),
-                total - MAX_FIND_RESULTS
+                max_results,
+                results[..max_results].join("\n"),
+                max_results,
+                total - max_results
             )
         } else {
             format!("{} files found:\n{}", total, results.join("\n"))

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -4,17 +4,26 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use crate::agent::tools::{
-    AskSender, GrepArgs, MAX_GREP_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
+    AskSender, GrepArgs, PermCheck, ToolError, check_perm, is_skip_dir,
 };
 
 pub struct GrepTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub max_results: u64,
 }
 
 impl GrepTool {
-    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        GrepTool { permission, ask_tx }
+    pub fn new(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        max_results: u64,
+    ) -> Self {
+        GrepTool {
+            permission,
+            ask_tx,
+            max_results,
+        }
     }
 
     fn glob_to_regex(glob: &str) -> String {
@@ -103,15 +112,16 @@ impl Tool for GrepTool {
             })
             .build();
 
+        let max_results = self.max_results as usize;
         let mut file_count = 0;
         let mut files_with_matches: usize = 0;
-        let mut all_results: Vec<String> = Vec::with_capacity(MAX_GREP_RESULTS.min(64));
+        let mut all_results: Vec<String> = Vec::with_capacity(max_results.min(64));
 
         for entry in walker
             .flatten()
             .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
         {
-            if all_results.len() >= MAX_GREP_RESULTS {
+            if all_results.len() >= max_results {
                 break;
             }
 
@@ -155,7 +165,7 @@ impl Tool for GrepTool {
                     if context == 0 {
                         for &ml in &match_lines {
                             all_results.push(format!("{}:{}:{}", path_str, ml + 1, lines[ml]));
-                            if all_results.len() >= MAX_GREP_RESULTS {
+                            if all_results.len() >= max_results {
                                 break;
                             }
                         }
@@ -170,7 +180,7 @@ impl Tool for GrepTool {
                         }
 
                         let mut i = 0;
-                        while i < total && all_results.len() < MAX_GREP_RESULTS {
+                        while i < total && all_results.len() < max_results {
                             if !shown[i] {
                                 i += 1;
                                 continue;
@@ -180,7 +190,7 @@ impl Tool for GrepTool {
                                 all_results.push("--".to_string());
                             }
 
-                            while i < total && shown[i] && all_results.len() < MAX_GREP_RESULTS {
+                            while i < total && shown[i] && all_results.len() < max_results {
                                 let is_match = match_lines.binary_search(&i).is_ok();
                                 let sep = if is_match { ':' } else { '-' };
                                 all_results.push(format!(
@@ -208,15 +218,16 @@ impl Tool for GrepTool {
         }
 
         let total = all_results.len();
-        let truncated = total >= MAX_GREP_RESULTS;
+        let truncated = total >= max_results;
         let result = if truncated {
             format!(
-                "{} results (showing first {}, searched {} files):\n{}\n\n... and {} more matches",
+                "{} results (showing first {}, searched {} files):\n{}\n\n[truncated after {} matches — {} more matches; narrow the pattern or restrict to a path]",
                 total,
-                MAX_GREP_RESULTS,
+                max_results,
                 file_count,
                 all_results.join("\n"),
-                total - MAX_GREP_RESULTS
+                max_results,
+                total - max_results
             )
         } else {
             format!(

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -32,11 +32,22 @@ fn count_dir_entries(path: &Path) -> u64 {
 pub struct ListDirTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    /// `None` = no truncation (matches the historical behaviour).
+    /// `Some(n)` = show the first `n` entries with a recovery hint.
+    pub max_entries: Option<u64>,
 }
 
 impl ListDirTool {
-    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        ListDirTool { permission, ask_tx }
+    pub fn new(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        max_entries: Option<u64>,
+    ) -> Self {
+        ListDirTool {
+            permission,
+            ask_tx,
+            max_entries,
+        }
     }
 }
 
@@ -139,9 +150,16 @@ impl Tool for ListDirTool {
             });
         }
 
-        let max_name = entries.iter().map(|e| e.0.len()).max().unwrap_or(0);
+        let total_entries = entries.len();
+        let cap = self.max_entries.map(|c| c as usize);
+        let shown = cap.map(|c| total_entries.min(c)).unwrap_or(total_entries);
+        let max_name = entries[..shown]
+            .iter()
+            .map(|e| e.0.len())
+            .max()
+            .unwrap_or(0);
         let mut result = format!("Listing {}:\n", path);
-        for (name, kind, size) in &entries {
+        for (name, kind, size) in &entries[..shown] {
             let padded = format!("{:width$}", name, width = max_name);
             let size_str = if size.is_empty() {
                 String::new()
@@ -149,6 +167,15 @@ impl Tool for ListDirTool {
                 format!("  {}", size)
             };
             result.push_str(&format!("  [{}]  {}{}\n", kind, padded, size_str));
+        }
+        if let Some(cap) = cap
+            && total_entries > cap
+        {
+            result.push_str(&format!(
+                "\n[truncated after {} entries — {} more; list a subdirectory or use find_files with a narrower pattern]",
+                cap,
+                total_entries - cap,
+            ));
         }
         if let Some(msg) = coaching {
             result = format!("{}\n\n{}", msg, result);

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -82,9 +82,6 @@ use serde::Deserialize;
 use crate::permission::ask::{AskRequest, AskSender, UserDecision};
 use crate::permission::checker::{CheckResult, PermCheck};
 
-pub const MAX_GREP_RESULTS: usize = 200;
-pub const MAX_FIND_RESULTS: usize = 200;
-
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
     #[error("{0}")]

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -13,6 +13,7 @@ pub struct ReadTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub max_text_file_size: u64,
+    pub max_lines: u64,
 }
 
 impl ReadTool {
@@ -20,11 +21,13 @@ impl ReadTool {
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
         max_text_file_size: Option<u64>,
+        max_lines: u64,
     ) -> Self {
         ReadTool {
             permission,
             ask_tx,
             max_text_file_size: max_text_file_size.unwrap_or(DEFAULT_MAX_TEXT_SIZE),
+            max_lines,
         }
     }
 }
@@ -39,7 +42,7 @@ impl Tool for ReadTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         let (desc, params) = match edit_system() {
             EditSystem::Similarity => (
-                "Read the contents of a file. Supports text files. Defaults to first 2000 lines. Use offset/limit for large files.".to_string(),
+                format!("Read the contents of a file. Supports text files. Defaults to first {} lines. Use offset/limit for large files.", self.max_lines),
                 serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -51,7 +54,7 @@ impl Tool for ReadTool {
                 }),
             ),
             EditSystem::Hashedit => (
-                "Read file contents with CRC-32 tagged lines for tag-based editing. Each line is prefixed with 'N|TAG' where TAG is an 8-char hex CRC-32 of the line content. Use these tags with the edit tool for CAS-guarded edits. Defaults to first 2000 lines.".to_string(),
+                format!("Read file contents with CRC-32 tagged lines for tag-based editing. Each line is prefixed with 'N|TAG' where TAG is an 8-char hex CRC-32 of the line content. Use these tags with the edit tool for CAS-guarded edits. Defaults to first {} lines.", self.max_lines),
                 serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -76,7 +79,7 @@ impl Tool for ReadTool {
         let coaching = check_perm_path(&self.permission, &self.ask_tx, "read", &path).await?;
 
         let offset = args.offset.unwrap_or(1).saturating_sub(1);
-        let limit = args.limit.unwrap_or(2000);
+        let limit = args.limit.unwrap_or(self.max_lines as usize);
 
         if let Some(msg) = crate::agent::tools::track_read(&path, offset, limit) {
             return Err(ToolError::Msg(msg));
@@ -154,6 +157,20 @@ impl Tool for ReadTool {
                     excerpt
                 )
             }
+        };
+
+        let info = if end < total_lines {
+            let remaining = total_lines - end;
+            format!(
+                "{}\n\n[truncated after {} lines — {} more lines (lines {}-{}); re-call with offset/limit to see more]",
+                info,
+                end - offset,
+                remaining,
+                end + 1,
+                total_lines,
+            )
+        } else {
+            info
         };
 
         let info = match coaching {

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use compact_str::CompactString;
 
-use crate::config::{Config, EditSystem, QuickModelConfig, ShowToolDetails};
+use crate::config::{Config, EditSystem, LocalLimitsConfig, QuickModelConfig, ShowToolDetails};
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::config::McpServerConfig;
 use crate::session::storage;
@@ -48,6 +48,71 @@ fn resolve_config_path() -> PathBuf {
 
 pub fn config_file_path() -> PathBuf {
     resolve_config_path()
+}
+
+/// Path to the optional `local-limits-config.toml` sidecar, in the same
+/// directory as the main config. Returns the candidate path whether or not
+/// the file exists — callers check existence separately.
+pub fn local_limits_config_path() -> PathBuf {
+    resolve_config_path()
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(storage::data_dir)
+        .join("local-limits-config.toml")
+}
+
+/// Load `local-limits-config.toml` if it exists. Returns `None` when the
+/// file is absent (the common case for non-local-LLM users). Parse errors
+/// — including the `deny_unknown_fields` rejection for non-limit keys —
+/// are fatal and printed to stderr before exit, matching the main config's
+/// behaviour.
+pub fn load_local_limits() -> Option<LocalLimitsConfig> {
+    let path = local_limits_config_path();
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        eprintln!(
+            "error: failed to read {} ({}). \
+             Remove or fix the file to continue.",
+            path.display(),
+            e,
+        );
+        std::process::exit(1);
+    });
+    let local: LocalLimitsConfig = toml::from_str(&content).unwrap_or_else(|e| {
+        eprintln!(
+            "error: {} is not a valid local-limits config: {}\n\
+             This file may only contain max_read_lines, max_bash_output_lines, \
+             max_grep_results, max_find_results, and max_list_dir_entries.",
+            path.display(),
+            e,
+        );
+        std::process::exit(1);
+    });
+    Some(local)
+}
+
+/// Apply a loaded `LocalLimitsConfig` on top of the main `Config`,
+/// field-by-field. A `Some(_)` in the local config wins over the main
+/// config's value (whether the main value is `Some` or `None`). A `None`
+/// in the local config leaves the main config's value untouched.
+pub fn merge_local_limits(cfg: &mut Config, local: &LocalLimitsConfig) {
+    if local.max_read_lines.is_some() {
+        cfg.max_read_lines = local.max_read_lines;
+    }
+    if local.max_bash_output_lines.is_some() {
+        cfg.max_bash_output_lines = local.max_bash_output_lines;
+    }
+    if local.max_grep_results.is_some() {
+        cfg.max_grep_results = local.max_grep_results;
+    }
+    if local.max_find_results.is_some() {
+        cfg.max_find_results = local.max_find_results;
+    }
+    if local.max_list_dir_entries.is_some() {
+        cfg.max_list_dir_entries = local.max_list_dir_entries;
+    }
 }
 
 fn default_quick_models() -> HashMap<String, QuickModelConfig> {
@@ -188,6 +253,11 @@ pub fn load() -> Config {
             }),
         }
     };
+
+    // Sidecar limits config wins field-by-field over the main config.
+    if let Some(local) = load_local_limits() {
+        merge_local_limits(&mut cfg, &local);
+    }
 
     #[cfg(feature = "mcp")]
     if cfg.mcp_servers.is_none() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -42,6 +42,22 @@ pub struct Config {
     pub max_agent_turns: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_text_file_size: Option<u64>,
+    // Tool output limits. `None` for `max_bash_output_lines` and
+    // `max_list_dir_entries` means "no truncation" — matches the historical
+    // behaviour. The other three have non-None defaults so existing users
+    // see no change unless they set these explicitly. Local-LLM users can
+    // tighten all five via a separate `local-limits-config.toml`; see the
+    // loader.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_read_lines: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_bash_output_lines: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_grep_results: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_find_results: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_list_dir_entries: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compact_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -147,6 +163,30 @@ impl Config {
 
     pub fn resolve_compact_enabled(&self) -> bool {
         self.compact_enabled.unwrap_or(true)
+    }
+
+    pub fn resolve_max_read_lines(&self) -> u64 {
+        self.max_read_lines.unwrap_or(2000)
+    }
+
+    /// Returns `None` when no cap is configured — preserves the historical
+    /// "no bash output truncation" behaviour.
+    pub fn resolve_max_bash_output_lines(&self) -> Option<u64> {
+        self.max_bash_output_lines
+    }
+
+    pub fn resolve_max_grep_results(&self) -> u64 {
+        self.max_grep_results.unwrap_or(200)
+    }
+
+    pub fn resolve_max_find_results(&self) -> u64 {
+        self.max_find_results.unwrap_or(200)
+    }
+
+    /// Returns `None` when no cap is configured — preserves the historical
+    /// "no list_dir truncation" behaviour.
+    pub fn resolve_max_list_dir_entries(&self) -> Option<u64> {
+        self.max_list_dir_entries
     }
 
     pub fn resolve_always_show_welcome(&self) -> bool {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -3,6 +3,30 @@ use std::collections::HashMap;
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
+/// A sidecar config file holding only tool output limits. Loaded from
+/// `local-limits-config.toml` next to the main config and merged on top
+/// of it field-by-field. Intended as a convenience for local-LLM users
+/// who run with tight context windows and want to swap in a tighter set
+/// of limits without editing their main config.
+///
+/// `deny_unknown_fields` is intentional: putting anything other than the
+/// five limit fields in this file is a parse error, so the file's purpose
+/// stays machine-checked rather than convention-only.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LocalLimitsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_read_lines: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bash_output_lines: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_grep_results: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_find_results: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_list_dir_entries: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuickModelConfig {
     pub provider: CompactString,

--- a/src/extras/subagents/builder.rs
+++ b/src/extras/subagents/builder.rs
@@ -20,11 +20,22 @@ fn build_explore_agent_inner<M: CompletionModel + 'static>(
         preamble.push_str(arch);
     }
 
+    // Subagents use the same built-in defaults as the main agent's
+    // `resolve_*` methods (2000 lines, 200 results, no list_dir cap) so a
+    // user who hasn't customized config sees identical subagent behaviour.
+    // Plumbing the user's resolved config through to subagents could be a
+    // future change if local-LLM operators want their tight limits to
+    // apply to subagent calls too.
     let tools: Vec<Box<dyn rig::tool::ToolDyn>> = vec![
-        Box::new(tools::ReadTool::new(None, None, Some(max_text_file_size))),
-        Box::new(tools::GrepTool::new(None, None)),
-        Box::new(tools::FindFilesTool::new(None, None)),
-        Box::new(tools::ListDirTool::new(None, None)),
+        Box::new(tools::ReadTool::new(
+            None,
+            None,
+            Some(max_text_file_size),
+            2000,
+        )),
+        Box::new(tools::GrepTool::new(None, None, 200)),
+        Box::new(tools::FindFilesTool::new(None, None, 200)),
+        Box::new(tools::ListDirTool::new(None, None, None)),
         #[cfg(feature = "memory")]
         Box::new(crate::extras::memory::MemoryRead::new(None, None)),
         #[cfg(feature = "memory")]

--- a/src/extras/truncate.rs
+++ b/src/extras/truncate.rs
@@ -13,3 +13,16 @@ pub(crate) fn truncate_cjk(s: &str, max: usize, marker: &str) -> String {
     out.push_str(marker);
     out
 }
+
+/// Keep the first `max` lines of `s`. Returns `(head, total_lines)` where
+/// `total_lines` is the original line count. If `total_lines <= max`, `head`
+/// equals `s` (no truncation needed). Callers should append a tool-specific
+/// recovery hint when truncation occurred.
+pub(crate) fn head_lines(s: &str, max: usize) -> (String, usize) {
+    let total = s.lines().count();
+    if total <= max {
+        return (s.to_string(), total);
+    }
+    let head: String = s.lines().take(max).collect::<Vec<_>>().join("\n");
+    (head, total)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -666,6 +666,43 @@ fn print_config(cli: &cli::Cli, cfg: &config::Config) {
     }
     print_section("Model", &model_entries);
 
+    // Attribution for the per-tool output limits.
+    //
+    // The merged `cfg` carries the resolved value; to print _where_ it came
+    // from we load `local-limits-config.toml` separately and check
+    // field-by-field. If both files set a field, local wins (matches the
+    // loader's merge order), so we check local first.
+    let local_limits = config::load_local_limits();
+    let main_config_path = config::config_file_path();
+    let main_config_label = main_config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("config")
+        .to_string();
+    let attribute = |merged: Option<u64>, local_value: Option<u64>| -> &str {
+        if local_value.is_some() {
+            "local-limits-config.toml"
+        } else if merged.is_some() {
+            // `cfg` already merged; if the merged value is Some but local
+            // didn't set it, it must have come from the main config.
+            &main_config_label
+        } else {
+            "default"
+        }
+    };
+    let fmt_opt = |v: Option<u64>| -> String {
+        match v {
+            Some(n) => n.to_string(),
+            None => "— (no cap)".to_string(),
+        }
+    };
+
+    let read_attr = attribute(cfg.max_read_lines, local_limits.as_ref().and_then(|l| l.max_read_lines));
+    let bash_attr = attribute(cfg.max_bash_output_lines, local_limits.as_ref().and_then(|l| l.max_bash_output_lines));
+    let grep_attr = attribute(cfg.max_grep_results, local_limits.as_ref().and_then(|l| l.max_grep_results));
+    let find_attr = attribute(cfg.max_find_results, local_limits.as_ref().and_then(|l| l.max_find_results));
+    let list_attr = attribute(cfg.max_list_dir_entries, local_limits.as_ref().and_then(|l| l.max_list_dir_entries));
+
     print_section(
         "Limits",
         &[
@@ -673,6 +710,26 @@ fn print_config(cli: &cli::Cli, cfg: &config::Config) {
             ("max-agent-turns", max_agent_turns.to_string()),
             ("context-window", context_window.to_string()),
             ("reserve-tokens", cfg.resolve_reserve_tokens().to_string()),
+            (
+                "max-read-lines",
+                format!("{}  ({})", cfg.resolve_max_read_lines(), read_attr),
+            ),
+            (
+                "max-bash-output-lines",
+                format!("{}  ({})", fmt_opt(cfg.resolve_max_bash_output_lines()), bash_attr),
+            ),
+            (
+                "max-grep-results",
+                format!("{}  ({})", cfg.resolve_max_grep_results(), grep_attr),
+            ),
+            (
+                "max-find-results",
+                format!("{}  ({})", cfg.resolve_max_find_results(), find_attr),
+            ),
+            (
+                "max-list-dir-entries",
+                format!("{}  ({})", fmt_opt(cfg.resolve_max_list_dir_entries()), list_attr),
+            ),
         ],
     );
 


### PR DESCRIPTION
Closes #97.

Five `Option<u64>` fields on the main `Config` struct cover the per-tool output limits. Built-in defaults exactly match current upstream behavior:

- `max_read_lines`: default 2000
- `max_bash_output_lines`: default None (no truncation)
- `max_grep_results`: default 200
- `max_find_results`: default 200
- `max_list_dir_entries`: default None (no truncation)

Users who don't set anything see no behavior change. Big-context model users can leave them alone too. The point of making them configurable at all is local-LLM users with tight context windows who need aggressive caps.

`local-limits-config.toml` sidecar. Optional file in the same directory as the main config. Loaded after the main config; sets any of the five fields field-by-field, local winning. `#[serde(deny_unknown_fields)]` on the `LocalLimitsConfig` struct so anything other than the five limit keys is a parse error. Lets a local-LLM operator keep a separate tight-limits config they can drop in or remove without editing the main config.

Plumbing. Each tool constructor now takes its own limit. The `MAX_GREP_RESULTS` / `MAX_FIND_RESULTS` / `MAX_LIST_DIR_ENTRIES` constants are gone from `src/agent/tools/mod.rs`. `agent/builder.rs` resolves the values from `Config` and passes them at construction. The subagent builder uses the same Config-default values (2000, 200, 200, None) so subagent behavior tracks the main agent's defaults. Plumbing the user's resolved config through to subagents could be a follow-up if local-LLM operators want their tight limits to apply there too.

`--print-config` attribution. The Limits section now shows the five new fields with the source of each value: `(local-limits-config.toml)`, `(config.toml)` or `(config.json)`, or `(default)`. The merged `Config` holds the resolved value; the print path loads `local-limits-config` separately to disambiguate "set by local" from "set by main." Helps a user verify their sidecar is being picked up.

Recovery hints unchanged. When a cap fires, the existing truncation hint at the end of the tool output still tells the agent how to recover. When a cap is None (bash, list_dir defaults), no truncation, no hint. Matches current behavior exactly.

Tested locally against my Qwen 3.6 35B-A3B setup. Five test cases all passed: defaults unchanged with no sidecar present, all five fields pick up from sidecar with correct attribution, `deny_unknown_fields` rejects non-limit keys, partial sidecar falls through to defaults for unset fields, tight cap actually fires (verified by running grep with `max_grep_results = 5` in a Rust project).