### PR TITLE
fix: resolv.conf may be a symlink

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -102,9 +102,23 @@ impl Sandbox {
             "/dev",
             "--tmpfs",
             "/tmp",
-            "--ro-bind",
-            "/etc/resolv.conf",
-            "/etc/resolv.conf",
+        ]);
+
+        match std::fs::canonicalize("/etc/resolv.conf") {
+            Ok(target) => {
+                cmd.arg("--ro-bind-try");
+                cmd.arg(target);
+                cmd.arg("/etc/resolv.conf");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "sandbox: no resolver file could be mounted: could not resolve /etc/resolv.conf: {}",
+                    e
+                );
+            }
+        }
+
+        cmd.args([
             "--unshare-ipc",
             "--unshare-pid",
             "--unshare-uts",


### PR DESCRIPTION
In WSL /etc/resolv.conf can be a symlink to /mnt/wsl to get that information from the host. This broke zerostack using bubblewrap.

Fixes #115 