### PR TITLE
Encourage task subagent use; remove restrictive prompt wording

### DIFF
--- a/prompts/code.md
+++ b/prompts/code.md
@@ -14,9 +14,15 @@ You are in **coding mode**. Write well-tested code.
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## Conventions
 

--- a/prompts/code.md
+++ b/prompts/code.md
@@ -12,6 +12,12 @@ You are in **coding mode**. Write well-tested code.
 4. **Verify** — run linters, type checker, and full test suite. Fix all failures. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
 5. **Review** — check edge cases, naming consistency, unintended changes.
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## Conventions
 
 - Do not introduce new dependencies without asking.

--- a/prompts/debug.md
+++ b/prompts/debug.md
@@ -36,9 +36,15 @@ NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## Red Flags — STOP and Return to Phase 1
 

--- a/prompts/debug.md
+++ b/prompts/debug.md
@@ -34,6 +34,12 @@ NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
 3. Verify the test passes and run the full suite. If pre-existing failures exist, STOP and notify the user — do not proceed.
 4. If the fix reveals a design flaw, flag it — do not silently refactor.
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## Red Flags — STOP and Return to Phase 1
 
 - "Let me just try changing X and see what happens."

--- a/prompts/default.md
+++ b/prompts/default.md
@@ -21,6 +21,12 @@ Before acting, classify the request:
 4. **Verify** — run linters, type checkers, tests. Fix all failures. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
 5. **Review** — check edge cases, naming consistency, and unrelated changes.
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## Conventions
 
 - Write code that is easy to test and maintain.

--- a/prompts/default.md
+++ b/prompts/default.md
@@ -23,9 +23,15 @@ Before acting, classify the request:
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## Conventions
 

--- a/prompts/refactor.md
+++ b/prompts/refactor.md
@@ -14,6 +14,12 @@ Never change what the code does — only how it is organized. Every refactor mus
 4. **Verify** — run linters, type checkers, and full test suite after all changes. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
 5. **Report** — summarize what was changed and why.
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## Refactoring Categories
 
 - **Rename** — variables, functions, types, modules for clarity. Update all references.

--- a/prompts/refactor.md
+++ b/prompts/refactor.md
@@ -16,9 +16,15 @@ Never change what the code does — only how it is organized. Every refactor mus
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## Refactoring Categories
 

--- a/prompts/review-security.md
+++ b/prompts/review-security.md
@@ -41,9 +41,15 @@ Systematically check each applicable category:
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## Severity
 

--- a/prompts/review-security.md
+++ b/prompts/review-security.md
@@ -39,6 +39,12 @@ Systematically check each applicable category:
 3. **Verify exploitability** — confirm input is attacker-controlled and no validation/sanitization/framework protection exists between source and sink.
 4. **Report HIGH confidence only** — group low-confidence items under "Notes."
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## Severity
 
 - **Critical** — RCE, SQL injection, auth bypass, hardcoded production secrets, arbitrary file write.

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -27,9 +27,15 @@ Summarize findings grouped by priority. Use the output format below.
 
 ## Subagent Dispatch
 
-For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+Delegate to the `task` tool whenever the answer requires synthesizing across multiple search results. This includes:
 
-The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+- **Enumeration:** "list / count / find ALL X across the codebase" — never assemble a count by adding up partial grep results yourself; the subagent verifies completeness.
+- **Cross-reference:** "where is X used", "how does Y work", "what calls Z" — anything touching multiple files.
+- **Investigation:** any question requiring more than one grep/read to answer.
+
+Reserve direct `read` / `grep` / `find_files` for known-location work: editing a specific file, reading one identified function, grepping for a literal you will act on immediately.
+
+**Anti-pattern:** running grep multiple times to find "all" matches and synthesizing a count is unreliable — truncation, overlapping regexes, and partial views all corrupt the answer. Use `task` instead.
 
 ## What to Check
 

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -25,6 +25,12 @@ Classify each issue:
 ### Phase 3: Report
 Summarize findings grouped by priority. Use the output format below.
 
+## Subagent Dispatch
+
+For investigations that cross-reference the codebase — "where is X used", "how does Y work", or anything likely to touch more than ~3 files — use the `task` tool to delegate to a subagent. Reserve direct `read` / `grep` / `find_files` for single-file edits and known-location lookups.
+
+The subagent runs in a fresh context, so wide exploration doesn't grow the main conversation.
+
 ## What to Check
 
 ### Correctness

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -14,7 +14,7 @@ You are an expert coding assistant. Read, write, edit files and run commands. Re
 - When you need multiple files, read them in parallel in one message. A single multi-tool-call message is faster than several sequential ones.
 - Prefer grep and find_files over reading many files one-by-one. Search first, then read only the files that matched.
 - Do NOT re-list the same directory. Do NOT re-search the same pattern. If you need the result again, it's the same.
-- **Subagent use:** The task tool spawns new LLM instances — it is slow and expensive. Use ONLY when answering requires searching 3+ distinct files and cross-referencing their contents (e.g. \"Where is MCP support implemented?\"). Do NOT use for: listing a directory, grepping one pattern, reading one known file, or any single-step operation. Call those tools directly instead. Do NOT use for wide/vague tasks (\"explore the codebase\"). If you already ran a subagent and got results, use those results — do not re-spawn.
+- **Subagent use:** The task tool runs a fresh-context subagent and is the default for cross-file work: find/list/count all X, where is Y used, how does Z work. It returns a verified summary in one call rather than forcing you to synthesize across multiple grep views. Call read/grep/find_files directly for single-file work or known-location lookups. If you already ran a subagent and got results, use those results; do not re-spawn.
 
 ## Tools
 - **read**: Read file contents (offset/limit for large files, max 10MB). Blocked on repeated reads of the same section.
@@ -24,7 +24,7 @@ You are an expert coding assistant. Read, write, edit files and run commands. Re
 - **grep**: Search file contents with regex. Respects .gitignore.
 - **find_files**: Find files by glob pattern.
 - **write_todo_list**: Track multi-step tasks.
-- **task**: Delegate a MULTI-STEP read-only investigation to a subagent. Use ONLY when answering needs several file reads and cross-referencing. NOT for single operations (list_dir, grep, read a known file). Multiple prompts run in parallel. Subagent has read, grep, find_files, list_dir, memory access. Returns findings.
+- **task**: Search and investigate via a fresh-context subagent. Use for any cross-file question (find/list/count all X, where is Y used, how does Z work). Multiple prompts run in parallel. Subagent has read, grep, find_files, list_dir, memory access. Returns a verified summary.
 
 ## Rules
 - Read a file before editing it. Read at least once per conversation first.

--- a/src/extras/subagents/task_tool.rs
+++ b/src/extras/subagents/task_tool.rs
@@ -48,16 +48,16 @@ impl Tool for TaskTool {
     async fn definition(&self, _p: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Delegate a MULTI-STEP read-only investigation to a subagent. \
-Use ONLY when answering a question requires searching several files, cross-referencing, \
-and synthesizing findings (e.g. \"Where is MCP support implemented?\", \
-\"What does the function get_signature do?\"). \
-Do NOT use for single-step operations: listing a directory, grepping for one pattern, \
-reading a known file — just call the tool directly. \
-Do NOT use for wide/vague tasks (e.g. \"check all documentation\", \"explore the codebase\"). \
+            description: "Search and investigate the codebase via a fresh-context subagent. \
+Use for any cross-file question: where is X used, how does Y work, \
+find/list/count all X across the codebase, what calls Z, audit Q. \
+The subagent reads, greps, finds files, lists directories, accesses memory, \
+and returns a verified summary. \
+More reliable than running multiple grep/read calls yourself; the subagent \
+enumerates completely without truncation gaps or synthesis errors across partial views. \
 Multiple prompts run in parallel. \
-The subagent can read, grep, find_files, list directories, and access memory. \
-Returns a summary of findings."
+Skip only for known-location work: reading one identified file, \
+editing in a known location, grepping for a literal you will act on immediately."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -65,7 +65,7 @@ Returns a summary of findings."
                     "prompts": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Investigation prompts requiring multiple tool calls to answer (parallel when multiple). NOT for single-step operations like listing a directory or reading one file."
+                        "description": "Investigation prompt for the subagent. Use one for a focused question, or multiple to run independent investigations in parallel. Examples: 'List all tests in this project', 'Where is config loaded?', 'How does the agent loop work?'"
                     }
                 },
                 "required": ["prompts"]


### PR DESCRIPTION
Closes #101.

Three commits, applied in sequence so the reasoning is visible.

**v1: Add `## Subagent Dispatch` to the six coding-mode prompts.**

`prompts/{code,debug,default,refactor,review,review-security}.md` now name `task` as the right tool for cross-codebase investigations and reserve direct `read`/`grep`/`find_files` for single-file edits and known-location lookups.

**v2: Harden the Subagent Dispatch wording.**

v1 said "anything likely to touch more than ~3 files," which the agent could rationalize away (one grep call IS one tool call, even when it returns 200 matches across many files). Rewrote each Subagent Dispatch section to name the failure mode directly: synthesizing across multiple search results. Added an Anti-pattern paragraph that calls out the grep-and-count mistake.

**v3: Rewrite the `task` tool's own affordance.**

Even with v2 wording the agent kept routing around `task`. Cause: a louder contradiction earlier in context.

- `src/agent/prompt.rs` SYSTEM_PROMPT had `**Subagent use:** ... Use ONLY when ...` under a CRITICAL header.
- `src/extras/subagents/task_tool.rs::definition()` said `Delegate a MULTI-STEP read-only investigation ... NOT for ...`.

CRITICAL-marked restrictive language overrode the mode-prompt positive framing. Rewrote both. `task` is now described as "Search and investigate via a fresh-context subagent. Use for any cross-file question..." with negative ONLY/NOT gating dropped. Kept the legitimately useful "don't re-spawn after you got results" guidance.

The v2 commit was rebased against the current upstream Read Operations section (which evolved nicely since this work was done). The upstream improvements to repeated-read blocking are preserved verbatim; only the `**Subagent use:**` bullet was rewritten.

Result locally: behavior on the test-counting and "find all callers" scenarios changed from "grind through files inline" to "dispatch to `task`."

If you'd rather review v3 (the affordance change) as its own PR, happy to split.