### PR TITLE
Opt-in mid-turn compaction with a hard ceiling

### DIFF
--- a/docs/COMPACTION_PLAN.md
+++ b/docs/COMPACTION_PLAN.md
@@ -1,0 +1,177 @@
+# Mid-Turn Compaction — Design Notes
+
+Status: implemented on branch `pr/mid-turn-compaction`. Phase 1 (observability) in commit `a32a622`; phase 2 (the config-gated trigger) follows. Captured 2026-06-01, revised 2026-06-14 after maintainer (gi-dellav) feedback on Matrix.
+
+## Revision log
+
+**2026-06-14 (gi-dellav, Matrix):**
+
+- **Drop the soft limit.** Two thresholds (soft plus hard) are too complex. Keep a single hard limit only.
+- **Make the hard limit a config setting, default off.** If the user does not set a value, mid-turn compaction does not run at all; the pre-existing between-turn behavior is unchanged. Setting a value opts in: compaction fires when real mid-turn prompt pressure crosses that percentage. Docs recommend **80%** as a reasonable starting value.
+- **Keep the current summarization technique;** it is fine as is. The motivation for opting in at all is avoiding context rot in long contexts (see <https://garrit.xyz/posts/2026-05-06-dont-trust-large-context-windows>); a tighter, user-chosen ceiling keeps the live prompt small enough that the model still attends to it.
+
+**2026-06-14 (implementation):**
+
+- **`compact_enabled` is the master switch.** Confirmed not redundant: it gates the existing between-turn check (`event_handler.rs`, on `Done`, against the session text-token estimate) and now also gates mid-turn. When `compact_enabled = false`, nothing compacts. When `true`, mid-turn additionally fires if `mid_turn_compact_threshold` is a valid fraction in `(0.0, 1.0]`. The two levers are complementary: between-turn catches cross-turn history accumulation; mid-turn catches a single turn's in-flight tool traffic, which never enters the session estimate and so is invisible to the between-turn check.
+- **Continuation prompt is a Rust `const`, not `prompts/auto-compact-continue.md`.** Every `.md` under `prompts/` is loaded as a user-selectable mode (`src/context/prompts.rs`), so a file there would pollute the `/prompt` picker. A `const MID_TURN_CONTINUE_PROMPT` in `src/ui/mod.rs` is truer to "hardcoded, no config override" and avoids the picker. Single template; the narrow-tool-calls urgency line is always included (any mid-turn fire means the ceiling was hit).
+- **Clean abort boundary = the over-threshold `CompletionCall`.** At that point the model's just-returned tool calls have not executed yet, so aborting leaves no half-applied edits. The dominant pressure relief is that the respawn rebuilds history from the session (`convert_history`), dropping the aborted run's in-flight tool context; `handle_compress` is an additional step that no-ops when the session text history is itself under the limit.
+- **Best-effort continuity.** Tool interactions live only in the runner and never reach the session, so before respawning we commit a recap built from `turn_trace` (a capped/truncated digest) plus any partial response text, as an Assistant message. This is lossy when a long turn overflows `turn_trace`'s cap; acceptable for v1, revisit if continuity proves weak.
+- **Runaway guard / hard stop.** A single `awaiting_compaction_relief` flag is set when we compact+respawn. If the *next* provider call is still over the ceiling, compaction provably cannot free enough space (the irreducible floor — system prompt, tool schemas, kept-recent transcript, reserved response — exceeds the budget), so `stop_turn_context_exhausted` aborts the turn rather than looping compact→respawn→compact forever. It prints the full arithmetic (context window, ceiling tokens and %, post-compaction prompt tokens and %, overflow, `reserve_tokens`, `keep_recent_tokens`) and concrete options (raise `context_window`/KV cache, raise the threshold above the shown %, lower `keep_recent_tokens`/`reserve_tokens`, or use a bigger-context model). If instead the post-compaction call comes back under the ceiling, the flag clears and a later accumulation in the same turn may compact again — so the flag distinguishes "compaction failed" from "fresh growth," and only the former is fatal.
+
+## Problem
+
+On a local llama.cpp server with a fixed 32k KV cache, zerostack reliably grinds the context past the limit during a single user turn, causing llama.cpp to either error or silently set `truncated = 1` (which corrupts the conversation). Auto-compaction does exist but never gets a chance to fire mid-turn.
+
+## Current behavior
+
+- Compaction trigger lives in `src/ui/event_handler.rs:319-345`. It only runs when the agent emits `AgentEvent::Done`, i.e. after rig's whole multi-turn stream completes.
+- `Done` comes from `MultiTurnStreamItem::FinalResponse` in `src/agent/runner.rs:107-123`. Everything before that — tool calls, tool results, reasoning, token deltas — flows through but does not trigger any pressure check.
+- `session.total_estimated_tokens` (`src/session/mod.rs:65-67, 94-103`) is a local `len()/4` heuristic. It is updated by `add_message` only — which fires on user input and on `Done`, never on intermediate tool calls or results. Mid-turn the gauge is frozen.
+- `session.total_input_tokens` and `total_output_tokens` exist and are populated from `usage` at `Done`, but they're cumulative billing counters, not "what's in the next prompt."
+- Compaction is explicitly suppressed during `/loop` runs (`event_handler.rs:319`).
+
+## The key discovery
+
+rig already emits per-call usage. See `rig/crates/rig-core/src/agent/prompt_request/streaming.rs:45-66`:
+
+```rust
+pub enum MultiTurnStreamItem<R> {
+    StreamAssistantItem(...),
+    StreamUserItem(...),
+    CompletionCall(CompletionCall),   // <-- this fires per provider call
+    FinalResponse(FinalResponse),
+}
+
+pub struct CompletionCall {
+    pub call_index: usize,
+    pub usage: Option<Usage>,   // input_tokens / output_tokens
+}
+```
+
+zerostack's `src/agent/runner.rs:131` has `_ => {}` that silently discards this event. The mid-turn blind spot is not a rig limitation — it's a missing match arm.
+
+## Plan (ordered)
+
+### 1. Tool output bounding at the tool boundary [START HERE]
+
+The single biggest win and it requires no human in the loop. Cap large tool results before they enter rig's history.
+
+- Touches: `src/fs.rs`, `src/sandbox.rs`, the subagent tool wrappers.
+- Helper already exists: `src/extras/truncate.rs::truncate_cjk` — currently used only for subagent output. Extend / generalize.
+- **Unit:** tool-native (lines for file/shell, matches for grep, entries for find). Real prompt-token impact is observed separately via rig's `CompletionCall` events — see option (2).
+- **Cut shape:** head-only with a clear recovery hint. Simplest to implement, predictable behavior.
+- **Defaults** (hardcoded; no config exposure yet — revisit once we have operational experience):
+  - **File read:** first ~1000 lines, then `[truncated after 1000 lines — file is M lines total; re-call with a line range to see more]`.
+  - **Shell exec:** first ~200 lines, then `[truncated after 200 lines — N more lines elided; re-run with a narrower invocation or pipe through `tail`]`. Caveat: head-only loses trailing output (final test result, stack-trace bottom). Acceptable for v1; revisit if it bites.
+  - **Grep:** first ~50 matches, then `[truncated after 50 matches — M more matches total; narrow the pattern or restrict to a path]`.
+  - **Find / list_files:** first ~200 entries, then `[truncated after 200 entries — N more; narrow the glob or path]`.
+- The recovery hint is load-bearing — without it the agent retries the same call. Verify on the Qwen 3.6 model that the hints actually steer behavior.
+- **Postponed:** an optional fast-model summarization variant above a second threshold (~5000 tokens) would be more powerful but adds a per-fire round-trip. Revisit only if structural truncation proves insufficient.
+
+### 2. Auto-compact between rig iterations
+
+Use the `CompletionCall` event to track real prompt-token pressure and intervene between iterations (not mid-iteration — that corrupts state).
+
+- Add `AgentEvent::CompletionCall { input_tokens, output_tokens }` to `src/event.rs`.
+- Wire it in `src/agent/runner.rs` by replacing the `_ => {}` arm.
+- In `src/ui/event_handler.rs`, on receipt:
+  - `session.total_estimated_tokens = max(current, input_tokens + output_tokens)` so the status bar's `x/y (z%)` is honest.
+  - Evaluate compaction trigger.
+- **Pressure metric:** `pressure = last_input_tokens / context_window`, where `last_input_tokens` comes from the most recent `CompletionCall.usage` (real provider count, not the `len/4` estimate). `context_window` is the zerostack config value (24576 in current setup), already chosen with margin below the real KV cache (32k).
+- **Config-gated single hard limit** (per gi-dellav, 2026-06-14; no soft limit):
+  - New optional config field, e.g. `mid_turn_compact_threshold: Option<f64>` in `src/config/mod.rs`, expressed as a fraction (0.0 to 1.0). Sits alongside the existing `context_window` / `reserve_tokens` / `keep_recent_tokens` / `compact_enabled` fields and follows the same `Option<T>` plus `resolve_*` convention.
+  - **Default is unset (`None`) = off.** Unlike the other resolvers, this one must *not* substitute an enabling default: `resolve_mid_turn_compact_threshold(&self) -> Option<f64>` returns the option as-is. `None` means the mid-turn trigger never evaluates and behavior is exactly today's between-turn-only compaction.
+  - When `Some(t)`, the trigger is simply:
+    ```
+    should_compact_now = pressure > t
+    ```
+    No iteration counter, no second threshold. The status-bar `max(estimate, real)` update from phase 1 still happens unconditionally; only the *trigger* is gated on the config value being set.
+  - **Docs recommend 80%** (`0.80`) as a reasonable starting value. With `context_window = 24576` that is ~19.7k tokens, leaving headroom below the 32k KV cache. The recommendation goes in `docs/CONFIG.md`; the field stays unset in the default config so out-of-the-box behavior is unchanged.
+  - Validation lives in the resolver: `resolve_mid_turn_compact_threshold` returns `Some(t)` only for `t` in `(0.0, 1.0]`, else `None`. A value of `0` would compact constantly, so `<= 0` (and `> 1`) silently behave as unset rather than wedging the agent.
+- **As implemented:** the trigger is evaluated in the main UI event loop (`src/ui/mod.rs`) when an `AgentEvent::CompletionCall` arrives, gated on `is_running && !loop_running && !cli.no_session && resolve_compact_enabled() && context_window > 0 && resolve_mid_turn_compact_threshold().is_some()`. `pressure = input_tokens / context_window`. The clean abort boundary is the over-threshold `CompletionCall` itself (the model's just-returned tool calls have not executed, so no half-applied edits). `mid_turn_compact_and_respawn` then aborts the runner, records a progress recap, runs `handle_compress` on the session, and respawns via `spawn_runner(MID_TURN_CONTINUE_PROMPT, convert_history(session))`. Dropping the aborted run's in-flight tool context (absent from `convert_history`) is the dominant relief; `handle_compress` no-ops when the session text history is under its own limit.
+- **Continuation prompt** is a Rust `const MID_TURN_CONTINUE_PROMPT` in `src/ui/mod.rs`, *not* a `prompts/*.md` file: every `.md` under `prompts/` loads as a selectable `/prompt` mode, which a continuation template should not be. Hardcoded, no config override. Single template (the soft/hard variants are gone with the soft limit):
+
+  ```
+  [Context was compacted to save space; the full prior history is in the
+  system summary above.]
+
+  Continue with the user's original task. Do not redo work already completed
+  per the summary; focus on what remains. Context was tight, so prefer narrower
+  follow-up tool calls over wide ones until pressure subsides.
+  ```
+
+  The acknowledgement that compaction happened is deliberate: it lets the agent read the summary as "what I did," not as part of the user's new instructions. The narrow-tool-calls line is always included, since any mid-turn fire means the user-chosen ceiling was hit, so the urgency always applies.
+
+### 3. Subagent dispatch by default for context-hungry work
+
+Prompt-level change only — zerostack already has the infrastructure: the `task` tool (`src/extras/subagents/task_tool.rs`, name = `"task"`) and a built-in `EXPLORE_PROMPT` (`src/extras/subagents/prompt.rs`) for a read-only investigator.
+
+- The structural win is **fresh context**, not parallelism. A subagent that reads 20 files eats those 20 file reads in its own context and returns a 500-token summary; main agent's history grows by 500 tokens instead of 20,000.
+- **Files to edit:** `prompts/default.md`, `prompts/code.md`, `prompts/debug.md`, `prompts/refactor.md`, `prompts/review.md`, `prompts/review-security.md`. Skip `ask.md` (low-touch), `plan.md` (already terse), and the non-coding modes (`brainstorm.md`, `simplify.md`, `write-prompt.md`, `autoconfig.md`, `frontend-design.md`).
+- **Add a new section `## Subagent Dispatch`** (placed after `## Process`) with identical wording across all six prompts. **Hardened wording (v2)** after the v1 phrasing failed on Qwen 3.6 for an enumeration task ("List all test names in this project" — answered 285, actual 245, never reached for `task`):
+
+  ```
+  ## Subagent Dispatch
+
+  Delegate to the `task` tool whenever the answer requires
+  synthesizing across multiple search results. This includes:
+
+  - **Enumeration:** "list / count / find ALL X across the
+    codebase" — never assemble a count by adding up partial
+    grep results yourself; the subagent verifies completeness.
+  - **Cross-reference:** "where is X used", "how does Y work",
+    "what calls Z" — anything touching multiple files.
+  - **Investigation:** any question requiring more than one
+    grep/read to answer.
+
+  Reserve direct `read` / `grep` / `find_files` for known-
+  location work: editing a specific file, reading one
+  identified function, grepping for a literal you will act
+  on immediately.
+
+  **Anti-pattern:** running grep multiple times to find "all"
+  matches and synthesizing a count is unreliable — truncation,
+  overlapping regexes, and partial views all corrupt the
+  answer. Use `task` instead.
+  ```
+
+- Strong directive ("Delegate", "never assemble"). Identical wording across all six files so behavior is predictable when the user switches modes.
+- The `task` tool's own description ("Delegate a MULTI-STEP read-only investigation... NOT for single-step operations") backstops the prompt guidance. Qwen weighed that description as describing the *number of tool calls*, not the *scope of synthesis* — the v2 wording targets the latter directly.
+- **v1 rationale lesson:** "anything touching ~3 files" let Qwen rationalize that a single `grep` call is one action regardless of internal file walks. v2 names the synthesis-from-partials failure mode explicitly so there's no semantic wiggle room.
+- **v2 rationale lesson:** even the hardened mode-prompt wording didn't move Qwen's behavior — it could *recite* the guidance and *agree* it should have followed it, but its decision-time tool selection still went around. Cause: **three contradictory sources** of guidance, with the restrictive ones earlier in context and marked CRITICAL:
+  1. `src/agent/prompt.rs::SYSTEM_PROMPT` line 16 (Read Operations section, CRITICAL): "Use the Task tool ONLY for specific multi-step investigations... Do NOT use it for single-step operations." — earliest, loudest.
+  2. `src/agent/prompt.rs::SYSTEM_PROMPT` line 26 (tool inventory): "Use ONLY when answering needs several file reads... NOT for single operations."
+  3. `src/extras/subagents/task_tool.rs::definition()` description: "Use ONLY when answering a question requires searching several files... Do NOT use for single-step operations."
+
+  When CRITICAL-marked early-context guidance contradicts later mode-prompt guidance, the model picks the loudest. **v3 affordance change:** rewrite all three sources to invite `task` use ("Search and investigate via a fresh-context subagent. Use for any cross-file question..."), and remove the negative-gating "ONLY"/"NOT for" language entirely. Mode prompts (v2 wording) stay aligned.
+
+- **Open question after v3:** if Qwen still doesn't reach for `task` on enumeration tasks despite all three sources being aligned and inviting, the next move is structural (option 2 mid-iteration auto-compact as backstop) rather than further prompt-engineering. Bound the prompt-tuning investment here.
+
+#### Interaction with llama.cpp slots
+
+Each slot is a separate KV cache; they share weights but not context memory.
+
+- **1 slot:** Subagent handoffs blow away the cached prefix on every switch. Full prefill cost per handoff (seconds on 35B-A3B). Still wins on structural grounds because subagent context is fresh.
+- **2 slots:** Main and subagent each hold their own warm KV. Handoffs cost nothing on the KV side.
+- **VRAM cost:** 2×32k roughly doubles KV cache memory budget. On 16 GB with 35B Q8 already partially offloaded, going to 2 slots means either lower per-slot context (~24k) or more layers to CPU.
+
+Recommendation: try 1 slot first with aggressive subagent dispatch. If prefill cost is painful, bump to 2 slots and accept per-slot context reduction.
+
+## Deferred / Rejected
+
+- **Soft limit (`iterations_since_last_compact >= K AND pressure > 0.65`).** Dropped 2026-06-14 per gi-dellav: two thresholds plus an iteration counter is more machinery than the problem warrants. A single user-set hard threshold is simpler to reason about and to document. If accumulating drag in long sessions turns out to matter, revisit, but only after the single-threshold version has operational time.
+- **Preemptive compaction at lower thresholds.** Doesn't fix the mid-turn problem — only changes between-turn headroom. A single turn can still blow whatever headroom you set. Possible small refinement on top of (1)+(2), not a primary lever.
+- **Tool-result deduplication.** Hash and dedupe identical tool results within a session. Real benefit (codebases re-read the same files constantly) but complex to implement correctly. Back burner.
+- **Status-bar warnings / human-in-the-loop signals.** Defeats the purpose of agentic coding. Rejected.
+
+## Hardware context
+
+- 4070 Ti Super, 16 GB VRAM.
+- Qwen 3.6 35B A3B MTP at Q8_0 (partial CPU offload).
+- llama.cpp KV cache: 32k. zerostack `context_window`: 24576 (deliberate margin against the `len()/4` undercount).
+- llama.cpp slots currently 1 (reduced from default 4 for VRAM). Willing to go to 2 if subagent dispatch warrants it.
+- zerostack config: `reserve_tokens=8192`, `keep_recent_tokens=6000`, `max_tokens=6144`, `max_agent_turns=16`. Mid-turn compaction is opt-in via `mid_turn_compact_threshold` (unset by default); recommended starting value is `0.80`.
+
+## Open questions to resolve before coding
+
+_All resolved._

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,6 +37,7 @@ Example (JSON):
   "reserve_tokens": 16384,
   "keep_recent_tokens": 10000,
   "compact_enabled": true,
+  "mid_turn_compact_threshold": 0.80,
   "deny_repeated_reads": false,
   "default_prompt": "code",
   "default_permission_mode": "standard",
@@ -100,6 +101,7 @@ context_window = 128000
 reserve_tokens = 16384
 keep_recent_tokens = 10000
 compact_enabled = true
+mid_turn_compact_threshold = 0.80
 edit_system = "similarity"
 default_prompt = "code"
 default_permission_mode = "standard"
@@ -150,7 +152,8 @@ Accepted top-level keys:
 | `keep_recent_tokens`      | integer | Approximate recent-token budget kept verbatim during compaction. Default: `10000`.                                                                                          |
 | `max_text_file_size`      | integer | Maximum allowed file size in bytes for read/write tool operations. Default: `1048576` (1 MB).                                                                               |
 | `deny_repeated_reads`     | boolean | Block repeated reads of the same file section within a session until the file is edited or written. Default: `true`. Set to `false` to allow re-reading.                     |
-| `compact_enabled`         | boolean | Enable automatic conversation compaction. Default: `true`.                                                                                                                  |
+| `compact_enabled`         | boolean | Master switch for all automatic conversation compaction (both between-turn and mid-turn). Default: `true`. When `false`, nothing is ever compacted automatically.            |
+| `mid_turn_compact_threshold` | number | Opt-in mid-turn compaction. Fraction of the context window (`0.0`–`1.0`) of real provider prompt pressure at which to compact *during* a turn, not just between turns. Unset by default, meaning no mid-turn compaction. Honored only when `compact_enabled` is `true`. Recommended starting value: `0.80`. See Mid-turn compaction below.            |
 | `always_show_welcome`     | boolean | Always show the welcome banner on startup, bypassing the one-shot marker file. Default: `false`.                                                                               |
 | `edit_system`             | string  | Edit system mode: `"similarity"` (SEARCH/REPLACE with fuzzy matching, default) or `"hashedit"` (CRC-32 tag-based CAS edits). See Edit System Modes below.                     |
 | `custom_providers`        | object  | Map of provider aliases to `{ "provider_type", "base_url", "api_key_env", "api_style", "headers", "danger_accept_invalid_certs", "timeout_secs" }`. `provider_type` must resolve to a built-in provider type; `api_key_env` is optional. For OpenAI providers, `api_style` selects `"responses"` or `"completions"`, `headers` sets custom HTTP headers (values support `${ENV_VAR}` expansion), and `timeout_secs` overrides the HTTP timeout. `danger_accept_invalid_certs` disables TLS verification. See the OpenAI API styles section below. |
@@ -176,6 +179,37 @@ Accepted top-level keys:
 | `acp_host`                | string  | TCP bind host for ACP server mode (equivalent to `--acp-host`).                                                                                                              |
 | `acp_port`                | integer | TCP bind port for ACP server mode (equivalent to `--acp-port`, default: 7243).                                                                                               |
 | `colors`                  | object  | Background color overrides for the TUI. See the colors section below.                                                                                                       |
+
+## Mid-turn compaction
+
+By default zerostack only compacts the conversation *between* turns, after a
+response finishes, when the accumulated session history exceeds
+`context_window - reserve_tokens`. A single long turn (many tool calls and large
+tool results) can still blow past the model's real context limit before that
+check ever runs, because the in-flight tool traffic never enters the session's
+token estimate.
+
+`mid_turn_compact_threshold` opts in to a second, *within-turn* check. On every
+provider call zerostack compares the real provider-reported prompt size against
+`context_window`; when the ratio crosses the threshold it stops the run at a
+clean boundary, compacts, and resumes the same task on the compacted history.
+
+- **Unset by default.** With no value set, behavior is unchanged: no mid-turn
+  compaction. Setting a value is the opt-in.
+- **Gated by `compact_enabled`.** `compact_enabled` is the master switch. If it
+  is `false`, `mid_turn_compact_threshold` is ignored and nothing compacts.
+- **Range.** A fraction in `(0.0, 1.0]`. An out-of-range value is ignored
+  (mid-turn compaction stays off) and zerostack prints a warning at startup
+  explaining the correct form, rather than failing silently. `0.80` is a
+  reasonable starting value; it leaves headroom below the
+  context window while still keeping the live prompt small enough to avoid the
+  attention degradation ("context rot") that large, full context windows suffer.
+
+```toml
+compact_enabled = true            # master switch (default true)
+context_window = 24576
+mid_turn_compact_threshold = 0.80 # compact mid-turn at 80% real prompt pressure
+```
 
 ## OpenAI API styles and custom headers
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -322,6 +322,17 @@ where
                         }
                         break;
                     }
+                    Ok(MultiTurnStreamItem::CompletionCall(call)) => {
+                        if let Some(usage) = call.usage {
+                            let _ = event_tx
+                                .send(AgentEvent::CompletionCall {
+                                    call_index: call.call_index,
+                                    input_tokens: usage.input_tokens,
+                                    output_tokens: usage.output_tokens,
+                                })
+                                .await;
+                        }
+                    }
                     Err(e) => {
                         let _ = event_tx
                             .send(AgentEvent::Error(CompactString::new(e.to_string())))

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -212,5 +212,23 @@ pub fn load() -> Config {
         cfg.mcp_servers = Some(defaults);
     }
 
+    // Validate the opt-in mid-turn compaction threshold once, here at load,
+    // rather than in `resolve_mid_turn_compact_threshold` (which runs per
+    // provider call in the hot path and would spam). Out-of-range values are
+    // ignored — mid-turn compaction simply stays off — but we say so loudly and
+    // explain the correct form instead of failing silently.
+    if let Some(t) = cfg.mid_turn_compact_threshold
+        && !(t > 0.0 && t <= 1.0)
+    {
+        eprintln!(
+            "warning: mid_turn_compact_threshold = {t} is out of range and will be ignored \
+             (mid-turn compaction disabled).\n\
+             It must be a fraction greater than 0 and at most 1, where the value is the \
+             fraction of the context window at which to compact during a turn \
+             (e.g. 0.80 = compact at 80%). Recommended starting value: 0.80. \
+             Remove the key to disable mid-turn compaction without this warning.",
+        );
+    }
+
     cfg
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,6 +68,12 @@ pub struct Config {
     // --- End subagent limits ---
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compact_enabled: Option<bool>,
+    /// Opt-in mid-turn compaction threshold, as a fraction of the context
+    /// window (0.0–1.0) of real provider prompt pressure. `None` (default)
+    /// disables mid-turn compaction entirely; the agent only compacts between
+    /// turns. Honored only when `compact_enabled` is also true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mid_turn_compact_threshold: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub always_show_welcome: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,6 +177,22 @@ impl Config {
 
     pub fn resolve_compact_enabled(&self) -> bool {
         self.compact_enabled.unwrap_or(true)
+    }
+
+    /// Mid-turn compaction pressure threshold as a fraction of the context
+    /// window. Unlike the other resolvers this one substitutes **no** enabling
+    /// default: `None` means the mid-turn trigger never fires (preserving the
+    /// historical between-turn-only behavior). Values outside `(0.0, 1.0]` are
+    /// treated as unset; [`load`](crate::config::load) warns about such values
+    /// once at startup, since this resolver runs in the per-call hot path and
+    /// must not log. The caller must additionally check
+    /// [`resolve_compact_enabled`](Self::resolve_compact_enabled), which is the
+    /// master switch for all compaction.
+    pub fn resolve_mid_turn_compact_threshold(&self) -> Option<f64> {
+        match self.mid_turn_compact_threshold {
+            Some(t) if t > 0.0 && t <= 1.0 => Some(t),
+            _ => None,
+        }
     }
 
     pub fn resolve_max_read_lines(&self) -> u64 {

--- a/src/event.rs
+++ b/src/event.rs
@@ -17,6 +17,15 @@ pub enum AgentEvent {
         args: serde_json::Value,
     },
     Error(CompactString),
+    /// Provider call finished mid-stream. Carries the real provider-reported
+    /// token usage for that call (when available). Used to update the
+    /// status-bar estimate and to drive mid-turn compaction decisions
+    /// independently of the local `len()/4` heuristic.
+    CompletionCall {
+        call_index: usize,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
     Done {
         response: CompactString,
         input_tokens: u64,

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -1,0 +1,66 @@
+use crate::config::Config;
+
+#[test]
+fn mid_turn_threshold_unset_by_default() {
+    let cfg = Config::default();
+    assert_eq!(cfg.resolve_mid_turn_compact_threshold(), None);
+}
+
+#[test]
+fn mid_turn_threshold_valid_value_passes_through() {
+    let cfg = Config {
+        mid_turn_compact_threshold: Some(0.80),
+        ..Config::default()
+    };
+    assert_eq!(cfg.resolve_mid_turn_compact_threshold(), Some(0.80));
+}
+
+#[test]
+fn mid_turn_threshold_upper_bound_inclusive() {
+    let cfg = Config {
+        mid_turn_compact_threshold: Some(1.0),
+        ..Config::default()
+    };
+    assert_eq!(cfg.resolve_mid_turn_compact_threshold(), Some(1.0));
+}
+
+#[test]
+fn mid_turn_threshold_out_of_range_treated_as_unset() {
+    // Zero would compact constantly; negatives and >1 are nonsense. All map to
+    // "unset" so a misconfigured value silently disables the feature rather
+    // than wedging the agent.
+    for bad in [0.0, -0.1, 1.5, 2.0] {
+        let cfg = Config {
+            mid_turn_compact_threshold: Some(bad),
+            ..Config::default()
+        };
+        assert_eq!(
+            cfg.resolve_mid_turn_compact_threshold(),
+            None,
+            "threshold {bad} should be treated as unset"
+        );
+    }
+}
+
+#[test]
+fn compact_enabled_default_true() {
+    // Master switch defaults on; mid-turn compaction layers on top of it.
+    assert!(Config::default().resolve_compact_enabled());
+}
+
+#[test]
+fn context_exhausted_report_math() {
+    // window 20000, threshold 0.80 -> ceiling 16000.
+    // prompt 18000 -> 90% of window, overflow 18000 - 16000 = 2000.
+    let lines = crate::ui::context_exhausted_report(18_000, 0.80, 20_000, 8_192, 6_000);
+    let joined = lines.join("\n");
+    assert!(joined.contains("context window .............. 20000 tokens"), "{joined}");
+    assert!(joined.contains("16000 tokens  (80% of window)"), "{joined}");
+    assert!(joined.contains("18000 tokens  (90% of window)"), "{joined}");
+    assert!(joined.contains("overflow above ceiling ...... 2000 tokens"), "{joined}");
+    assert!(joined.contains("reserved for response ....... 8192 tokens"), "{joined}");
+    assert!(joined.contains("kept-recent budget .......... 6000 tokens"), "{joined}");
+    // Guidance references the actual pressure and the floor the KV cache must hold.
+    assert!(joined.contains("raise mid_turn_compact_threshold above 90%"), "{joined}");
+    assert!(joined.contains("hold 18000+ tokens"), "{joined}");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,8 @@ mod btw_tests;
 #[cfg(test)]
 mod checker_tests;
 #[cfg(test)]
+mod config_tests;
+#[cfg(test)]
 mod crc_tests;
 #[cfg(test)]
 mod edit_tests;

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -290,6 +290,20 @@ pub async fn handle_agent_event(
             )
             .await?;
         }
+        AgentEvent::CompletionCall {
+            call_index: _,
+            input_tokens,
+            output_tokens,
+        } => {
+            // Real provider-reported usage for the call that just finished.
+            // The local len()/4 heuristic in session.total_estimated_tokens
+            // undercounts code-heavy turns; trust the real number as a floor
+            // so the status bar's x/y/% reflects what llama.cpp actually saw.
+            let real = input_tokens.saturating_add(output_tokens);
+            if real > session.total_estimated_tokens {
+                session.total_estimated_tokens = real;
+            }
+        }
         AgentEvent::Error(e) => {
             *was_reasoning = false;
             let safe = sanitize_output(&e);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -295,6 +295,255 @@ async fn start_main_run(
     }
 }
 
+/// Continuation prompt injected after a mid-turn compaction. Hardcoded as a
+/// `const` rather than a `prompts/*.md` file: every `.md` under `prompts/` is
+/// loaded as a selectable mode, so a file here would pollute the prompt picker.
+/// Acknowledging the compaction is deliberate — it frames the summary as "what
+/// I already did," not as new user instructions. The narrow-tool-calls line is
+/// always present because any mid-turn fire means the configured ceiling was
+/// hit, so the urgency always applies.
+const MID_TURN_CONTINUE_PROMPT: &str = "[Context was compacted to save space; \
+the full prior history is in the system summary above.]\n\nContinue with the \
+user's original task. Do not redo work already completed per the summary; focus \
+on what remains. Context was tight, so prefer narrower follow-up tool calls over \
+wide ones until pressure subsides.";
+
+/// Mid-turn auto-compaction (PR H). Invoked when real provider prompt pressure
+/// (`CompletionCall` usage / context window) crosses
+/// `mid_turn_compact_threshold`, and only when `compact_enabled` is true.
+///
+/// The in-flight run is aborted at the `CompletionCall` boundary — the model's
+/// just-returned tool calls have not executed yet, so nothing is left half
+/// applied. This turn's progress is recorded as a recap message (tool traffic
+/// lives only in the now-aborted runner and never reaches the session, so
+/// without this the agent would redo the turn), the session is compacted, and
+/// the agent is respawned on the compacted history with a continuation prompt.
+/// The dominant pressure relief is dropping the aborted run's in-flight tool
+/// context, which the respawn achieves even when the session itself is under the
+/// between-turn limit and `handle_compress` is a no-op.
+#[allow(clippy::too_many_arguments)]
+async fn mid_turn_compact_and_respawn(
+    pressure: f64,
+    renderer: &mut Renderer,
+    agent: &mut Option<AnyAgent>,
+    client: &mut AnyClient,
+    session: &mut Session,
+    cli: &Cli,
+    cfg: &Config,
+    context: &mut ContextFiles,
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    sandbox: &Sandbox,
+    reasoning_enabled: bool,
+    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
+    main_abort: &mut Option<tokio::task::AbortHandle>,
+    is_running: &mut bool,
+    status_signals: &Option<StatusSignals>,
+    turn_trace: &mut Vec<compact_str::CompactString>,
+    response_buf: &mut String,
+    response_start_line: &mut Option<usize>,
+    agent_line_started: &mut bool,
+    was_reasoning: &mut bool,
+    #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
+) -> anyhow::Result<()> {
+    // 1. Stop the in-flight run. bash children die via kill_on_drop.
+    if let Some(h) = main_abort.take() {
+        h.abort();
+    }
+    *is_running = false;
+    *agent_rx = None;
+    *was_reasoning = false;
+
+    // 2. Record progress so far. `turn_trace` is a capped/truncated digest, so
+    // this is best-effort continuity, paired with any partial response text.
+    let mut recap = String::new();
+    if !response_buf.trim().is_empty() {
+        recap.push_str(response_buf.trim());
+        recap.push_str("\n\n");
+    }
+    if !turn_trace.is_empty() {
+        recap.push_str("[Progress this turn before context compaction]\n");
+        for line in turn_trace.iter() {
+            recap.push_str(line);
+            recap.push('\n');
+        }
+    }
+    let recap = recap.trim();
+    if !recap.is_empty() {
+        session.add_message(MessageRole::Assistant, recap);
+    }
+    turn_trace.clear();
+    response_buf.clear();
+    *response_start_line = None;
+    *agent_line_started = false;
+
+    renderer.write_line(
+        &format!(
+            "mid-turn auto-compacting (context at {}%)...",
+            (pressure * 100.0).round() as u64
+        ),
+        Color::DarkGrey,
+    )?;
+
+    // 3. Compact the session (no-op if its text history is under the limit).
+    #[cfg(feature = "mcp")]
+    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
+    let compress_result = handle_compress(
+        None,
+        agent,
+        client,
+        renderer,
+        session,
+        cli,
+        cfg,
+        context,
+        reasoning_enabled,
+        permission,
+        ask_tx,
+        sandbox,
+        #[cfg(feature = "mcp")]
+        mcp_ref,
+    )
+    .await;
+    if let Err(e) = compress_result {
+        renderer.write_line(&format!("mid-turn compact error: {}", e), C_ERROR)?;
+    }
+
+    // 4. Respawn on the compacted history with the continuation prompt.
+    #[cfg(feature = "mcp")]
+    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
+    ensure_agent(
+        agent,
+        client,
+        session,
+        cli,
+        cfg,
+        context,
+        permission,
+        ask_tx,
+        sandbox,
+        reasoning_enabled,
+        #[cfg(feature = "mcp")]
+        mcp_ref,
+    )
+    .await;
+    let history = crate::agent::runner::convert_history(session);
+    let runner = agent
+        .as_ref()
+        .unwrap()
+        .clone()
+        .spawn_runner(MID_TURN_CONTINUE_PROMPT.to_string(), history);
+    *agent_rx = Some(runner.event_rx);
+    *main_abort = Some(runner.abort_handle);
+    *is_running = true;
+    if let Some(ss) = status_signals.as_ref() {
+        ss.send_start();
+    }
+    Ok(())
+}
+
+/// Hard stop for a turn whose context cannot be brought under the mid-turn
+/// ceiling even after a compaction. What remains is the irreducible floor
+/// (system prompt, tool schemas, kept-recent transcript, reserved response
+/// space), so compacting again is futile. Aborts the run and shows the user the
+/// full arithmetic — the model and context-window combination is simply too
+/// small to run the agentic loop on this task.
+#[allow(clippy::too_many_arguments)]
+fn stop_turn_context_exhausted(
+    prompt_tokens: u64,
+    threshold: f64,
+    renderer: &mut Renderer,
+    session: &Session,
+    cfg: &Config,
+    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
+    main_abort: &mut Option<tokio::task::AbortHandle>,
+    is_running: &mut bool,
+    status_signals: &Option<StatusSignals>,
+    turn_trace: &mut Vec<compact_str::CompactString>,
+    response_buf: &mut String,
+    response_start_line: &mut Option<usize>,
+    agent_line_started: &mut bool,
+    was_reasoning: &mut bool,
+) -> anyhow::Result<()> {
+    if let Some(h) = main_abort.take() {
+        h.abort();
+    }
+    *is_running = false;
+    *agent_rx = None;
+    *was_reasoning = false;
+    *agent_line_started = false;
+    turn_trace.clear();
+    response_buf.clear();
+    *response_start_line = None;
+    if let Some(ss) = status_signals.as_ref() {
+        ss.send_stop();
+    }
+
+    renderer.write_line("error: not enough context to continue this turn.", C_ERROR)?;
+    renderer.write_line(
+        "Compaction ran, but the next prompt was still over the mid-turn ceiling. \
+         Compacting again cannot help: what remains is the irreducible floor (system \
+         prompt, tool schemas, the kept-recent transcript, and reserved response \
+         space). Stopping the turn so the conversation is not corrupted.",
+        Color::White,
+    )?;
+    renderer.write_line("", Color::White)?;
+    for line in context_exhausted_report(
+        prompt_tokens,
+        threshold,
+        session.context_window,
+        cfg.resolve_reserve_tokens(),
+        cfg.resolve_keep_recent_tokens(),
+    ) {
+        renderer.write_line(&line, Color::White)?;
+    }
+    Ok(())
+}
+
+/// Builds the math-and-guidance body for a context-exhaustion stop. Pure (no
+/// I/O) so the arithmetic can be unit-tested. `window` must be non-zero (the
+/// caller only reaches here after gating on `context_window > 0`).
+pub(crate) fn context_exhausted_report(
+    prompt_tokens: u64,
+    threshold: f64,
+    window: u64,
+    reserve: u64,
+    keep_recent: u64,
+) -> Vec<String> {
+    let ceiling = (threshold * window as f64) as u64;
+    let pressure_pct = prompt_tokens as f64 / window as f64 * 100.0;
+    let overflow = prompt_tokens.saturating_sub(ceiling);
+    vec![
+        format!("  context window .............. {window} tokens"),
+        format!(
+            "  mid-turn ceiling ............ {ceiling} tokens  ({:.0}% of window)",
+            threshold * 100.0
+        ),
+        format!(
+            "  prompt after compaction ..... {prompt_tokens} tokens  ({pressure_pct:.0}% of window)"
+        ),
+        format!("  overflow above ceiling ...... {overflow} tokens"),
+        format!("  reserved for response ....... {reserve} tokens"),
+        format!("  kept-recent budget .......... {keep_recent} tokens"),
+        String::new(),
+        "This model and context-window combination is too small to run zerostack's \
+         agentic loop on this task. To proceed you can:"
+            .to_string(),
+        "  - increase context_window (and the model server's real KV cache) so the \
+         window clears the floor above;"
+            .to_string(),
+        format!(
+            "  - raise mid_turn_compact_threshold above {pressure_pct:.0}% so this prompt \
+             fits under the ceiling (trades safety for room: the real KV cache must still \
+             hold {prompt_tokens}+ tokens);"
+        ),
+        "  - lower keep_recent_tokens or reserve_tokens to shrink the floor;".to_string(),
+        "  - switch to a model/server with a larger context window, or split the task \
+         into smaller pieces."
+            .to_string(),
+    ]
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_interactive(
     mut client: AnyClient,
@@ -382,6 +631,12 @@ pub async fn run_interactive(
     // session itself only records the final assistant text per turn).
     let mut turn_trace: Vec<compact_str::CompactString> = Vec::new();
     const TURN_TRACE_MAX: usize = 64;
+    // True between a mid-turn compaction and the next provider call. If that
+    // call is *still* over the ceiling, compaction failed to free space and the
+    // turn is stopped (see `stop_turn_context_exhausted`); if it comes back
+    // under, relief worked and the flag clears so a later accumulation can
+    // compact again. Reset at every turn boundary.
+    let mut awaiting_compaction_relief = false;
     let mut dot_prompt_restore: Option<String> = None;
 
     let perm_mode = || -> Option<String> {
@@ -626,6 +881,7 @@ pub async fn run_interactive(
                                 }
                                 agent_rx = None;
                                 turn_trace.clear();
+                                awaiting_compaction_relief = false;
                                 pending_inputs.clear();
                                 #[cfg(feature = "loop")]
                                 if let Some(ref mut ls) = loop_state {
@@ -1281,8 +1537,64 @@ pub async fn run_interactive(
                             )));
                         }
                     }
-                    AgentEvent::Done { .. } | AgentEvent::Error(_) => turn_trace.clear(),
+                    AgentEvent::Done { .. } | AgentEvent::Error(_) => {
+                        turn_trace.clear();
+                        awaiting_compaction_relief = false;
+                    }
                     _ => {}
+                }
+                // Mid-turn compaction (PR H). On a provider-call boundary, if
+                // real prompt pressure crossed the opt-in threshold, abort the
+                // run cleanly, compact, and respawn on the compacted history.
+                // Gated by `compact_enabled` (master switch) and suppressed in
+                // /loop runs and `--no-session` mode (which never compact).
+                #[cfg(feature = "loop")]
+                let loop_running = loop_state.as_ref().is_some_and(|ls| ls.active);
+                #[cfg(not(feature = "loop"))]
+                let loop_running = false;
+                if let AgentEvent::CompletionCall { input_tokens, .. } = &event
+                    && is_running
+                    && !loop_running
+                    && !cli.no_session
+                    && cfg.resolve_compact_enabled()
+                    && session.context_window > 0
+                    && let Some(threshold) = cfg.resolve_mid_turn_compact_threshold()
+                {
+                    let pressure = *input_tokens as f64 / session.context_window as f64;
+                    if pressure > threshold {
+                        if awaiting_compaction_relief {
+                            // We already compacted this turn and the very next
+                            // provider call is STILL over the ceiling — the floor
+                            // exceeds the budget, so compacting again is futile.
+                            // Stop the turn and show the user the arithmetic.
+                            stop_turn_context_exhausted(
+                                *input_tokens, threshold, &mut renderer, session, cfg,
+                                &mut agent_rx, &mut main_abort, &mut is_running,
+                                &status_signals, &mut turn_trace, &mut response_buf,
+                                &mut response_start_line, &mut agent_line_started,
+                                &mut was_reasoning,
+                            )?;
+                            awaiting_compaction_relief = false;
+                        } else {
+                            mid_turn_compact_and_respawn(
+                                pressure, &mut renderer, &mut agent, &mut client, session,
+                                cli, cfg, context, &permission, &ask_tx, &sandbox,
+                                reasoning_enabled, &mut agent_rx, &mut main_abort,
+                                &mut is_running, &status_signals, &mut turn_trace,
+                                &mut response_buf, &mut response_start_line,
+                                &mut agent_line_started, &mut was_reasoning,
+                                #[cfg(feature = "mcp")] &mut mcp_manager,
+                            ).await?;
+                            awaiting_compaction_relief = true;
+                        }
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                        continue;
+                    } else {
+                        // A provider call came back under the ceiling: either we
+                        // never compacted, or the compaction worked. Either way a
+                        // later accumulation is allowed to compact afresh.
+                        awaiting_compaction_relief = false;
+                    }
                 }
                 #[cfg(feature = "mcp")]
                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;


### PR DESCRIPTION
Closes #109.

Adds an opt-in lever to compact the conversation *during* a turn, not just between turns, so a single long turn can't silently overrun a fixed context window (e.g. llama.cpp's KV cache).

## Commits

1. **Wire mid-turn token observability via rig `CompletionCall`** — forwards real provider-reported usage mid-stream and uses it as a floor for the status-bar estimate (observability only; no behavior change).
2. **Add opt-in mid-turn compaction with a hard ceiling** — the trigger that acts on it.

## Behavior

- New config key `mid_turn_compact_threshold` (fraction of the context window). **Unset by default → no behavior change.** Gated by the existing `compact_enabled` master switch.
- When set and enabled: on an over-threshold `CompletionCall`, abort the run at that clean boundary (the model's just-returned tool calls haven't executed, so no half-applied edits), record a turn-progress recap, compact, and respawn on the compacted history with a hardcoded continuation prompt. The dominant relief is dropping the aborted run's in-flight tool context, which never enters the session estimate.
- **Runaway guard:** if the next provider call after a compaction is still over the ceiling, compacting again is futile, so the turn is stopped with the full arithmetic (window, ceiling, post-compaction prompt, overflow, reserve, kept-recent) and concrete options. A relief flag distinguishes "compaction failed" from later fresh growth, so a healthy long turn can still compact again.
- Out-of-range threshold values are ignored with a one-time startup warning (the resolver runs per call and must not log).

## Design notes

Single hard threshold (no soft limit); current summarization technique unchanged. Full rationale and the implementation decisions (const continuation prompt vs. a `prompts/*.md` mode file, the abort boundary, continuity caveats) are in `docs/COMPACTION_PLAN.md`.

## Testing

`cargo test` (278 pass), `cargo build` and `cargo clippy` clean (no new warnings). Added unit tests for threshold validation and the exhaustion-report arithmetic. The hard-stop guard's wiring is unit-tested at the arithmetic level; tripping it end-to-end needs a genuinely too-small `context_window` and hasn't been exercised against a live server yet.