### PR TITLE
fix: improve CJK token estimation and calibrate context size with real usage

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -66,7 +66,29 @@ pub struct Session {
 
 impl Session {
     pub fn estimate_tokens(text: &str) -> u64 {
-        (text.len() as u64 / 4).max(1)
+        let mut wide: u64 = 0;
+        let mut narrow: u64 = 0;
+        for ch in text.chars() {
+            if Self::is_wide_char(ch) {
+                wide += 1;
+            } else {
+                narrow += 1;
+            }
+        }
+        // wide * 0.9 + narrow / 4, min 1
+        ((wide * 9 / 10) + narrow / 4).max(1)
+    }
+
+    fn is_wide_char(ch: char) -> bool {
+        matches!(ch as u32,
+            0x1100..=0x11FF |   // Hangul Jamo
+            0x2E80..=0x9FFF |   // CJK radicals/Kangxi/punctuation/kana/Unified+ExtA
+            0xA000..=0xA4CF |   // Yi
+            0xAC00..=0xD7A3 |   // Hangul Syllables
+            0xF900..=0xFAFF |   // CJK Compatibility Ideographs
+            0xFF00..=0xFFEF |   // Halfwidth/Fullwidth Forms
+            0x20000..=0x3FFFF   // Supplementary Ideographic Plane (Ext B–F)
+        )
     }
 
     pub fn new(provider: &str, model: &str, context_window: u64) -> Self {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -164,6 +164,36 @@ impl Session {
             .sum();
         self.calibrated_tokens.saturating_add(delta)
     }
+    
+    /// Pick the compaction boundary: `messages[..cut]` get summarized and
+    /// `messages[cut..]` are kept as recent context. Walks backward summing
+    /// per-message `estimated_tokens` until `keep_recent` is covered.
+    ///
+    /// This deliberately stays in the per-message estimate scale rather than
+    /// the calibrated total: it is a *relative* comparison among messages (how
+    /// far back does `keep_recent` reach), so any uniform estimator bias
+    /// cancels out. Calibration only matters for the absolute total in
+    /// `effective_context_tokens`.
+    ///
+    /// Returns 0 ("nothing old enough to summarize") when every message fits
+    /// within `keep_recent`. The initial value is 0, not `messages.len()`, so
+    /// an oversized `keep_recent` keeps the recent messages instead of
+    /// summarizing the entire history, a case made reachable now that the
+    /// compaction gate measures context against real usage (system prompt and
+    /// context files can push the real total over budget while the messages
+    /// themselves stay small).
+    pub fn select_compaction_cut(messages: &[SessionMessage], keep_recent: u64) -> usize {
+        let mut accumulated = 0u64;
+        let mut cut_idx = 0;
+        for (i, msg) in messages.iter().enumerate().rev() {
+            if accumulated >= keep_recent {
+                cut_idx = i + 1;
+                break;
+            }
+            accumulated = accumulated.saturating_add(msg.estimated_tokens);
+        }
+        cut_idx
+    }
 
     pub fn needs_compaction(&self, reserve_tokens: u64) -> bool {
         if self.context_window == 0 {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -50,6 +50,10 @@ pub struct Session {
     pub total_cost: f64,
     pub total_estimated_tokens: u64,
     #[serde(default)]
+    pub calibrated_tokens: u64,
+    #[serde(default)]
+    pub calibrated_msg_count: usize,
+    #[serde(default)]
     pub input_token_cost: f64,
     #[serde(default)]
     pub output_token_cost: f64,
@@ -104,6 +108,8 @@ impl Session {
             total_output_tokens: 0,
             total_cost: 0.0,
             total_estimated_tokens: 0,
+            calibrated_tokens: 0,
+            calibrated_msg_count: 0,
             input_token_cost: 0.0,
             output_token_cost: 0.0,
             context_window,
@@ -134,11 +140,36 @@ impl Session {
         std::mem::take(&mut self.pending_media)
     }
 
+    pub fn set_calibration(&mut self, input_tokens: u64, output_tokens: u64) {
+        if input_tokens == 0 {
+            return;
+        }
+        self.calibrated_tokens = input_tokens.saturating_add(output_tokens);
+        self.calibrated_msg_count = self.messages.len();
+    }
+
+    pub fn reset_calibration(&mut self) {
+        self.calibrated_tokens = 0;
+        self.calibrated_msg_count = 0;
+    }
+
+    pub fn effective_context_tokens(&self) -> u64 {
+        if self.calibrated_tokens == 0 {
+            return self.total_estimated_tokens;
+        }
+        let start = self.calibrated_msg_count.min(self.messages.len());
+        let delta: u64 = self.messages[start..]
+            .iter()
+            .map(|m| m.estimated_tokens)
+            .sum();
+        self.calibrated_tokens.saturating_add(delta)
+    }
+
     pub fn needs_compaction(&self, reserve_tokens: u64) -> bool {
         if self.context_window == 0 {
             return false;
         }
-        self.total_estimated_tokens > self.context_window.saturating_sub(reserve_tokens)
+        self.effective_context_tokens() > self.context_window.saturating_sub(reserve_tokens)
     }
 
     pub fn update_context_window(&mut self, cw: u64) {
@@ -178,6 +209,10 @@ impl Session {
             token_savings,
             created_at: CompactString::new(chrono::Utc::now().to_rfc3339()),
         });
+
+        // Compaction reindexes messages, so the calibration anchor no longer
+        // lines up. Drop it; the next completed turn re-anchors.
+        self.reset_calibration();
 
         // Adjust all compaction first_kept indices for the removed messages
         // (since we never have >1 compaction with the current simple approach, this is fine)

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -1,4 +1,4 @@
-use crate::session::{MessageRole, Session, SessionMessage};
+use crate::session::{MessageRole, Session};
 
 #[test]
 fn estimate_tokens_empty() {
@@ -26,6 +26,35 @@ fn estimate_tokens_rounds_down() {
 fn estimate_tokens_long() {
     assert_eq!(Session::estimate_tokens(&"x".repeat(100)), 25);
 }
+
+#[test]
+fn estimate_tokens_cjk_not_undercounted_like_chars_div4() {
+    let text = "今天天氣很好真開心"; // 9 chars
+    let est = Session::estimate_tokens(text);
+    assert_eq!(est, 8); // 9 * 9 / 10 = 8
+    assert!(est > (text.chars().count() as u64 / 4));
+}
+
+#[test]
+fn estimate_tokens_mixed_cjk_and_latin() {
+    let text = "請幫我 refactor this function 好嗎";
+    let wide = text
+        .chars()
+        .filter(|c| {
+            let o = *c as u32;
+            (0x2E80..=0x9FFF).contains(&o)
+        })
+        .count() as u64;
+    let est = Session::estimate_tokens(text);
+    assert!(est >= wide * 9 / 10);
+}
+
+#[test]
+fn estimate_tokens_pure_ascii_matches_old_formula() {
+    let text = "the quick brown fox jumps over the lazy dog";
+    assert_eq!(Session::estimate_tokens(text), text.len() as u64 / 4);
+}
+
 
 #[test]
 fn new_session_has_id() {

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -84,6 +84,46 @@ fn calibration_ignores_zero_usage() {
     assert_eq!(s.effective_context_tokens(), s.total_estimated_tokens);
 }
 
+// Helper: a session with `n` ASCII messages of `len` chars each, so every
+// message has a predictable estimated_tokens == len/4.
+fn session_with_messages(n: usize, len: usize) -> Session {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    for _ in 0..n {
+        s.add_message(MessageRole::User, &"x".repeat(len));
+    }
+    s
+}
+
+#[test]
+fn compaction_cut_keeps_recent_within_budget() {
+    // 4 messages × 10 tokens = 40 total. keep_recent=15 reaches back across
+    // the last two (20 tokens), so the first two are summarized.
+    let s = session_with_messages(4, 40);
+    assert_eq!(s.messages[0].estimated_tokens, 10);
+    assert_eq!(Session::select_compaction_cut(&s.messages, 15), 2);
+}
+
+#[test]
+fn compaction_cut_oversized_keep_recent_summarizes_nothing() {
+    // Regression: keep_recent (100) larger than the whole history (40) must
+    // keep the recent messages, NOT summarize everything (cut == 0, which the
+    // caller treats as "entire context is recent").
+    let s = session_with_messages(4, 40);
+    assert_eq!(Session::select_compaction_cut(&s.messages, 100), 0);
+}
+
+#[test]
+fn compaction_cut_zero_keep_recent_summarizes_all() {
+    let s = session_with_messages(4, 40);
+    assert_eq!(Session::select_compaction_cut(&s.messages, 0), 4);
+}
+
+#[test]
+fn compaction_cut_single_message_is_kept() {
+    let s = session_with_messages(1, 40); // 1 msg, 10 tokens
+    assert_eq!(Session::select_compaction_cut(&s.messages, 5), 0);
+}
+
 #[test]
 fn new_session_has_id() {
     let s = Session::new("openai", "gpt-4", 128000);

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -55,6 +55,34 @@ fn estimate_tokens_pure_ascii_matches_old_formula() {
     assert_eq!(Session::estimate_tokens(text), text.len() as u64 / 4);
 }
 
+#[test]
+fn effective_context_falls_back_without_calibration() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "hello world this is a test message");
+    assert_eq!(s.effective_context_tokens(), s.total_estimated_tokens);
+}
+
+#[test]
+fn effective_context_uses_calibration_anchor_plus_delta() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "first user message");
+    s.add_message(MessageRole::Assistant, "assistant reply");
+    s.set_calibration(5000, 200); // anchor = 5200, covers 2 messages
+    assert_eq!(s.calibrated_msg_count, 2);
+
+    s.add_message(MessageRole::User, "a follow up question");
+    let delta = Session::estimate_tokens("a follow up question");
+    assert_eq!(s.effective_context_tokens(), 5200 + delta);
+}
+
+#[test]
+fn calibration_ignores_zero_usage() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "msg");
+    s.set_calibration(0, 0);
+    assert_eq!(s.calibrated_tokens, 0);
+    assert_eq!(s.effective_context_tokens(), s.total_estimated_tokens);
+}
 
 #[test]
 fn new_session_has_id() {

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -365,6 +365,9 @@ async fn handle_agent_done(
         session.input_token_cost,
         session.output_token_cost,
     );
+    // Anchor context-size accounting to the provider's real usage.
+    // Must come after add_message so the anchor includes the just-appended response.
+    session.set_calibration(input_tokens, output_tokens);
     *agent_line_started = false;
     response_buf.clear();
     *response_start_line = None;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -183,15 +183,7 @@ pub async fn handle_compress(
         return Ok(());
     }
 
-    let mut accumulated = 0u64;
-    let mut cut_idx = session.messages.len();
-    for (i, msg) in session.messages.iter().enumerate().rev() {
-        if accumulated >= keep_recent {
-            cut_idx = i + 1;
-            break;
-        }
-        accumulated = accumulated.saturating_add(msg.estimated_tokens);
-    }
+    let cut_idx = crate::session::Session::select_compaction_cut(&session.messages, keep_recent);
 
     if cut_idx == 0 {
         renderer.write_line("nothing to compress (entire context is recent)", C_AGENT)?;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -178,7 +178,7 @@ pub async fn handle_compress(
     let keep_recent = cfg.resolve_keep_recent_tokens();
     let max_tokens = session.context_window.saturating_sub(reserve);
 
-    if session.total_estimated_tokens <= max_tokens {
+    if session.effective_context_tokens() <= max_tokens {
         renderer.write_line("context within limits, no compression needed", C_AGENT)?;
         return Ok(());
     }

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -136,6 +136,7 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
 async fn handle_clear(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     ctx.session.messages.clear();
     ctx.session.total_estimated_tokens = 0;
+    ctx.session.reset_calibration();
     ctx.session.compactions.clear();
     ctx.context.chain_declined.clear();
     render_session(ctx.renderer, ctx.session, ctx.cli, ctx.cfg, ctx.context)?;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -40,7 +40,7 @@ impl StatusLine {
 
         let ctx = session.context_window;
         let pct = if ctx > 0 {
-            (session.total_estimated_tokens * 100) / ctx
+            (session.effective_context_tokens() * 100) / ctx
         } else {
             0
         };


### PR DESCRIPTION
## Summary
This PR fixes context-size accounting to prevent severe token underestimation for CJK languages by introducing a character-width-based weighting heuristic. It also anchors the overall context size to the provider's actual usage tokens, applying the new heuristic only to recent message deltas. These changes ensure more accurate compaction triggers and UI reporting without affecting actual API billing.

## Background
The context-size accounting used a tokenizer-free `bytes / 4` heuristic for `estimate_tokens`. That works for Latin text (~1 byte/char, ~4 chars/token) but is fragile for CJK (Chinese, Japanese, Korean): it only lands in a sane range because a CJK codepoint is 3 UTF-8 bytes, giving ~0.75 tokens/char (the low end of the real range).
The obvious "fix" of swapping `len()` for `chars().count()` is a trap: it drops to ~0.25 tokens/char and underestimates CJK by ~3x. This PR addresses both the estimate itself and how it's used.

Billing is **not** affected: cost has always used the provider's exact `usage`, and the UI already hides token/cost when usage is absent. This is purely about context-window accounting (the compaction trigger and the status-bar percentage).

## What changed
- `estimate_tokens` now classifies each char as wide (CJK ideographs, kana, hangul, fullwidth forms) or narrow. Wide chars are weighted ~0.9 token each (slightly conservative, underestimating context delays compaction, which is worse than overestimating); narrow chars keep the `/4` rule. Pure-ASCII input yields the exact same number as before.
- Context size is now anchored to real usage. After each completed turn, `set_calibration` records the provider's `input + output` tokens as a high-water mark covering every message sent so far (system prompt and context files included). `effective_context_tokens()` returns that anchor plus an estimate of only the messages appended since — so the heuristic's error applies to the recent delta, not the whole history.
- `needs_compaction`, the status-bar percentage and the manual `/compress` gate all read `effective_context_tokens()`.
- The anchor is dropped on compaction (indices shift) and `/clear`, and a `0` usage report is ignored, so providers that don't return usage fall back to the running estimate.

## Estimate accuracy (fallback path)
This estimate is only load-bearing on the fallback path, eg, the first turn before an anchor exists, or providers that never report usage. Once calibration kicks in it applies only to the recent delta, so its error is heavily diluted.

The correction itself is modest: `bytes/4` gives ~0.75 tokens per CJK char, the weighting gives ~0.9, a ~20% upward nudge that holds across context lengths.
The point is that the fallback estimate is now defensible for CJK (it was sitting at the low end of the real range) without regressing ASCII, which is unchanged.

| Text type            | chars | `bytes/4` (before) | weighted (after) | actual ≈ |
|----------------------|------:|-------------------:|-----------------:|---------:|
| English              |    62 |                 15 |               15 |    14–18 |
| Chinese              |    25 |                 18 |               22 |    15–30 |
| Mixed CJK + Latin    |    47 |                 19 |               21 |    16–28 |
| Japanese             |    27 |                 20 |               24 |    16–32 |
| Korean               |    29 |                 17 |               20 |    14–27 |

On a long CJK conversation the 20% compounds in absolute terms (e.g. ~17k vs ~20k tokens over ~23k chars) but stays a few percentage points of a 128k window, meaningful near the limit, not dramatic in the common case.

## Compaction cut-point
Extracted into a testable `select_compaction_cut`. It keeps using per-message `estimated_tokens` (a relative comparison, so estimator bias cancels) but no longer summarizes the entire history when `keep_recent` exceeds the message total, a degenerate case the usage-calibrated gate above makes reachable.

## Testing
`cargo test session` — added cases for CJK weighting, the ASCII regression guard, calibration fallback / anchor-plus-delta / zero-usage handling, and the compaction cut-point (including the oversized-`keep_recent` regression).