### PR TITLE
fix(acp): handle AgentEvent::CompletionCall so the acp feature compiles

### DIFF
--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -364,6 +364,10 @@ async fn run_prompt(
                     tracing::warn!("ACP failed to send tool result notification: {}", e);
                 }
             }
+            AgentEvent::CompletionCall { .. } => {
+                // Mid-stream provider usage; ACP has no status bar to update, so
+                // there is nothing to surface for this event.
+            }
             AgentEvent::Done { .. } => {
                 break;
             }


### PR DESCRIPTION
## Summary
Building with `--features acp` fails to compile:
```
error[E0004]: non-exhaustive patterns: event::AgentEvent::CompletionCall { .. } not covered –> src/extras/acp/mod.rs:297:15
```
the `match event` loop in `run_prompt` was never updated after `agentevent::completioncall` was added to the enum.

## Fix
Add a no-op match arm for `CompletionCall`. The event carries mid-stream provider token usage that other consumers use to update the status bar and drive mid-turn compaction.
ACP has no status bar to update, so there is nothing to surface, so the arm exists only to make the match exhaustive.

```rust
AgentEvent::CompletionCall { .. } => {
    // Mid-stream provider usage; ACP has no status bar to update, so
    // there is nothing to surface for this event.
}
```
## Verification
```bash
cargo clippy --features acp
```
compiles successfully with **zero warnings**.