### PR TITLE
Support all 256 ANSI color codes, allow theming all foreground colors, and fix a `/theme default` bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 - **Standard tools**: all of the standard tools exposed to coding agents, as described by the opencode documentation.
 - **Permission system**: five configurable modes with per-tool patterns, session allowlists, and configurable mode-to-rule application policies
 - **Session management**: save/load/resume sessions, auto-compaction to stay within context windows
-- **Terminal UI**: crossterm-based, markdown rendering, mouse selection/copy, scrollback, reasoning visibility toggle
+- **Terminal UI**: crossterm-based, markdown rendering, mouse selection/copy, scrollback, reasoning visibility toggle, customizable color themes
 - **Prompts system**: switch between system prompt modes at runtime (`code`, `plan`, `review`, `debug`, etc.) to tailor the agent's behavior to the task without having to manage Skills.
 - **MCP support**: connect MCP servers for extended tooling (exposed as an optional compile-time feature)
 - **Integrated Exa search**: allows for WebFetch and WebSearch tools
@@ -138,6 +138,19 @@ project root or any ancestor directory, injecting their contents into the
 system prompt. When enabled (feature `archmd`), `ARCHITECTURE.md` is also loaded
 the same way, providing high-level design context to speed up exploration.
 Use `-n` / `--no-context-files` to disable all context file loading.
+
+## Themes
+
+zerostack supports color themes that customize the TUI appearance. Built-in themes
+include popular dark palettes (gruvbox, dracula, tokyo-night, nord, etc.).
+
+Use `/theme` to list available themes, `/theme <name>` to activate one, and
+`/theme default` to revert to config colors. Colors can also be set directly in
+the config file — see [docs/CONFIG.md](docs/CONFIG.md#colors) for all fields
+and color syntax (named, hex, `ansi:N`).
+
+Custom themes can be created by placing a `.json` file in
+`~/.local/share/zerostack/themes/`.
 
 ## Permission system
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -221,17 +221,51 @@ gateways) — use with care, as it makes the connection vulnerable to MITM.
 
 ## Colors
 
-The `colors` object accepts three optional string fields, each of which can be a
-named color or hex color (e.g. `"#1e1e2e"`). Named colors are case-insensitive.
-Accepted values:
+The `colors` object accepts optional string fields for both background and
+foreground colors. Each value can be a named color, hex color (e.g. `"#1e1e2e"`),
+or ANSI color code (e.g. `"ansi:7"`). Named colors and ANSI codes are
+case-insensitive.
+
+### Background colors
 
 - `chat_background` — background color for the main conversation buffer.
 - `input_background` — background color for the text input area.
 - `status_background` — background color for the status bar (lowest line).
 
+### Foreground colors
+
+| Field | Default | Used for |
+|-------|---------|----------|
+| `agent_text` | `white` | Agent output, default text, table rows |
+| `error` | `red` | Error messages |
+| `tool_call` | `yellow` | Tool call output |
+| `permission` | `magenta` | Permission prompts |
+| `by_the_way` | `cyan` | BTW messages |
+| `reasoning` | `dark_magenta` | Reasoning tokens |
+| `secondary` | `dark_grey` | Tool results, blockquotes, rules |
+| `success` | `green` | Completed todos |
+| `heading` | `cyan` | Markdown headings |
+| `code_block` | `dark_yellow` | Code blocks |
+| `link_text` | `dark_cyan` | Markdown link text |
+| `prompt_marker` | `cyan` | The `>` input prompt |
+| `scroll_indicator` | `dark_grey` | Scroll position indicator |
+| `picker_secondary` | `dark_grey` | Unselected picker items |
+| `picker_selected` | `green` | Selected picker item highlight |
+| `status_foreground` | `dark_grey` | Status bar text |
+
+All foreground fields default to `None` (the built-in default shown above is
+used). Set a field to override only that color — unspecified fields keep their
+built-in defaults.
+
+### Color syntax
+
 Supported named colors: `reset`, `black`, `red`, `green`, `yellow`, `blue`,
 `magenta`, `cyan`, `white`, `grey`, `dark_grey`, `dark_red`, `dark_green`,
 `dark_yellow`, `dark_blue`, `dark_magenta`, `dark_cyan`.
+
+ANSI 256-color codes: `ansi:N` where N is 0–255 (e.g. `"ansi:7"`, `"ansi:214"`).
+
+Hex truecolor: `#RRGGBB` (e.g. `"#1e1e2e"`).
 
 Example:
 ```json
@@ -239,10 +273,44 @@ Example:
   "colors": {
     "chat_background": "#1e1e2e",
     "input_background": "#181825",
-    "status_background": "#11111b"
+    "status_background": "#11111b",
+    "agent_text": "ansi:7",
+    "error": "ansi:9",
+    "secondary": "ansi:8"
   }
 }
 ```
+
+### Built-in themes
+
+zerostack ships with built-in color themes that can be activated with
+`/theme <name>`. Themes are JSON files stored in the themes directory
+(`~/.local/share/zerostack/themes/`).
+
+Each theme file is a `colors` object — the same format as the `colors` key
+in the config file. Theme files set only the colors they define; unspecified
+fields keep the built-in defaults.
+
+To list available themes, use `/theme`. To regenerate built-in themes
+(e.g. after an update adds new ones), use `/regen-themes`.
+
+| Theme | Style |
+|-------|-------|
+| `default` | Empty theme (built-in defaults) |
+| `ayu-mirage` | Warm dark (hex backgrounds) |
+| `dracula` | Purple-tinted dark (hex backgrounds) |
+| `everforest` | Green-tinted dark (hex backgrounds) |
+| `gruvbox` | Warm earth tones (hex backgrounds) |
+| `kanagawa` | Blue-tinged dark (hex backgrounds) |
+| `monokai` | Classic editor dark (hex backgrounds) |
+| `nord` | Cool blue-grey (hex backgrounds) |
+| `one-dark` | Atom-inspired dark (hex backgrounds) |
+| `rose-pine` | Soft pastel dark (hex backgrounds) |
+| `solarized-dark` | Solarized palette (hex backgrounds) |
+| `tokyo-night` | Deep blue dark (hex backgrounds) |
+
+You can create custom themes by placing a `.json` file in the themes
+directory. The filename (without `.json`) becomes the theme name.
 
 Permission actions are lowercase strings: `allow`, `ask`, or `deny`. Each tool
 rule can be a single action or an object mapping patterns to actions. Supported

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -71,7 +71,42 @@ impl std::str::FromStr for EditSystem {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ColorsConfig {
+    // Background colors
     pub chat_background: Option<CompactString>,
     pub input_background: Option<CompactString>,
     pub status_background: Option<CompactString>,
+
+    // Semantic foreground colors
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_text: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub by_the_way: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secondary: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub success: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heading: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_block: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link_text: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_marker: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_foreground: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scroll_indicator: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub picker_secondary: Option<CompactString>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub picker_selected: Option<CompactString>,
 }

--- a/src/context/themes.rs
+++ b/src/context/themes.rs
@@ -5,7 +5,7 @@ use include_dir::{Dir, include_dir};
 
 use crate::config::ColorsConfig;
 use crate::ui::renderer::Renderer;
-use crate::ui::utils::parse_color;
+use crate::ui::utils::UiColors;
 
 static EMBEDDED: Dir = include_dir!("$CARGO_MANIFEST_DIR/themes");
 
@@ -44,9 +44,6 @@ pub fn regen() -> anyhow::Result<()> {
 
 pub fn apply(content: &str, renderer: &mut Renderer) {
     if let Ok(colors) = serde_json::from_str::<ColorsConfig>(content) {
-        let chat_bg = colors.chat_background.as_deref().and_then(parse_color);
-        let input_bg = colors.input_background.as_deref().and_then(parse_color);
-        let status_bg = colors.status_background.as_deref().and_then(parse_color);
-        renderer.set_background_colors(chat_bg, input_bg, status_bg);
+        renderer.set_colors(UiColors::from_config(&colors));
     }
 }

--- a/src/tests/markdown_tests.rs
+++ b/src/tests/markdown_tests.rs
@@ -1,6 +1,6 @@
 use crate::ui::markdown::{markdown_to_styled, word_wrap};
+use crate::ui::renderer::LineColor;
 use crate::ui::utils::display_width;
-use crossterm::style::Color;
 
 // ── word_wrap ───────────────────────────────────────────────────────
 
@@ -138,7 +138,7 @@ fn link_text_is_colored() {
     let styled = markdown_to_styled("[link text](https://x.com)", 80);
     let cyan_lines: Vec<_> = styled
         .iter()
-        .filter(|e| e.color == Color::DarkCyan)
+        .filter(|e| e.color == LineColor::LinkText)
         .collect();
     assert!(!cyan_lines.is_empty(), "link text should be DarkCyan");
 }
@@ -148,7 +148,7 @@ fn link_url_is_dark_grey() {
     let styled = markdown_to_styled("[text](https://x.com)", 80);
     let url_lines: Vec<_> = styled
         .iter()
-        .filter(|e| e.color == Color::DarkGrey && e.text.contains('\u{21aa}'))
+        .filter(|e| e.color == LineColor::Secondary && e.text.contains('\u{21aa}'))
         .collect();
     assert!(
         !url_lines.is_empty(),
@@ -208,7 +208,7 @@ fn table_borders_are_dark_grey() {
     let styled = markdown_to_styled(input, 80);
     let border_lines: Vec<_> = styled
         .iter()
-        .filter(|e| e.color == Color::DarkGrey && e.text.contains('\u{2500}'))
+        .filter(|e| e.color == LineColor::Secondary && e.text.contains('\u{2500}'))
         .collect();
     assert!(!border_lines.is_empty(), "table borders should be DarkGrey");
 }
@@ -219,7 +219,7 @@ fn table_content_is_white() {
     let styled = markdown_to_styled(input, 80);
     let content_lines: Vec<_> = styled
         .iter()
-        .filter(|e| e.color == Color::White && e.text.contains('y'))
+        .filter(|e| e.color == LineColor::AgentText && e.text.contains('y'))
         .collect();
     assert!(!content_lines.is_empty(), "table content should be White");
 }
@@ -262,8 +262,8 @@ fn empty_input_returns_empty_vec() {
 #[test]
 fn headings_still_work() {
     let styled = markdown_to_styled("# Hello", 80);
-    let heading = styled.iter().find(|e| e.color == Color::Cyan);
-    assert!(heading.is_some(), "heading should be Cyan");
+    let heading = styled.iter().find(|e| e.color == LineColor::Heading);
+    assert!(heading.is_some(), "heading should be Heading color");
     assert!(heading.unwrap().text.contains("Hello"));
 }
 
@@ -273,9 +273,12 @@ fn code_blocks_still_work() {
     let styled = markdown_to_styled(input, 80);
     let code_lines: Vec<_> = styled
         .iter()
-        .filter(|e| e.color == Color::DarkYellow)
+        .filter(|e| e.color == LineColor::CodeBlock)
         .collect();
-    assert!(!code_lines.is_empty(), "code block should be DarkYellow");
+    assert!(
+        !code_lines.is_empty(),
+        "code block should be CodeBlock color"
+    );
 }
 
 #[test]
@@ -288,6 +291,6 @@ fn lists_still_work() {
 #[test]
 fn blockquotes_still_work() {
     let styled = markdown_to_styled("> quoted text", 80);
-    let quoted = styled.iter().any(|e| e.color == Color::DarkGrey);
-    assert!(quoted, "blockquote text should be DarkGrey");
+    let quoted = styled.iter().any(|e| e.color == LineColor::Secondary);
+    assert!(quoted, "blockquote text should be Secondary color");
 }

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -66,6 +66,7 @@ fn line_color_resolve_default_colors() {
     assert_eq!(LineColor::PromptMarker.resolve(&colors), Color::Green);
 }
 
+
 #[test]
 fn line_color_resolve_custom_colors() {
     let mut colors = UiColors::default_colors();

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -1,4 +1,6 @@
-use crate::ui::renderer::{base64_encode, copy_to_clipboard};
+use crate::ui::renderer::{LineColor, base64_encode, copy_to_clipboard};
+use crate::ui::utils::UiColors;
+use crossterm::style::Color;
 
 #[test]
 fn base64_encode_empty() {
@@ -45,4 +47,30 @@ fn copy_to_clipboard_does_not_panic() {
 #[test]
 fn copy_to_clipboard_empty_string() {
     copy_to_clipboard("");
+}
+
+#[test]
+fn line_color_resolve_default_colors() {
+    let colors = UiColors::default_colors();
+    assert_eq!(LineColor::AgentText.resolve(&colors), Color::White);
+    assert_eq!(LineColor::Error.resolve(&colors), Color::Red);
+    assert_eq!(LineColor::ToolCall.resolve(&colors), Color::Yellow);
+    assert_eq!(LineColor::Permission.resolve(&colors), Color::Magenta);
+    assert_eq!(LineColor::ByTheWay.resolve(&colors), Color::Cyan);
+    assert_eq!(LineColor::Reasoning.resolve(&colors), Color::DarkGrey);
+    assert_eq!(LineColor::Secondary.resolve(&colors), Color::DarkGrey);
+    assert_eq!(LineColor::Success.resolve(&colors), Color::Green);
+    assert_eq!(LineColor::Heading.resolve(&colors), Color::Cyan);
+    assert_eq!(LineColor::CodeBlock.resolve(&colors), Color::DarkYellow);
+    assert_eq!(LineColor::LinkText.resolve(&colors), Color::DarkCyan);
+    assert_eq!(LineColor::PromptMarker.resolve(&colors), Color::Green);
+}
+
+#[test]
+fn line_color_resolve_custom_colors() {
+    let mut colors = UiColors::default_colors();
+    colors.agent_text = Color::Cyan;
+    colors.error = Color::Magenta;
+    assert_eq!(LineColor::AgentText.resolve(&colors), Color::Cyan);
+    assert_eq!(LineColor::Error.resolve(&colors), Color::Magenta);
 }

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -1,5 +1,5 @@
 use compact_str::CompactString;
-use crossterm::style::Color;
+
 use tokio::sync::mpsc;
 
 use crate::agent::tools::todo::TODO_LIST;
@@ -16,10 +16,10 @@ use crate::provider::{AnyAgent, AnyClient};
 use crate::sandbox::Sandbox;
 use crate::session::{MessageRole, Session};
 use crate::ui::events::sanitize_output;
-use crate::ui::renderer::Renderer;
+use crate::ui::renderer::{LineColor, Renderer};
 use crate::ui::slash::handle_compress;
 
-use super::{C_AGENT, C_ERROR, C_TOOL, apply_current_prompt_mode};
+use super::apply_current_prompt_mode;
 
 #[cfg(feature = "mcp")]
 #[allow(clippy::too_many_arguments)]
@@ -121,16 +121,16 @@ pub async fn handle_agent_event(
                 return Ok(());
             }
             if !*agent_line_started {
-                renderer.write("< ", Color::DarkMagenta)?;
+                renderer.write("< ", LineColor::Reasoning)?;
                 *agent_line_started = true;
             }
             let safe = sanitize_output(&text);
-            renderer.write(&safe, Color::DarkMagenta)?;
+            renderer.write(&safe, LineColor::Reasoning)?;
             *was_reasoning = true;
         }
         AgentEvent::Token(text) => {
             if *was_reasoning {
-                renderer.write_line("", Color::White)?;
+                renderer.write_line("", LineColor::AgentText)?;
                 *agent_line_started = false;
                 *was_reasoning = false;
                 response_buf.clear();
@@ -163,7 +163,7 @@ pub async fn handle_agent_event(
         AgentEvent::ToolCall { name, args } => {
             *was_reasoning = false;
             if *agent_line_started {
-                renderer.write_line("", Color::White)?;
+                renderer.write_line("", LineColor::AgentText)?;
                 *agent_line_started = false;
             }
             response_buf.clear();
@@ -172,26 +172,26 @@ pub async fn handle_agent_event(
                 "◈ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
             );
-            renderer.write_line(&sanitize_output(&line), C_TOOL)?;
+            renderer.write_line(&sanitize_output(&line), LineColor::ToolCall)?;
         }
         AgentEvent::SubagentToolCall { name, args } => {
             let line = format!(
                 "⌥ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
             );
-            renderer.write_line(&sanitize_output(&line), C_TOOL)?;
+            renderer.write_line(&sanitize_output(&line), LineColor::ToolCall)?;
         }
         AgentEvent::ToolResult { name, output } => {
             if name == "write_todo_list" {
                 let list = TODO_LIST.lock().unwrap_or_else(|e| e.into_inner());
                 if list.is_empty() {
-                    renderer.write_line("tasks cleared", Color::DarkGrey)?;
+                    renderer.write_line("tasks cleared", LineColor::Secondary)?;
                 } else {
                     let total = list.len();
                     let completed = list.iter().filter(|t| t.status == "completed").count();
                     renderer.write_line(
                         &format!("tasks  {} done / {} total", completed, total),
-                        C_TOOL,
+                        LineColor::ToolCall,
                     )?;
                     for item in list.iter() {
                         let icon = match item.status.as_str() {
@@ -201,10 +201,10 @@ pub async fn handle_agent_event(
                             _ => "[ ]",
                         };
                         let status_color = match item.status.as_str() {
-                            "completed" => Color::Green,
-                            "in_progress" => C_TOOL,
-                            "cancelled" => Color::DarkGrey,
-                            _ => Color::DarkGrey,
+                            "completed" => LineColor::Success,
+                            "in_progress" => LineColor::ToolCall,
+                            "cancelled" => LineColor::Secondary,
+                            _ => LineColor::Secondary,
                         };
                         let priority_mark = match item.priority.as_str() {
                             "high" => "!!",
@@ -238,18 +238,18 @@ pub async fn handle_agent_event(
                                 max_lines,
                                 shown
                             );
-                            renderer.write_line(&summary, Color::DarkGrey)?;
+                            renderer.write_line(&summary, LineColor::Secondary)?;
                         } else {
                             let summary =
                                 format!("◈ result ({} chars):\n{}", char_count, sanitized);
-                            renderer.write_line(&summary, Color::DarkGrey)?;
+                            renderer.write_line(&summary, LineColor::Secondary)?;
                         }
                     }
                     ResolvedShowToolDetails::Unlimited => {
                         let sanitized = sanitize_output(&output);
                         let char_count = sanitized.chars().count();
                         let summary = format!("◈ result ({} chars):\n{}", char_count, sanitized);
-                        renderer.write_line(&summary, Color::DarkGrey)?;
+                        renderer.write_line(&summary, LineColor::Secondary)?;
                     }
                 }
             }
@@ -293,7 +293,7 @@ pub async fn handle_agent_event(
         AgentEvent::Error(e) => {
             *was_reasoning = false;
             let safe = sanitize_output(&e);
-            renderer.write_line(&format!("error: {}", safe), C_ERROR)?;
+            renderer.write_line(&format!("error: {}", safe), LineColor::Error)?;
             *is_running = false;
             if let Some(ss) = status_signals.as_ref() {
                 ss.send_stop();
@@ -347,11 +347,11 @@ async fn handle_agent_done(
             renderer.render_viewport()?;
         }
     } else if !*agent_line_started {
-        renderer.write("< ", C_AGENT)?;
+        renderer.write("< ", LineColor::AgentText)?;
     }
 
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("", Color::White)?;
+    renderer.write_line("", LineColor::AgentText)?;
+    renderer.write_line("", LineColor::AgentText)?;
     session.add_message(MessageRole::Assistant, &response);
     session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
     session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
@@ -383,7 +383,7 @@ async fn handle_agent_done(
         && session.needs_compaction(reserve)
         && !cli.no_session
     {
-        renderer.write_line("auto-compacting...", Color::DarkGrey)?;
+        renderer.write_line("auto-compacting...", LineColor::Secondary)?;
         let compress_result = handle_compress(
             None,
             agent,
@@ -402,14 +402,17 @@ async fn handle_agent_done(
         )
         .await;
         if let Err(e) = compress_result {
-            renderer.write_line(&format!("auto-compact error: {}", e), C_ERROR)?;
+            renderer.write_line(&format!("auto-compact error: {}", e), LineColor::Error)?;
         }
     }
 
     if !cli.no_session
         && let Err(e) = crate::session::storage::save_session(session)
     {
-        renderer.write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
+        renderer.write_line(
+            &format!("warning: failed to save session: {}", e),
+            LineColor::Error,
+        )?;
     }
     *is_running = false;
     if let Some(ss) = status_signals.as_ref() {
@@ -424,7 +427,7 @@ async fn handle_agent_done(
         if ls.should_stop() {
             renderer.write_line(
                 &format!("[loop] max iterations ({}) reached, stopping", ls.iteration),
-                C_AGENT,
+                LineColor::AgentText,
             )?;
             ls.active = false;
             *loop_label = None;
@@ -462,7 +465,7 @@ async fn handle_agent_done(
             *loop_label = Some(ls.iteration_label());
             renderer.write_line(
                 &format!("[loop] launching {}", ls.iteration_label()),
-                C_AGENT,
+                LineColor::AgentText,
             )?;
         }
     }
@@ -497,13 +500,13 @@ async fn handle_agent_done(
                 crate::ui::events::render_session(renderer, session, cli, cfg, context)?;
                 renderer.write_line(
                     &format!("merged and returned to main repo at {}", main_path),
-                    C_AGENT,
+                    LineColor::AgentText,
                 )?;
             }
             Err(e) => {
                 renderer.write_line(
                     &format!("warning: failed to change back to main repo: {}", e),
-                    C_ERROR,
+                    LineColor::Error,
                 )?;
             }
         }

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1,13 +1,12 @@
 use chrono::Datelike;
 use compact_str::CompactString;
-use crossterm::style::Color;
 
 use crate::cli::Cli;
 use crate::config::Config;
 use crate::context::ContextFiles;
 use crate::session::{MessageRole, Session};
 use crate::ui::markdown;
-use crate::ui::renderer::Renderer;
+use crate::ui::renderer::{LineColor, Renderer};
 
 pub fn format_time(rfc3339: &str) -> CompactString {
     let dt = chrono::DateTime::parse_from_rfc3339(rfc3339).ok();
@@ -40,16 +39,16 @@ pub fn render_session(
         cli.resolve_model(cfg),
         env!("CARGO_PKG_VERSION")
     );
-    renderer.write_line(&welcome, Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
+    renderer.write_line(&welcome, LineColor::Heading)?;
+    renderer.write_line("", LineColor::AgentText)?;
     if context.agents.is_some() {
-        renderer.write_line("loaded AGENTS.md", Color::DarkGrey)?;
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("loaded AGENTS.md", LineColor::Secondary)?;
+        renderer.write_line("", LineColor::AgentText)?;
     }
     #[cfg(feature = "archmd")]
     if context.architecture.is_some() {
-        renderer.write_line("loaded ARCHITECTURE.md", Color::DarkGrey)?;
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("loaded ARCHITECTURE.md", LineColor::Secondary)?;
+        renderer.write_line("", LineColor::AgentText)?;
     }
     if !session.compactions.is_empty() {
         renderer.write_line(
@@ -62,15 +61,15 @@ pub fn render_session(
                     .map(|c| c.token_savings)
                     .unwrap_or(0),
             ),
-            Color::DarkGrey,
+            LineColor::Secondary,
         )?;
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", LineColor::AgentText)?;
     }
     for msg in &session.messages {
         let (prefix, _c) = match msg.role {
-            MessageRole::User => (">", Color::Green),
-            MessageRole::Assistant => ("<", Color::White),
-            MessageRole::System => ("#", Color::DarkGrey),
+            MessageRole::User => (">", LineColor::PromptMarker),
+            MessageRole::Assistant => ("<", LineColor::AgentText),
+            MessageRole::System => ("#", LineColor::Secondary),
         };
         if msg.role == MessageRole::Assistant {
             let max_width = renderer.line_width();
@@ -86,58 +85,76 @@ pub fn render_session(
                 renderer.write_line(&format!("{} {}", prefix, line), _c)?;
             }
         }
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", LineColor::AgentText)?;
     }
     Ok(())
 }
 
 pub fn show_welcome(renderer: &mut Renderer) -> std::io::Result<()> {
-    use super::C_TOOL;
-    use crossterm::style::Color;
-
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("  zerostack Quickstart", Color::Cyan)?;
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Pickers:", C_TOOL)?;
+    renderer.write_line(
+        "──────────────────────────────────────────",
+        LineColor::Heading,
+    )?;
+    renderer.write_line("  zerostack Quickstart", LineColor::Heading)?;
+    renderer.write_line(
+        "──────────────────────────────────────────",
+        LineColor::Heading,
+    )?;
+    renderer.write_line("", LineColor::AgentText)?;
+    renderer.write_line("  Pickers:", LineColor::ToolCall)?;
     renderer.write_line(
         "    @<path>     File picker / auto-complete paths",
-        Color::White,
+        LineColor::AgentText,
     )?;
     renderer.write_line(
         "    !<command>  Run a shell command (output stored as assistant)",
-        Color::White,
+        LineColor::AgentText,
     )?;
     renderer.write_line(
         "    .<prompt>   Switch prompt or one-shot .<prompt> <message>",
-        Color::White,
+        LineColor::AgentText,
     )?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Slash Commands:", C_TOOL)?;
-    renderer.write_line("    /model        Switch model", Color::White)?;
-    renderer.write_line("    /prompt       List / activate prompts", Color::White)?;
+    renderer.write_line("", LineColor::AgentText)?;
+    renderer.write_line("  Slash Commands:", LineColor::ToolCall)?;
+    renderer.write_line("    /model        Switch model", LineColor::AgentText)?;
+    renderer.write_line(
+        "    /prompt       List / activate prompts",
+        LineColor::AgentText,
+    )?;
     renderer.write_line(
         "    .autoconfig        Switches to auto-configurator",
-        Color::White,
+        LineColor::AgentText,
     )?;
-    renderer.write_line("    /mode         Change security mode", Color::White)?;
-    renderer.write_line("    /clear        Clear session", Color::White)?;
-    renderer.write_line("    /undo         Undo last exchange", Color::White)?;
-    renderer.write_line("    /compress     Free context window space", Color::White)?;
-    renderer.write_line("    /help         Show all commands", Color::White)?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Keybindings:", C_TOOL)?;
-    renderer.write_line("    Ctrl+G     Open input in $EDITOR", Color::White)?;
-    renderer.write_line("    Ctrl+H     Launch lazygit", Color::White)?;
-    renderer.write_line("    Ctrl+S     Save session", Color::White)?;
-    renderer.write_line("    Tab        File picker / auto-complete", Color::White)?;
+    renderer.write_line(
+        "    /mode         Change security mode",
+        LineColor::AgentText,
+    )?;
+    renderer.write_line("    /clear        Clear session", LineColor::AgentText)?;
+    renderer.write_line("    /undo         Undo last exchange", LineColor::AgentText)?;
+    renderer.write_line(
+        "    /compress     Free context window space",
+        LineColor::AgentText,
+    )?;
+    renderer.write_line("    /help         Show all commands", LineColor::AgentText)?;
+    renderer.write_line("", LineColor::AgentText)?;
+    renderer.write_line("  Keybindings:", LineColor::ToolCall)?;
+    renderer.write_line("    Ctrl+G     Open input in $EDITOR", LineColor::AgentText)?;
+    renderer.write_line("    Ctrl+H     Launch lazygit", LineColor::AgentText)?;
+    renderer.write_line("    Ctrl+S     Save session", LineColor::AgentText)?;
+    renderer.write_line(
+        "    Tab        File picker / auto-complete",
+        LineColor::AgentText,
+    )?;
     renderer.write_line(
         "  Website: https://gi-dellav.github.io/zerostack/",
-        Color::White,
+        LineColor::AgentText,
     )?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
+    renderer.write_line("", LineColor::AgentText)?;
+    renderer.write_line(
+        "──────────────────────────────────────────",
+        LineColor::Heading,
+    )?;
+    renderer.write_line("", LineColor::AgentText)?;
     Ok(())
 }
 

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use crate::ui::pickers::file::FilePicker;
 use crate::ui::pickers::list::ListPicker;
 use crate::ui::pickers::models::ModelsPicker;
+use crate::ui::utils::UiColors;
 
 const MAX_KILL_RING: usize = 30;
 
@@ -25,6 +26,7 @@ pub struct InputEditor {
     draft: Option<CompactString>,
     pub picker: Option<Picker>,
     monochrome: bool,
+    colors: UiColors,
     prompt_names: Vec<String>,
     theme_names: Vec<String>,
     quick_model_names: Vec<String>,
@@ -46,6 +48,7 @@ impl InputEditor {
             draft: None,
             picker: None,
             monochrome: false,
+            colors: UiColors::default_colors(),
             prompt_names: Vec::new(),
             theme_names: Vec::new(),
             quick_model_names: Vec::new(),
@@ -81,6 +84,13 @@ impl InputEditor {
         }
     }
 
+    pub fn set_colors(&mut self, colors: UiColors) {
+        self.colors = colors.clone();
+        if let Some(ref mut picker) = self.picker {
+            picker.set_colors(colors);
+        }
+    }
+
     pub fn set_prompt_names(&mut self, names: Vec<String>) {
         self.prompt_names = names;
     }
@@ -102,6 +112,7 @@ impl InputEditor {
     pub fn start_file_picker(&mut self) {
         let mut picker = FilePicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         picker.activate();
         self.picker = Some(Picker::File(picker));
     }
@@ -109,6 +120,7 @@ impl InputEditor {
     pub fn start_command_picker(&mut self) {
         let mut picker = ListPicker::with_static_commands();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         picker.activate();
         self.picker = Some(Picker::Command(picker));
     }
@@ -116,6 +128,7 @@ impl InputEditor {
     pub fn start_models_picker(&mut self) {
         let mut picker = ModelsPicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         picker.set_groups(
             self.quick_model_names.clone(),
             self.live_model_names.clone(),
@@ -127,6 +140,7 @@ impl InputEditor {
     pub fn start_provider_picker(&mut self) {
         let mut picker = ListPicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         if !self.provider_names.is_empty() {
             picker.set_items(self.provider_names.clone());
         }
@@ -137,6 +151,7 @@ impl InputEditor {
     pub fn start_prompt_picker(&mut self) {
         let mut picker = ListPicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         if !self.prompt_names.is_empty() {
             picker.set_items(self.prompt_names.clone());
         }
@@ -147,6 +162,7 @@ impl InputEditor {
     pub fn start_dot_picker(&mut self) {
         let mut picker = ListPicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         if !self.prompt_names.is_empty() {
             picker.set_items(self.prompt_names.clone());
         }
@@ -157,6 +173,7 @@ impl InputEditor {
     pub fn start_theme_picker(&mut self) {
         let mut picker = ListPicker::new();
         picker.set_monochrome(self.monochrome);
+        picker.set_colors(self.colors.clone());
         if !self.theme_names.is_empty() {
             picker.set_items(self.theme_names.clone());
         }

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -1,5 +1,7 @@
 use crossterm::event::KeyEvent;
 
+use crate::ui::utils::UiColors;
+
 use crate::ui::pickers::file::FilePicker;
 use crate::ui::pickers::handlers;
 use crate::ui::pickers::list::ListPicker;
@@ -28,6 +30,15 @@ impl Picker {
             Picker::Command(p) => p.set_monochrome(monochrome),
             Picker::Prefixed(p, _) => p.set_monochrome(monochrome),
             Picker::Models(p) => p.set_monochrome(monochrome),
+        }
+    }
+
+    pub fn set_colors(&mut self, colors: UiColors) {
+        match self {
+            Picker::File(p) => p.set_colors(colors),
+            Picker::Command(p) => p.set_colors(colors),
+            Picker::Prefixed(p, _) => p.set_colors(colors),
+            Picker::Models(p) => p.set_colors(colors),
         }
     }
 
@@ -66,7 +77,9 @@ impl InputEditor {
                 };
                 let (handled, replacement) =
                     handlers::handle_command_key(&mut self.buffer, &mut self.cursor, &ctx, p, key);
-                if let Some(new) = replacement {
+                if let Some(mut new) = replacement {
+                    new.set_monochrome(self.monochrome);
+                    new.set_colors(self.colors.clone());
                     self.picker = Some(new);
                 }
                 handled

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,9 +1,10 @@
 use compact_str::CompactString;
-use crossterm::style::Color;
+
 use pulldown_cmark::{Alignment, Event, Options, Tag, TagEnd};
 use smallvec::{SmallVec, smallvec};
 
-use super::renderer::LineEntry;
+use super::renderer::{LineColor, LineEntry};
+
 use super::utils::display_width;
 
 pub(crate) fn word_wrap(text: &str, max_width: usize) -> SmallVec<[CompactString; 4]> {
@@ -83,7 +84,7 @@ pub(crate) fn word_wrap(text: &str, max_width: usize) -> SmallVec<[CompactString
     lines
 }
 
-fn flush_acc(acc: &str, color: Color, max_width: usize, out: &mut Vec<LineEntry>) {
+fn flush_acc(acc: &str, color: LineColor, max_width: usize, out: &mut Vec<LineEntry>) {
     if acc.is_empty() {
         return;
     }
@@ -102,11 +103,8 @@ fn flush_acc(acc: &str, color: Color, max_width: usize, out: &mut Vec<LineEntry>
     }
 }
 
-fn bullet_prefix(col: Color) -> &'static str {
-    match col {
-        Color::DarkGrey => "  ┊ ",
-        _ => "  • ",
-    }
+fn bullet_prefix(in_blockquote: bool) -> &'static str {
+    if in_blockquote { "  ┊ " } else { "  • " }
 }
 
 pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
@@ -141,17 +139,17 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
             Event::Start(tag) => match tag {
                 Tag::Paragraph => {}
                 Tag::Heading { level: _, .. } => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                     acc.clear();
                     in_heading = true;
                 }
                 Tag::CodeBlock(_kind) => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                     acc.clear();
                     in_code_block = true;
                 }
                 Tag::BlockQuote(_) => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                     acc.clear();
                     in_blockquote = true;
                 }
@@ -160,13 +158,13 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     list_item_count = 0;
                 }
                 Tag::Item => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                     acc.clear();
                     list_item_count += 1;
                 }
                 Tag::FootnoteDefinition(_) => {}
                 Tag::Table(alignments) => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                     acc.clear();
                     table_rows.clear();
                     table_row.clear();
@@ -196,20 +194,20 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
             Event::End(tag_end) => match tag_end {
                 TagEnd::Paragraph => {
                     let color = if in_blockquote {
-                        Color::DarkGrey
+                        LineColor::Secondary
                     } else {
-                        Color::White
+                        LineColor::AgentText
                     };
                     flush_acc(&acc, color, max_width, &mut result);
                     acc.clear();
                 }
                 TagEnd::Heading(_) => {
-                    flush_acc(&acc, Color::Cyan, max_width, &mut result);
+                    flush_acc(&acc, LineColor::Heading, max_width, &mut result);
                     acc.clear();
                     in_heading = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: LineColor::AgentText,
                     });
                 }
                 TagEnd::CodeBlock => {
@@ -218,12 +216,12 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         if trimmed.is_empty() {
                             result.push(LineEntry {
                                 text: CompactString::new(""),
-                                color: Color::DarkYellow,
+                                color: LineColor::CodeBlock,
                             });
                         } else {
                             result.push(LineEntry {
                                 text: CompactString::from(trimmed),
-                                color: Color::DarkYellow,
+                                color: LineColor::CodeBlock,
                             });
                         }
                     }
@@ -231,7 +229,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     in_code_block = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: LineColor::AgentText,
                     });
                 }
                 TagEnd::BlockQuote(_) => {
@@ -241,14 +239,14 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         if trimmed.is_empty() {
                             quoted.push(LineEntry {
                                 text: CompactString::new(""),
-                                color: Color::DarkGrey,
+                                color: LineColor::Secondary,
                             });
                         } else {
                             let prefixed = format!("│ {}", trimmed);
                             for chunk in word_wrap(&prefixed, max_width) {
                                 quoted.push(LineEntry {
                                     text: chunk,
-                                    color: Color::DarkGrey,
+                                    color: LineColor::Secondary,
                                 });
                             }
                         }
@@ -258,19 +256,19 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     in_blockquote = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: LineColor::AgentText,
                     });
                 }
                 TagEnd::Item => {
                     let color = if in_blockquote {
-                        Color::DarkGrey
+                        LineColor::Secondary
                     } else {
-                        Color::White
+                        LineColor::AgentText
                     };
                     let bullet = if ordered_list {
                         format!(" {}. ", list_item_count)
                     } else {
-                        bullet_prefix(color).to_string()
+                        bullet_prefix(in_blockquote).to_string()
                     };
                     let mut item_lines = Vec::new();
                     let mut first = true;
@@ -301,7 +299,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     list_item_count = 0;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: LineColor::AgentText,
                     });
                 }
                 TagEnd::Link => {
@@ -309,12 +307,12 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         if in_table_cell {
                             table_cell.push_str(&format!(" ({})", link_url));
                         } else if !acc.is_empty() {
-                            flush_acc(&acc, Color::DarkCyan, max_width, &mut result);
+                            flush_acc(&acc, LineColor::LinkText, max_width, &mut result);
                             let note = format!("  ↪ {}", link_url);
                             for chunk in word_wrap(&note, max_width) {
                                 result.push(LineEntry {
                                     text: chunk,
-                                    color: Color::DarkGrey,
+                                    color: LineColor::Secondary,
                                 });
                             }
                             acc.clear();
@@ -328,7 +326,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     table_alignments.clear();
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: LineColor::AgentText,
                     });
                 }
                 TagEnd::TableHead => {
@@ -376,16 +374,16 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 }
             }
             Event::Rule => {
-                flush_acc(&acc, Color::White, max_width, &mut result);
+                flush_acc(&acc, LineColor::AgentText, max_width, &mut result);
                 acc.clear();
                 let rule: String = "\u{2500}".repeat(max_width.min(40));
                 result.push(LineEntry {
                     text: CompactString::from(rule),
-                    color: Color::DarkGrey,
+                    color: LineColor::Secondary,
                 });
                 result.push(LineEntry {
                     text: CompactString::new(""),
-                    color: Color::White,
+                    color: LineColor::AgentText,
                 });
             }
             Event::Html(t) => {
@@ -418,13 +416,13 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
 
     if !acc.is_empty() {
         let color = if in_blockquote {
-            Color::DarkGrey
+            LineColor::Secondary
         } else if in_code_block {
-            Color::DarkYellow
+            LineColor::CodeBlock
         } else if in_heading {
-            Color::Cyan
+            LineColor::Heading
         } else {
-            Color::White
+            LineColor::AgentText
         };
         flush_acc(&acc, color, max_width, &mut result);
     }
@@ -474,16 +472,16 @@ fn flush_table(
     let sep = format_table_rule(&col_widths, '\u{251c}', '\u{253c}', '\u{2524}');
     let bot = format_table_rule(&col_widths, '\u{2514}', '\u{2534}', '\u{2518}');
 
-    push_table_line(&top, Color::DarkGrey, out);
+    push_table_line(&top, LineColor::Secondary, out);
     for (i, row) in rows.iter().enumerate() {
         for line in format_table_row(row, &col_widths, alignments) {
-            push_table_line(&line, Color::White, out);
+            push_table_line(&line, LineColor::AgentText, out);
         }
         if i == 0 && rows.len() > 1 {
-            push_table_line(&sep, Color::DarkGrey, out);
+            push_table_line(&sep, LineColor::Secondary, out);
         }
     }
-    push_table_line(&bot, Color::DarkGrey, out);
+    push_table_line(&bot, LineColor::Secondary, out);
 }
 
 fn format_table_rule(widths: &[usize], left: char, mid: char, right: char) -> String {
@@ -501,7 +499,7 @@ fn format_table_rule(widths: &[usize], left: char, mid: char, right: char) -> St
     s
 }
 
-fn push_table_line(text: &str, color: Color, out: &mut Vec<LineEntry>) {
+fn push_table_line(text: &str, color: LineColor, out: &mut Vec<LineEntry>) {
     out.push(LineEntry {
         text: CompactString::from(text),
         color,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use crossterm::ExecutableCommand;
 use crossterm::event;
 use crossterm::event::{KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
-use crossterm::style::Color;
+
 use tokio::sync::mpsc;
 
 use crate::cli::Cli;
@@ -39,12 +39,12 @@ use crate::ui::event_handler::{ensure_agent, handle_agent_event};
 use crate::ui::events::{render_session, sanitize_output};
 use crate::ui::input::InputEditor;
 use crate::ui::permission_handler::handle_permission_request;
-use crate::ui::renderer::{Renderer, copy_to_clipboard};
+use crate::ui::renderer::{LineColor, Renderer, copy_to_clipboard};
 use crate::ui::slash::{handle_compress, handle_slash};
 use crate::ui::status::StatusLine;
 use crate::ui::terminal::TerminalGuard;
 
-use self::utils::parse_color;
+use self::utils::UiColors;
 
 pub(crate) fn apply_current_prompt_mode(
     context: &mut ContextFiles,
@@ -68,12 +68,6 @@ pub(crate) fn apply_current_prompt_mode(
         guard.set_prompt_mode(mode);
     }
 }
-
-pub(super) const C_AGENT: Color = Color::White;
-pub(super) const C_ERROR: Color = Color::Red;
-pub(super) const C_TOOL: Color = Color::Yellow;
-pub(super) const C_PERM: Color = Color::Magenta;
-pub(super) const C_BTW: Color = Color::Cyan;
 
 #[allow(clippy::too_many_arguments)]
 fn refresh_display(
@@ -311,12 +305,10 @@ pub async fn run_interactive(
             crate::context::themes::apply(content, &mut renderer);
         }
     } else if let Some(colors) = &cfg.colors {
-        let chat_bg = colors.chat_background.as_deref().and_then(parse_color);
-        let input_bg = colors.input_background.as_deref().and_then(parse_color);
-        let status_bg = colors.status_background.as_deref().and_then(parse_color);
-        renderer.set_background_colors(chat_bg, input_bg, status_bg);
+        renderer.set_colors(UiColors::from_config(colors));
     }
     let mut input = InputEditor::new();
+    input.set_colors(renderer.colors().clone());
     input.set_monochrome(cli.no_color);
     input.set_prompt_names(context.prompts.keys().cloned().collect());
     input.set_theme_names(context.themes.keys().cloned().collect());
@@ -445,7 +437,7 @@ pub async fn run_interactive(
                 let _ = render_session(&mut renderer, session, cli, cfg, context);
             }
             Err(e) => {
-                let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
+                let _ = renderer.write_line(&format!("worktree failed: {}", e), LineColor::Error);
             }
         }
     }
@@ -484,7 +476,7 @@ pub async fn run_interactive(
                 let _ = render_session(&mut renderer, session, cli, cfg, context);
             }
             Err(e) => {
-                let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
+                let _ = renderer.write_line(&format!("worktree failed: {}", e), LineColor::Error);
             }
         }
     }
@@ -492,9 +484,9 @@ pub async fn run_interactive(
     if let Some(ref trigger_msg) = auto_trigger_msg {
         for line in trigger_msg.lines() {
             let safe_line = sanitize_output(line);
-            renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+            renderer.write_line(&format!("> {}", safe_line), LineColor::PromptMarker)?;
         }
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", LineColor::AgentText)?;
 
         #[cfg(feature = "mcp")]
         let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
@@ -600,7 +592,7 @@ pub async fn run_interactive(
                                     h.abort();
                                 }
                                 btw_inflight = 0;
-                                renderer.write_line("btw cancelled", C_ERROR)?;
+                                renderer.write_line("btw cancelled", LineColor::Error)?;
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             } else if is_running {
                                 // Actually cancel the run's task (not just stop
@@ -635,7 +627,7 @@ pub async fn run_interactive(
                                 }
                                 renderer.write_line(
                                     "interrupted (changes may be partial; review with git diff)",
-                                    C_ERROR,
+                                    LineColor::Error,
                                 )?;
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             } else {
@@ -647,7 +639,7 @@ pub async fn run_interactive(
                         if renderer.selection_active && key.code == KeyCode::Char('y') {
                             if let Some(text) = renderer.selected_text() {
                                 copy_to_clipboard(&text);
-                                renderer.write_line("copied selection", Color::Green)?;
+                                renderer.write_line("copied selection", LineColor::Success)?;
                             }
                             renderer.clear_selection();
                             refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
@@ -665,7 +657,7 @@ pub async fn run_interactive(
                             show_reasoning = !show_reasoning;
                             renderer.write_line(
                                 &format!("reasoning visibility: {}", if show_reasoning { "on" } else { "off" }),
-                                Color::White,
+                                LineColor::AgentText,
                             )?;
                             refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
@@ -724,7 +716,7 @@ pub async fn run_interactive(
                             {
                                 renderer.write_line(
                                     "warning: lazygit not found — install it (https://github.com/jesseduffield/lazygit)",
-                                    C_ERROR,
+                                    LineColor::Error,
                                 )?;
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
@@ -755,7 +747,7 @@ pub async fn run_interactive(
                         if let Some(mut text) = input.handle_key(key) {
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
-                                renderer.write_line("loop active: /loop stop to cancel", C_ERROR)?;
+                                renderer.write_line("loop active: /loop stop to cancel", LineColor::Error)?;
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }
@@ -777,14 +769,14 @@ pub async fn run_interactive(
                                 SubmitAction::RejectWhileRunning => {
                                     renderer.write_line(
                                         "agent is running — wait for it to finish or press Ctrl-C before running a command",
-                                        C_ERROR,
+                                        LineColor::Error,
                                     )?;
                                     refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
                                 SubmitAction::Queue => {
                                     pending_inputs.push_back(text.to_string());
-                                    renderer.write_line(&format!("queued: {}", sanitize_output(&text)), C_TOOL)?;
+                                    renderer.write_line(&format!("queued: {}", sanitize_output(&text)), LineColor::ToolCall)?;
                                     refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
                                 }
@@ -800,23 +792,23 @@ pub async fn run_interactive(
                                         "clear" => {
                                             let n = pending_inputs.len();
                                             pending_inputs.clear();
-                                            renderer.write_line(&format!("queue cleared ({} removed)", n), C_TOOL)?;
+                                            renderer.write_line(&format!("queue cleared ({} removed)", n), LineColor::ToolCall)?;
                                         }
                                         "pop" => match pending_inputs.pop_back() {
-                                            Some(x) => renderer.write_line(&format!("unqueued: {}", sanitize_output(&x)), C_TOOL)?,
-                                            None => renderer.write_line("queue is empty", C_TOOL)?,
+                                            Some(x) => renderer.write_line(&format!("unqueued: {}", sanitize_output(&x)), LineColor::ToolCall)?,
+                                            None => renderer.write_line("queue is empty", LineColor::ToolCall)?,
                                         },
                                         "" | "ls" | "list" => {
                                             if pending_inputs.is_empty() {
-                                                renderer.write_line("queue is empty", C_TOOL)?;
+                                                renderer.write_line("queue is empty", LineColor::ToolCall)?;
                                             } else {
-                                                renderer.write_line(&format!("queued ({}):", pending_inputs.len()), C_TOOL)?;
+                                                renderer.write_line(&format!("queued ({}):", pending_inputs.len()), LineColor::ToolCall)?;
                                                 for (i, q) in pending_inputs.iter().enumerate() {
-                                                    renderer.write_line(&format!("  {}. {}", i + 1, sanitize_output(q)), C_TOOL)?;
+                                                    renderer.write_line(&format!("  {}. {}", i + 1, sanitize_output(q)), LineColor::ToolCall)?;
                                                 }
                                             }
                                         }
-                                        _ => renderer.write_line("usage: /queue [ls|clear|pop]", C_ERROR)?,
+                                        _ => renderer.write_line("usage: /queue [ls|clear|pop]", LineColor::Error)?,
                                     }
                                     refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
@@ -832,12 +824,12 @@ pub async fn run_interactive(
                                 let t = text.trim_start();
                                 if t == "/btw" || t.starts_with("/btw ") {
                                     for line in text.lines() {
-                                        renderer.write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
+                                        renderer.write_line(&format!("> {}", sanitize_output(line)), LineColor::PromptMarker)?;
                                     }
-                                    renderer.write_line("", Color::White)?;
+                                    renderer.write_line("", LineColor::AgentText)?;
                                     let btw_text = t.strip_prefix("/btw").map(|s| s.trim()).unwrap_or("");
                                     if btw_text.is_empty() {
-                                        renderer.write_line("usage: /btw <message>", C_AGENT)?;
+                                        renderer.write_line("usage: /btw <message>", LineColor::AgentText)?;
                                     } else {
                                         let id = btw_next_id;
                                         btw_next_id = btw_next_id.wrapping_add(1);
@@ -853,7 +845,7 @@ pub async fn run_interactive(
                                         );
                                         btw_abort.push((id, runner.abort_handle));
                                         btw_inflight += 1;
-                                        renderer.write_line(&format!("[btw #{}] thinking...", id), C_BTW)?;
+                                        renderer.write_line(&format!("[btw #{}] thinking...", id), LineColor::ByTheWay)?;
                                     }
                                     refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                     continue;
@@ -866,9 +858,9 @@ pub async fn run_interactive(
 
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("> {}", safe_line), LineColor::PromptMarker)?;
                                 }
-                                renderer.write_line("", Color::White)?;
+                                renderer.write_line("", LineColor::AgentText)?;
 
                                 if after_dot.is_empty() {
                                     input.buffer = ".".into();
@@ -901,7 +893,7 @@ pub async fn run_interactive(
                                         text = msg.to_string().into();
                                         is_dot_cmd = false;
                                     } else {
-                                        renderer.write_line(&format!("error: unknown prompt '{}'", prompt_name), C_ERROR)?;
+                                        renderer.write_line(&format!("error: unknown prompt '{}'", prompt_name), LineColor::Error)?;
                                     }
                                 } else {
                                     let prompt_name = after_dot.trim();
@@ -925,17 +917,17 @@ pub async fn run_interactive(
                                                     }
                                                 }
                                         }
-                                        renderer.write_line(&format!("switched to prompt '{}'", prompt_name), C_AGENT)?;
+                                        renderer.write_line(&format!("switched to prompt '{}'", prompt_name), LineColor::AgentText)?;
                                         if !cli.no_session
                                             && let Err(e) = crate::session::storage::save_session(session)
                                         {
                                             renderer.write_line(
                                                 &format!("warning: failed to save session: {}", e),
-                                                C_ERROR,
+                                                LineColor::Error,
                                             )?;
                                         }
                                     } else {
-                                        renderer.write_line(&format!("error: unknown prompt '{}'", prompt_name), C_ERROR)?;
+                                        renderer.write_line(&format!("error: unknown prompt '{}'", prompt_name), LineColor::Error)?;
                                     }
                                 }
                             }
@@ -943,9 +935,9 @@ pub async fn run_interactive(
                             if text.starts_with('/') {
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("> {}", safe_line), LineColor::PromptMarker)?;
                                 }
-                                renderer.write_line("", Color::White)?;
+                                renderer.write_line("", LineColor::AgentText)?;
                                 #[cfg(feature = "mcp")]
                                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
                                 // `/btw` is handled earlier in the bypass-slot (it
@@ -976,7 +968,7 @@ pub async fn run_interactive(
                                             #[cfg(feature = "mcp")] mcp_ref,
                                         ).await;
                                         if let Err(e) = compress_result {
-                                            renderer.write_line(&format!("compress error: {}", e), C_ERROR)?;
+                                            renderer.write_line(&format!("compress error: {}", e), LineColor::Error)?;
                                         }
                                         let _ = crate::session::storage::save_session(session);
                                     }
@@ -1070,7 +1062,7 @@ pub async fn run_interactive(
                                             render_session(&mut renderer, session, cli, cfg, context)?;
                                             renderer.write_line(
                                                 &format!("returned to main repo at {}", main_path),
-                                                C_AGENT,
+                                                LineColor::AgentText,
                                             )?;
                                         }
                                     }
@@ -1113,13 +1105,13 @@ pub async fn run_interactive(
                                         let _ = crossterm::ExecutableCommand::execute(&mut stdout, crossterm::event::EnableMouseCapture);
                                         let _ = crossterm::terminal::enable_raw_mode();
                                         render_session(&mut renderer, session, cli, cfg, context)?;
-                                        renderer.write_line(&format!("returned from editing {}", path), C_AGENT)?;
+                                        renderer.write_line(&format!("returned from editing {}", path), LineColor::AgentText)?;
                                     }
                                     Err(e) => {
                                         if e.downcast_ref::<std::io::Error>().is_some_and(|e: &std::io::Error| e.kind() == std::io::ErrorKind::Interrupted) {
                                             break;
                                         }
-                                        renderer.write_line(&format!("error: {}", e), C_ERROR)?;
+                                        renderer.write_line(&format!("error: {}", e), LineColor::Error)?;
                                     }
                                     Ok(_) => {
                                         if !cli.no_session
@@ -1127,7 +1119,7 @@ pub async fn run_interactive(
                                         {
                                             renderer.write_line(
                                                 &format!("warning: failed to save session: {}", e),
-                                                C_ERROR,
+                                                LineColor::Error,
                                             )?;
                                         }
                                         #[cfg(feature = "loop")]
@@ -1156,7 +1148,7 @@ pub async fn run_interactive(
                                 {
                                     renderer.write_line(
                                         &format!("warning: failed to save session: {}", e),
-                                        C_ERROR,
+                                        LineColor::Error,
                                     )?;
                                 }
                             } else if text.starts_with('!') {
@@ -1164,9 +1156,9 @@ pub async fn run_interactive(
                                 if !cmd.is_empty() {
                                     for line in text.lines() {
                                         let safe_line = sanitize_output(line);
-                                        renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                        renderer.write_line(&format!("> {}", safe_line), LineColor::PromptMarker)?;
                                     }
-                                    renderer.write_line("", Color::White)?;
+                                    renderer.write_line("", LineColor::AgentText)?;
 
                                     let cmd_owned = cmd.to_string();
                                     let output = tokio::task::spawn_blocking(move || {
@@ -1195,10 +1187,10 @@ pub async fn run_interactive(
                                         let safe_line = sanitize_output(line);
                                         renderer.write_line(
                                             &safe_line,
-                                            if output.status.success() { C_AGENT } else { C_ERROR },
+                                            if output.status.success() { LineColor::AgentText } else { LineColor::Error },
                                         )?;
                                     }
-                                    renderer.write_line("", Color::White)?;
+                                    renderer.write_line("", LineColor::AgentText)?;
 
                                     session.add_message(MessageRole::User, &text);
                                     session.add_message(MessageRole::Assistant, &result);
@@ -1211,14 +1203,14 @@ pub async fn run_interactive(
                                         );
                                     }
                                 } else {
-                                    renderer.write_line("error: empty command after '!'", C_ERROR)?;
+                                    renderer.write_line("error: empty command after '!'", LineColor::Error)?;
                                 }
                             } else {
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("> {}", safe_line), LineColor::PromptMarker)?;
                                 }
-                                renderer.write_line("", Color::White)?;
+                                renderer.write_line("", LineColor::AgentText)?;
 
                                 // Guaranteed not running here (the is_running gate
                                 // above returns early), so this never orphans a run.
@@ -1304,9 +1296,9 @@ pub async fn run_interactive(
                     main_abort = None;
                     if let Some(next) = pending_inputs.pop_front() {
                         for line in next.lines() {
-                            renderer.write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
+                            renderer.write_line(&format!("> {}", sanitize_output(line)), LineColor::PromptMarker)?;
                         }
-                        renderer.write_line("", Color::White)?;
+                        renderer.write_line("", LineColor::AgentText)?;
                         start_main_run(
                             &next, &mut agent, &client, session, cli, cfg, context,
                             &permission, &ask_tx, &sandbox, reasoning_enabled,
@@ -1340,16 +1332,16 @@ pub async fn run_interactive(
                         btw_total_out = btw_total_out.saturating_add(output_tokens);
                         btw_abort.retain(|(i, _)| *i != id);
                         btw_inflight = btw_inflight.saturating_sub(1);
-                        renderer.write_line(&format!("[btw #{}] answer:", id), C_BTW)?;
+                        renderer.write_line(&format!("[btw #{}] answer:", id), LineColor::ByTheWay)?;
                         for line in response.lines() {
-                            renderer.write_line(&sanitize_output(line), C_AGENT)?;
+                            renderer.write_line(&sanitize_output(line), LineColor::AgentText)?;
                         }
-                        renderer.write_line("", Color::White)?;
+                        renderer.write_line("", LineColor::AgentText)?;
                     }
                     crate::event::BtwEvent::Error { id, message } => {
                         btw_abort.retain(|(i, _)| *i != id);
                         btw_inflight = btw_inflight.saturating_sub(1);
-                        renderer.write_line(&format!("[btw #{}] error: {}", id, sanitize_output(&message)), C_ERROR)?;
+                        renderer.write_line(&format!("[btw #{}] error: {}", id, sanitize_output(&message)), LineColor::Error)?;
                     }
                 }
                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
@@ -1375,7 +1367,7 @@ pub async fn run_interactive(
                 "auto-merging worktree '{}' into '{}'...",
                 info.branch, target
             ),
-            C_AGENT,
+            LineColor::AgentText,
         );
         let (state, outcome) = crate::extras::git_worktree::try_merge(&info, &target);
         match outcome {
@@ -1389,13 +1381,13 @@ pub async fn run_interactive(
                     Ok(()) => {
                         let _ = renderer.write_line(
                             &format!("merged '{}' into '{}' and cleaned up", info.branch, target),
-                            C_AGENT,
+                            LineColor::AgentText,
                         );
                     }
                     Err(e) => {
                         let _ = renderer.write_line(
                             &format!("merge succeeded but cleanup failed: {}", e),
-                            C_ERROR,
+                            LineColor::Error,
                         );
                     }
                 }
@@ -1403,13 +1395,15 @@ pub async fn run_interactive(
             crate::extras::git_worktree::MergeOutcome::Conflicts(files) => {
                 let _ = renderer.write_line(
                     &format!("merge conflict in {} file(s):", files.len()),
-                    C_ERROR,
+                    LineColor::Error,
                 );
                 for f in &files {
-                    let _ = renderer.write_line(&format!("  {}", f), C_ERROR);
+                    let _ = renderer.write_line(&format!("  {}", f), LineColor::Error);
                 }
-                let _ = renderer
-                    .write_line("Keep conflict state for manual resolution? [y/N] ", C_PERM);
+                let _ = renderer.write_line(
+                    "Keep conflict state for manual resolution? [y/N] ",
+                    LineColor::Permission,
+                );
 
                 let abort = loop {
                     tokio::select! {
@@ -1427,19 +1421,22 @@ pub async fn run_interactive(
 
                 if abort {
                     let _ = crate::extras::git_worktree::cancel_merge(&state);
-                    let _ = renderer.write_line("merge aborted, restored original state", C_AGENT);
+                    let _ = renderer.write_line(
+                        "merge aborted, restored original state",
+                        LineColor::AgentText,
+                    );
                 } else {
                     let _ = renderer.write_line(
                         &format!(
                             "conflict state left in {} for manual resolution",
                             info.main_repo_path.display()
                         ),
-                        C_AGENT,
+                        LineColor::AgentText,
                     );
                 }
             }
             crate::extras::git_worktree::MergeOutcome::Error(e) => {
-                let _ = renderer.write_line(&format!("merge failed: {}", e), C_ERROR);
+                let _ = renderer.write_line(&format!("merge failed: {}", e), LineColor::Error);
             }
         }
     }

--- a/src/ui/permission_handler.rs
+++ b/src/ui/permission_handler.rs
@@ -1,13 +1,10 @@
-use crossterm::style::Color;
 use tokio::sync::mpsc;
 
 use crate::cli::Cli;
 use crate::event::UserEvent;
 use crate::session::Session;
-use crate::ui::renderer::Renderer;
+use crate::ui::renderer::{LineColor, Renderer};
 use crate::ui::utils::suggest_pattern;
-
-use super::C_PERM;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_permission_request(
@@ -21,17 +18,17 @@ pub async fn handle_permission_request(
 ) -> anyhow::Result<()> {
     *was_reasoning = false;
     if *agent_line_started {
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", LineColor::AgentText)?;
         *agent_line_started = false;
     }
 
     renderer.write_line(
         &format!("[permission] {}: {}", ask_req.tool, ask_req.input),
-        C_PERM,
+        LineColor::Permission,
     )?;
     renderer.write_line(
         "  (y) allow once  (a) allow always  (n) deny  (ESC) abort",
-        C_PERM,
+        LineColor::Permission,
     )?;
 
     let decision = loop {
@@ -44,7 +41,7 @@ pub async fn handle_permission_request(
                             let pattern = suggest_pattern(&ask_req.tool, &ask_req.input);
                             renderer.write_line(
                                 &format!("  -> will allow: {}", pattern),
-                                Color::Green,
+                                LineColor::Success,
                             )?;
                             break crate::permission::ask::UserDecision::AllowAlways(pattern);
                         }
@@ -65,7 +62,7 @@ pub async fn handle_permission_request(
     if let Some(pattern) = allow_pattern {
         renderer.write_line(
             &format!("  allowed {} {} (saved to session)", ask_req.tool, pattern),
-            Color::Green,
+            LineColor::Success,
         )?;
         session
             .permission_allowlist

--- a/src/ui/pickers/file.rs
+++ b/src/ui/pickers/file.rs
@@ -8,7 +8,7 @@ use crossterm::cursor::MoveTo;
 use crossterm::style::{Color, ResetColor, SetForegroundColor};
 use crossterm::terminal::Clear;
 
-use super::super::utils::resolve_color;
+use super::super::utils::{UiColors, resolve_color};
 
 pub struct FilePicker {
     pub active: bool,
@@ -20,6 +20,7 @@ pub struct FilePicker {
     monochrome: bool,
     loading: bool,
     walk_done: Arc<AtomicBool>,
+    colors: UiColors,
 }
 
 impl FilePicker {
@@ -32,6 +33,7 @@ impl FilePicker {
             selected: 0,
             file_cache: Arc::new(Mutex::new(Vec::new())),
             monochrome: false,
+            colors: UiColors::default_colors(),
             loading: false,
             walk_done: Arc::new(AtomicBool::new(false)),
         }
@@ -39,6 +41,10 @@ impl FilePicker {
 
     pub fn set_monochrome(&mut self, monochrome: bool) {
         self.monochrome = monochrome;
+    }
+
+    pub fn set_colors(&mut self, colors: UiColors) {
+        self.colors = colors;
     }
 
     fn color(&self, color: Color) -> Color {
@@ -180,7 +186,7 @@ impl FilePicker {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkGrey))
+                SetForegroundColor(self.color(self.colors.picker_secondary))
             )?;
             write!(stdout, "scanning files...")?;
             write!(stdout, "{}", ResetColor)?;
@@ -194,7 +200,7 @@ impl FilePicker {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkGrey))
+                SetForegroundColor(self.color(self.colors.picker_secondary))
             )?;
             write!(stdout, "no matches")?;
             write!(stdout, "{}", ResetColor)?;
@@ -231,13 +237,17 @@ impl FilePicker {
                 .collect();
 
             if i == self.selected {
-                write!(stdout, "{}", SetForegroundColor(self.color(Color::Green)))?;
+                write!(
+                    stdout,
+                    "{}",
+                    SetForegroundColor(self.color(self.colors.picker_selected))
+                )?;
                 write!(stdout, "▸ {}", truncated)?;
             } else {
                 write!(
                     stdout,
                     "{}",
-                    SetForegroundColor(self.color(Color::DarkGrey))
+                    SetForegroundColor(self.color(self.colors.picker_secondary))
                 )?;
                 write!(stdout, "  {}", truncated)?;
             }

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -1,4 +1,5 @@
 use super::draw_picker_list;
+use crate::ui::utils::UiColors;
 
 const COMMANDS: &[&str] = &[
     "/add",
@@ -49,6 +50,7 @@ pub struct ListPicker {
     pub selected: usize,
     items: Vec<String>,
     monochrome: bool,
+    colors: UiColors,
 }
 
 impl ListPicker {
@@ -61,6 +63,7 @@ impl ListPicker {
             selected: 0,
             items: Vec::new(),
             monochrome: false,
+            colors: UiColors::default_colors(),
         }
     }
 
@@ -149,6 +152,10 @@ impl ListPicker {
         self.matches.get(self.selected).map(|s| s.as_str())
     }
 
+    pub fn set_colors(&mut self, colors: UiColors) {
+        self.colors = colors;
+    }
+
     pub fn draw(&self, empty_message: Option<&str>) -> std::io::Result<()> {
         if !self.active {
             return Ok(());
@@ -159,6 +166,7 @@ impl ListPicker {
             self.monochrome,
             empty_message,
             4,
+            &self.colors,
         )
     }
 }

--- a/src/ui/pickers/mod.rs
+++ b/src/ui/pickers/mod.rs
@@ -7,10 +7,10 @@ use std::io::Write;
 
 use crossterm::ExecutableCommand;
 use crossterm::cursor::MoveTo;
-use crossterm::style::{Color, ResetColor, SetForegroundColor};
+use crossterm::style::{ResetColor, SetForegroundColor};
 use crossterm::terminal::Clear;
 
-use super::utils::resolve_color;
+use super::utils::{UiColors, resolve_color};
 
 pub(crate) fn fuzzy_score(item: &str, query: &str) -> Option<i32> {
     if query.is_empty() {
@@ -72,6 +72,7 @@ pub(crate) fn draw_picker_list(
     monochrome: bool,
     empty_message: Option<&str>,
     bottom_reserved: u16,
+    colors: &UiColors,
 ) -> std::io::Result<()> {
     let (cols, rows) = crossterm::terminal::size()?;
     let mut stdout = std::io::stdout();
@@ -81,7 +82,7 @@ pub(crate) fn draw_picker_list(
     if matches.is_empty() {
         let r = rows.saturating_sub(3);
         stdout.execute(MoveTo(0, r))?;
-        let color = resolve_color(Color::DarkGrey, monochrome);
+        let color = resolve_color(colors.picker_secondary, monochrome);
         write!(stdout, "{}", SetForegroundColor(color))?;
         write!(stdout, "{}", empty_message.unwrap_or("no matches"))?;
         write!(stdout, "{}", ResetColor)?;
@@ -117,14 +118,14 @@ pub(crate) fn draw_picker_list(
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(resolve_color(Color::Green, monochrome))
+                SetForegroundColor(resolve_color(colors.picker_selected, monochrome))
             )?;
             write!(stdout, "▸ {}", truncated)?;
         } else {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(resolve_color(Color::DarkGrey, monochrome))
+                SetForegroundColor(resolve_color(colors.picker_secondary, monochrome))
             )?;
             write!(stdout, "  {}", truncated)?;
         }

--- a/src/ui/pickers/models.rs
+++ b/src/ui/pickers/models.rs
@@ -5,7 +5,7 @@ use crossterm::cursor::MoveTo;
 use crossterm::style::{Color, ResetColor, SetForegroundColor};
 use crossterm::terminal::Clear;
 
-use super::super::utils::resolve_color;
+use super::super::utils::{UiColors, resolve_color};
 use super::{draw_picker_list, fuzzy_score};
 
 pub struct ModelsPicker {
@@ -18,6 +18,7 @@ pub struct ModelsPicker {
     provider: Vec<String>,
     pub group: usize,
     monochrome: bool,
+    colors: UiColors,
 }
 
 impl ModelsPicker {
@@ -32,6 +33,7 @@ impl ModelsPicker {
             provider: Vec::new(),
             group: 0,
             monochrome: false,
+            colors: UiColors::default_colors(),
         }
     }
 
@@ -42,6 +44,10 @@ impl ModelsPicker {
     pub fn set_groups(&mut self, quick: Vec<String>, provider: Vec<String>) {
         self.quick = quick;
         self.provider = provider;
+    }
+
+    pub fn set_colors(&mut self, colors: UiColors) {
+        self.colors = colors;
     }
 
     fn color(&self, color: Color) -> Color {
@@ -166,7 +172,7 @@ impl ModelsPicker {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkGrey))
+                SetForegroundColor(self.color(self.colors.picker_secondary))
             )?;
             write!(
                 stdout,
@@ -177,6 +183,13 @@ impl ModelsPicker {
             write!(stdout, "{}", ResetColor)?;
         }
 
-        draw_picker_list(&self.matches, self.selected, self.monochrome, None, 5)
+        draw_picker_list(
+            &self.matches,
+            self.selected,
+            self.monochrome,
+            None,
+            5,
+            &self.colors,
+        )
     }
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -46,6 +46,7 @@ impl LineColor {
             LineColor::CodeBlock => colors.code_block,
             LineColor::LinkText => colors.link_text,
             LineColor::PromptMarker => colors.prompt_marker,
+
         }
     }
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -10,12 +10,50 @@ use crossterm::terminal::{Clear, ClearType, ScrollUp};
 use smallvec::{SmallVec, smallvec};
 
 use super::markdown::word_wrap;
-use super::utils::{char_display_width, display_width, resolve_color};
+use super::utils::{UiColors, char_display_width, display_width, resolve_color};
+
+/// Semantic color role stored in the buffer. Resolved to a concrete `Color`
+/// at render time via `UiColors`, so theme switches take effect immediately
+/// without re-writing the buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LineColor {
+    AgentText,
+    Error,
+    ToolCall,
+    Permission,
+    ByTheWay,
+    Reasoning,
+    Secondary,
+    Success,
+    Heading,
+    CodeBlock,
+    LinkText,
+    PromptMarker,
+}
+
+impl LineColor {
+    pub fn resolve(&self, colors: &UiColors) -> Color {
+        match self {
+            LineColor::AgentText => colors.agent_text,
+            LineColor::Error => colors.error,
+            LineColor::ToolCall => colors.tool_call,
+            LineColor::Permission => colors.permission,
+            LineColor::ByTheWay => colors.by_the_way,
+            LineColor::Reasoning => colors.reasoning,
+            LineColor::Secondary => colors.secondary,
+            LineColor::Success => colors.success,
+            LineColor::Heading => colors.heading,
+            LineColor::CodeBlock => colors.code_block,
+            LineColor::LinkText => colors.link_text,
+            LineColor::PromptMarker => colors.prompt_marker,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct LineEntry {
     pub text: CompactString,
-    pub color: Color,
+    pub color: LineColor,
 }
 
 pub struct Renderer {
@@ -24,7 +62,7 @@ pub struct Renderer {
     spinner_tick: bool,
     buffer: Vec<LineEntry>,
     partial: CompactString,
-    partial_color: Color,
+    partial_color: LineColor,
     scroll_offset: usize,
     input_scroll_offset: usize,
     monochrome: bool,
@@ -35,6 +73,7 @@ pub struct Renderer {
     pub selection_start: Option<usize>,
     pub selection_end: Option<usize>,
     prev_input_height: usize,
+    colors: UiColors,
 }
 
 impl Renderer {
@@ -45,7 +84,7 @@ impl Renderer {
             spinner_tick: false,
             buffer: Vec::new(),
             partial: CompactString::new(""),
-            partial_color: Color::White,
+            partial_color: LineColor::AgentText,
             scroll_offset: 0,
             input_scroll_offset: 0,
             monochrome: false,
@@ -56,6 +95,7 @@ impl Renderer {
             selection_start: None,
             selection_end: None,
             prev_input_height: 0,
+            colors: UiColors::default_colors(),
         })
     }
 
@@ -63,15 +103,15 @@ impl Renderer {
         self.monochrome = monochrome;
     }
 
-    pub fn set_background_colors(
-        &mut self,
-        chat_bg: Option<Color>,
-        input_bg: Option<Color>,
-        status_bg: Option<Color>,
-    ) {
-        self.chat_bg = chat_bg;
-        self.input_bg = input_bg;
-        self.status_bg = status_bg;
+    pub fn colors(&self) -> &UiColors {
+        &self.colors
+    }
+
+    pub fn set_colors(&mut self, colors: UiColors) {
+        self.chat_bg = colors.chat_background;
+        self.input_bg = colors.input_background;
+        self.status_bg = colors.status_background;
+        self.colors = colors;
     }
 
     fn color(&self, color: Color) -> Color {
@@ -192,7 +232,7 @@ impl Renderer {
             for chunk in self.wrap_line(&self.partial, max_width) {
                 self.buffer.push(LineEntry {
                     text: chunk,
-                    color: c,
+                    color: c.clone(),
                 });
             }
             self.partial.clear();
@@ -303,7 +343,11 @@ impl Renderer {
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
                 }
-                write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
+                write!(
+                    stdout,
+                    "{}",
+                    SetForegroundColor(self.color(entry.color.resolve(&self.colors)))
+                )?;
                 write!(stdout, "{}", chunk)?;
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
@@ -342,7 +386,7 @@ impl Renderer {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkYellow))
+                SetForegroundColor(self.color(self.colors.scroll_indicator))
             )?;
             write!(stdout, "{}", indicator)?;
             write!(stdout, "{}", ResetColor)?;
@@ -390,7 +434,7 @@ impl Renderer {
         }
     }
 
-    pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
+    pub fn write_line(&mut self, text: &str, color: LineColor) -> io::Result<()> {
         self.commit_partial();
         let max_width = self.max_line_width();
         for segment in text.split('\n') {
@@ -398,7 +442,7 @@ impl Renderer {
             for chunk in &wrapped {
                 self.buffer.push(LineEntry {
                     text: chunk.clone(),
-                    color,
+                    color: color.clone(),
                 });
                 if self.scroll_offset == 0 {
                     self.ensure_room();
@@ -409,7 +453,11 @@ impl Renderer {
                         write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                     }
                     write!(stdout, "{}", Clear(ClearType::CurrentLine))?;
-                    write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
+                    write!(
+                        stdout,
+                        "{}",
+                        SetForegroundColor(self.color(color.resolve(&self.colors)))
+                    )?;
                     writeln!(stdout, "{}", chunk)?;
                     write!(stdout, "{}", ResetColor)?;
                     self.lines = self.lines.saturating_add(1);
@@ -423,7 +471,7 @@ impl Renderer {
         Ok(())
     }
 
-    pub fn write(&mut self, text: &str, color: Color) -> io::Result<()> {
+    pub fn write(&mut self, text: &str, color: LineColor) -> io::Result<()> {
         if text.is_empty() {
             return Ok(());
         }
@@ -439,13 +487,13 @@ impl Renderer {
                 self.commit_partial();
                 let had_content = len_before < self.buffer.len();
                 if !segment.is_empty() {
-                    self.partial_color = color;
+                    self.partial_color = color.clone();
                     self.partial.push_str(segment);
                     self.commit_partial();
                 } else if !had_content {
                     self.buffer.push(LineEntry {
                         text: CompactString::new(""),
-                        color,
+                        color: color.clone(),
                     });
                 }
                 if self.scroll_offset == 0 {
@@ -457,7 +505,11 @@ impl Renderer {
                         write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                     }
                     if !segment.is_empty() {
-                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
+                        write!(
+                            stdout,
+                            "{}",
+                            SetForegroundColor(self.color(color.resolve(&self.colors)))
+                        )?;
                         write!(stdout, "{}", segment)?;
                         write!(stdout, "{}", ResetColor)?;
                     }
@@ -505,7 +557,7 @@ impl Renderer {
                         }
                     }
                     let chunk: String = chars[idx..end].iter().collect();
-                    self.partial_color = color;
+                    self.partial_color = color.clone();
                     self.partial.push_str(&chunk);
                     if self.scroll_offset == 0 {
                         self.ensure_room();
@@ -515,7 +567,11 @@ impl Renderer {
                         if let Some(bg) = self.chat_bg {
                             write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                         }
-                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
+                        write!(
+                            stdout,
+                            "{}",
+                            SetForegroundColor(self.color(color.resolve(&self.colors)))
+                        )?;
                         write!(stdout, "{}", chunk)?;
                         write!(stdout, "{}", ResetColor)?;
 
@@ -652,7 +708,11 @@ impl Renderer {
             }
 
             if i == first_visible {
-                write!(stdout, "{}", SetForegroundColor(self.color(Color::Cyan)))?;
+                write!(
+                    stdout,
+                    "{}",
+                    SetForegroundColor(self.color(self.colors.prompt_marker))
+                )?;
                 write!(stdout, "{}", prompt)?;
                 write!(stdout, "{}", SetForegroundColor(Color::Reset))?;
             } else {
@@ -699,7 +759,13 @@ impl Renderer {
         write!(
             stdout,
             "{}",
-            SetForegroundColor(self.color(Color::DarkGrey))
+            SetForegroundColor(
+                self.color(
+                    self.colors
+                        .status_foreground
+                        .unwrap_or(self.colors.secondary)
+                )
+            )
         )?;
         let status_display = if self.scroll_offset > 0 {
             format!("-- SCROLL -- {}", status)

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -121,21 +121,10 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             ctx.context.current_theme_name = None;
             let _ = storage::save_theme_name(None);
             if let Some(colors) = &ctx.cfg.colors {
-                let chat_bg = colors
-                    .chat_background
-                    .as_deref()
-                    .and_then(crate::ui::utils::parse_color);
-                let input_bg = colors
-                    .input_background
-                    .as_deref()
-                    .and_then(crate::ui::utils::parse_color);
-                let status_bg = colors
-                    .status_background
-                    .as_deref()
-                    .and_then(crate::ui::utils::parse_color);
                 ctx.renderer
-                    .set_background_colors(chat_bg, input_bg, status_bg);
+                    .set_colors(crate::ui::utils::UiColors::from_config(colors));
             }
+
             write_ok(ctx.renderer, "theme cleared (using config colors)");
         }
     } else {
@@ -144,6 +133,7 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             ctx.context.current_theme_name = Some(name.to_string());
             let _ = storage::save_theme_name(Some(name));
             crate::context::themes::apply(content, ctx.renderer);
+
             write_ok(ctx.renderer, format!("active theme: {}", name));
         } else {
             write_error(ctx.renderer, format!("unknown theme: '{}'", name));

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -123,8 +123,11 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             if let Some(colors) = &ctx.cfg.colors {
                 ctx.renderer
                     .set_colors(crate::ui::utils::UiColors::from_config(colors));
+            } else {
+                ctx.renderer
+                    .set_colors(crate::ui::utils::UiColors::default_colors());
             }
-
+            ctx.input.set_colors(ctx.renderer.colors().clone());
             write_ok(ctx.renderer, "theme cleared (using config colors)");
         }
     } else {
@@ -133,7 +136,7 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             ctx.context.current_theme_name = Some(name.to_string());
             let _ = storage::save_theme_name(Some(name));
             crate::context::themes::apply(content, ctx.renderer);
-
+            ctx.input.set_colors(ctx.renderer.colors().clone());
             write_ok(ctx.renderer, format!("active theme: {}", name));
         } else {
             write_error(ctx.renderer, format!("unknown theme: '{}'", name));

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -22,11 +22,7 @@ use crate::sandbox::Sandbox;
 use crate::session::{MessageRole, Session};
 use crate::ui::events::render_session;
 use crate::ui::input::InputEditor;
-use crate::ui::renderer::Renderer;
-
-pub(crate) const C_AGENT: crossterm::style::Color = crossterm::style::Color::White;
-pub(crate) const C_RESULT: crossterm::style::Color = crossterm::style::Color::DarkGrey;
-pub(crate) const C_ERROR: crossterm::style::Color = crossterm::style::Color::Red;
+use crate::ui::renderer::{LineColor, Renderer};
 
 pub struct SlashCtx<'a> {
     pub agent: &'a mut Option<AnyAgent>,
@@ -102,15 +98,15 @@ impl SlashCtx<'_> {
 }
 
 pub(crate) fn write_ok(renderer: &mut Renderer, msg: impl std::fmt::Display) {
-    let _ = renderer.write_line(&msg.to_string(), C_AGENT);
+    let _ = renderer.write_line(&msg.to_string(), LineColor::AgentText);
 }
 
 pub(crate) fn write_result(renderer: &mut Renderer, msg: impl std::fmt::Display) {
-    let _ = renderer.write_line(&msg.to_string(), C_RESULT);
+    let _ = renderer.write_line(&msg.to_string(), LineColor::Secondary);
 }
 
 pub(crate) fn write_error(renderer: &mut Renderer, msg: impl std::fmt::Display) {
-    let _ = renderer.write_line(&msg.to_string(), C_ERROR);
+    let _ = renderer.write_line(&msg.to_string(), LineColor::Error);
 }
 
 pub fn undo_last(session: &mut Session) -> usize {
@@ -153,15 +149,18 @@ pub async fn handle_compress(
     sandbox: &Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
 ) -> anyhow::Result<()> {
-    renderer.write_line("compressing...", C_AGENT)?;
-    renderer.write_line("", crossterm::style::Color::White)?;
+    renderer.write_line("compressing...", LineColor::AgentText)?;
+    renderer.write_line("", LineColor::AgentText)?;
 
     let reserve = cfg.resolve_reserve_tokens();
     let keep_recent = cfg.resolve_keep_recent_tokens();
     let max_tokens = session.context_window.saturating_sub(reserve);
 
     if session.total_estimated_tokens <= max_tokens {
-        renderer.write_line("context within limits, no compression needed", C_AGENT)?;
+        renderer.write_line(
+            "context within limits, no compression needed",
+            LineColor::AgentText,
+        )?;
         return Ok(());
     }
 
@@ -176,7 +175,10 @@ pub async fn handle_compress(
     }
 
     if cut_idx == 0 {
-        renderer.write_line("nothing to compress (entire context is recent)", C_AGENT)?;
+        renderer.write_line(
+            "nothing to compress (entire context is recent)",
+            LineColor::AgentText,
+        )?;
         return Ok(());
     }
 
@@ -221,7 +223,10 @@ pub async fn handle_compress(
         )
         .await,
     );
-    renderer.write_line("prompt cleared (back to default behavior)", C_AGENT)?;
+    renderer.write_line(
+        "prompt cleared (back to default behavior)",
+        LineColor::AgentText,
+    )?;
 
     render_session(renderer, session, cli, cfg, context)?;
     renderer.write_line(
@@ -229,7 +234,7 @@ pub async fn handle_compress(
             "compressed {} messages (saved ~{} tokens)",
             cut_idx, tokens_before,
         ),
-        C_AGENT,
+        LineColor::AgentText,
     )?;
 
     Ok(())

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,3 +1,4 @@
+use crate::config::ColorsConfig;
 use crossterm::style::Color;
 use unicode_width::UnicodeWidthStr;
 
@@ -59,6 +60,13 @@ pub(crate) fn parse_color(s: &str) -> Option<Color> {
         "white" => Some(Color::White),
         "grey" | "gray" => Some(Color::Grey),
         _ => {
+            if let Some(num) = s.strip_prefix("ansi:") {
+                if let Ok(n) = num.parse::<u8>() {
+                    return Some(Color::AnsiValue(n));
+                }
+                // Value > 255 or invalid
+                return None;
+            }
             if let Some(hex) = s.strip_prefix('#')
                 && hex.len() == 6
                 && let (Ok(r), Ok(g), Ok(b)) = (
@@ -158,5 +166,223 @@ pub(crate) fn suggest_pattern(tool: &str, input: &str) -> String {
             format!("{}*", first)
         }
         _ => "*".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_color_ansi_valid() {
+        assert_eq!(parse_color("ansi:7"), Some(Color::AnsiValue(7)));
+        assert_eq!(parse_color("ansi:0"), Some(Color::AnsiValue(0)));
+        assert_eq!(parse_color("ansi:255"), Some(Color::AnsiValue(255)));
+    }
+
+    #[test]
+    fn parse_color_ansi_invalid() {
+        assert_eq!(parse_color("ansi:256"), None);
+        assert_eq!(parse_color("ansi:abc"), None);
+        assert_eq!(parse_color("ansi:-1"), None);
+        assert_eq!(parse_color("ansi:"), None);
+    }
+
+    #[test]
+    fn parse_color_ansi_whitespace_case() {
+        assert_eq!(parse_color(" ANSI:42 "), Some(Color::AnsiValue(42)));
+    }
+}
+
+/// Resolved theme colors used throughout the TUI.
+///
+/// Each field is a concrete `Color` resolved from `ColorsConfig` string values
+/// via `parse_color`, falling back to the built-in default when the config
+/// field is `None` or unparseable.
+#[derive(Debug, Clone)]
+
+pub(crate) struct UiColors {
+    // Background
+    pub chat_background: Option<Color>,
+    pub input_background: Option<Color>,
+    pub status_background: Option<Color>,
+
+    // Semantic foreground
+    pub agent_text: Color,
+    pub error: Color,
+    pub tool_call: Color,
+    pub permission: Color,
+    pub by_the_way: Color,
+    pub reasoning: Color,
+    pub secondary: Color,
+    pub success: Color,
+    pub heading: Color,
+    pub code_block: Color,
+    pub link_text: Color,
+    pub prompt_marker: Color,
+    pub status_foreground: Option<Color>,
+    pub scroll_indicator: Color,
+    pub picker_secondary: Color,
+    pub picker_selected: Color,
+}
+
+impl UiColors {
+    /// Default color scheme (matches the existing hard-coded constants).
+    pub(crate) const fn default_colors() -> Self {
+        Self {
+            chat_background: None,
+            input_background: None,
+            status_background: None,
+            agent_text: Color::White,
+            error: Color::Red,
+            tool_call: Color::Yellow,
+            permission: Color::Magenta,
+            by_the_way: Color::Cyan,
+            reasoning: Color::DarkGrey,
+            secondary: Color::DarkGrey,
+            success: Color::Green,
+            heading: Color::Cyan,
+            code_block: Color::DarkYellow,
+            link_text: Color::DarkCyan,
+            prompt_marker: Color::Green,
+            status_foreground: None,
+            scroll_indicator: Color::DarkGrey,
+            picker_secondary: Color::DarkGrey,
+            picker_selected: Color::Green,
+        }
+    }
+
+    /// Resolve all colors from a `ColorsConfig`, falling back to defaults.
+    pub fn from_config(cfg: &ColorsConfig) -> Self {
+        let defaults = Self::default_colors();
+        Self {
+            chat_background: cfg.chat_background.as_deref().and_then(parse_color),
+            input_background: cfg.input_background.as_deref().and_then(parse_color),
+            status_background: cfg.status_background.as_deref().and_then(parse_color),
+            agent_text: cfg
+                .agent_text
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.agent_text),
+            error: cfg
+                .error
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.error),
+            tool_call: cfg
+                .tool_call
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.tool_call),
+            permission: cfg
+                .permission
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.permission),
+            by_the_way: cfg
+                .by_the_way
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.by_the_way),
+            reasoning: cfg
+                .reasoning
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.reasoning),
+            secondary: cfg
+                .secondary
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.secondary),
+            success: cfg
+                .success
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.success),
+            heading: cfg
+                .heading
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.heading),
+            code_block: cfg
+                .code_block
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.code_block),
+            link_text: cfg
+                .link_text
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.link_text),
+            prompt_marker: cfg
+                .prompt_marker
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.prompt_marker),
+            status_foreground: cfg.status_foreground.as_deref().and_then(parse_color),
+            scroll_indicator: cfg
+                .scroll_indicator
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.scroll_indicator),
+            picker_secondary: cfg
+                .picker_secondary
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.picker_secondary),
+            picker_selected: cfg
+                .picker_selected
+                .as_deref()
+                .and_then(parse_color)
+                .unwrap_or(defaults.picker_selected),
+        }
+    }
+}
+
+#[cfg(test)]
+mod ui_colors_tests {
+    use super::*;
+
+    #[test]
+    fn from_config_empty() {
+        let cfg = ColorsConfig::default();
+        let colors = UiColors::from_config(&cfg);
+        let defaults = UiColors::default_colors();
+        assert_eq!(colors.agent_text, defaults.agent_text);
+        assert_eq!(colors.error, defaults.error);
+        assert_eq!(colors.tool_call, defaults.tool_call);
+        assert_eq!(colors.permission, defaults.permission);
+        assert_eq!(colors.by_the_way, defaults.by_the_way);
+        assert_eq!(colors.chat_background, None);
+        assert_eq!(colors.status_foreground, None);
+    }
+
+    #[test]
+    fn from_config_overrides() {
+        let mut cfg = ColorsConfig::default();
+        cfg.agent_text = Some(compact_str::CompactString::from("red"));
+        cfg.error = Some(compact_str::CompactString::from("ansi:202"));
+        cfg.chat_background = Some(compact_str::CompactString::from("#1a1a2e"));
+        let colors = UiColors::from_config(&cfg);
+        assert_eq!(colors.agent_text, Color::Red);
+        assert_eq!(colors.error, Color::AnsiValue(202));
+        assert_eq!(
+            colors.chat_background,
+            Some(Color::Rgb {
+                r: 0x1a,
+                g: 0x1a,
+                b: 0x2e
+            })
+        );
+    }
+
+    #[test]
+    fn from_config_invalid_falls_back() {
+        let mut cfg = ColorsConfig::default();
+        cfg.agent_text = Some(compact_str::CompactString::from("notacolor"));
+        cfg.tool_call = Some(compact_str::CompactString::from("ansi:999"));
+        let colors = UiColors::from_config(&cfg);
+        assert_eq!(colors.agent_text, Color::White);
+        assert_eq!(colors.tool_call, Color::Yellow);
     }
 }


### PR DESCRIPTION
This PR:

- Adds support for full 8-bit (0-255) ANSI color codes in theme configuration at all (rather than requiring truecolor/hex codes/named colors)
- Allows reconfiguring/overriding the colors of all foreground elements in the UI (using ANSI color codes or truecolor/hex), rather than using eg. hardcoded `CYAN` for some UI element. The prior hardcoded colors are now just defaults that can be overridden.

I squashed the commit log down a good bit from the tiny chunks that once existed, but if you prefer I split this back out into more chunks than exist, just let me know!