### PR TITLE
fix(session): count Anthropic cached tokens so compaction triggers correctly

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -318,6 +318,8 @@ where
                                     response: CompactString::from(response_text),
                                     input_tokens: usage.input_tokens,
                                     output_tokens: usage.output_tokens,
+                                    cached_input_tokens: usage.cached_input_tokens,
+                                    cache_creation_input_tokens: usage.cache_creation_input_tokens,
                                 })
                                 .await;
                             return;
@@ -330,6 +332,8 @@ where
                                 .send(AgentEvent::CompletionCall {
                                     input_tokens: usage.input_tokens,
                                     output_tokens: usage.output_tokens,
+                                    cached_input_tokens: usage.cached_input_tokens,
+                                    cache_creation_input_tokens: usage.cache_creation_input_tokens,
                                 })
                                 .await;
                         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -187,6 +187,30 @@ impl Config {
         self.custom_providers.clone().unwrap_or_default()
     }
 
+    /// Whether requests for `provider` go through the Anthropic-native API
+    /// route. This is the route that enables prompt caching and reports
+    /// `input_tokens` *excluding* cached/cache-creation tokens, so it is the
+    /// only one whose context accounting must add the cache fields back in
+    /// (see [`Session::real_input_tokens`](crate::session::Session::real_input_tokens)).
+    ///
+    /// Keyed on the resolved provider *kind*, not the user-facing name: a
+    /// custom provider registered under any name but with
+    /// `provider_type = "anthropic"` still hits the native route, while
+    /// OpenRouter — even when serving a Claude model — normalizes usage to the
+    /// OpenAI shape (`input_tokens` already includes cached) and must not.
+    pub fn is_anthropic_native(&self, provider: &str) -> bool {
+        let kind_name = self
+            .custom_providers
+            .as_ref()
+            .and_then(|m| m.get(provider))
+            .map(|c| c.provider_type.as_str())
+            .unwrap_or(provider);
+        matches!(
+            crate::auth::ProviderKind::from_name(kind_name),
+            Some(crate::auth::ProviderKind::Anthropic)
+        )
+    }
+
     pub fn resolve_context_window(&self, provider: &str, model_id: &str) -> u64 {
         if let Some(cw) = self.context_window {
             return cw;

--- a/src/event.rs
+++ b/src/event.rs
@@ -24,11 +24,15 @@ pub enum AgentEvent {
     CompletionCall {
         input_tokens: u64,
         output_tokens: u64,
+        cached_input_tokens: u64,
+        cache_creation_input_tokens: u64,
     },
     Done {
         response: CompactString,
         input_tokens: u64,
         output_tokens: u64,
+        cached_input_tokens: u64,
+        cache_creation_input_tokens: u64,
     },
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -140,6 +140,37 @@ impl Session {
         std::mem::take(&mut self.pending_media)
     }
 
+    /// The true prompt size occupying the context window, normalizing across
+    /// providers' differing cache-usage reporting.
+    ///
+    /// The Anthropic-native route reports `input_tokens` counting *only* the
+    /// uncached portion of the prompt; the cache-read and cache-creation tokens
+    /// are reported in separate fields even though they still occupy the context
+    /// window. So there the real prompt size is the sum of all three. The
+    /// OpenAI, Gemini and OpenRouter shapes instead fold the cached subset into
+    /// `input_tokens` and report no cache-creation, so `input_tokens` is already
+    /// the full prompt size and adding the cache fields would double-count.
+    ///
+    /// `anthropic_native` must be the *resolved protocol route*, not a literal
+    /// provider-name comparison — a custom gateway with `provider_type =
+    /// "anthropic"` uses the native route under a different name, while
+    /// OpenRouter serving a Claude model does not. Compute it with
+    /// [`Config::is_anthropic_native`](crate::config::Config::is_anthropic_native).
+    pub fn real_input_tokens(
+        anthropic_native: bool,
+        input_tokens: u64,
+        cached_input_tokens: u64,
+        cache_creation_input_tokens: u64,
+    ) -> u64 {
+        if anthropic_native {
+            input_tokens
+                .saturating_add(cached_input_tokens)
+                .saturating_add(cache_creation_input_tokens)
+        } else {
+            input_tokens
+        }
+    }
+
     pub fn set_calibration(&mut self, input_tokens: u64, output_tokens: u64) {
         if input_tokens == 0 {
             return;

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -1,4 +1,48 @@
 use crate::config::Config;
+use crate::config::types::CustomProviderConfig;
+use compact_str::CompactString;
+use std::collections::HashMap;
+
+fn custom_provider(provider_type: &str) -> CustomProviderConfig {
+    CustomProviderConfig {
+        provider_type: CompactString::new(provider_type),
+        base_url: "https://gateway.example.com".to_string(),
+        api_key_env: None,
+        danger_accept_invalid_certs: None,
+        api_style: None,
+        headers: HashMap::new(),
+        timeout_secs: None,
+        model: None,
+    }
+}
+
+#[test]
+fn is_anthropic_native_builtin_providers() {
+    let cfg = Config::default();
+    assert!(cfg.is_anthropic_native("anthropic"));
+    assert!(cfg.is_anthropic_native("Anthropic")); // case-insensitive
+    for p in ["openai", "gemini", "google", "openrouter", "ollama"] {
+        assert!(!cfg.is_anthropic_native(p), "{p} is not anthropic-native");
+    }
+}
+
+#[test]
+fn is_anthropic_native_resolves_custom_provider_type() {
+    // A custom gateway named anything but routing through the Anthropic-native
+    // protocol must be treated as anthropic-native (so cache fields are added),
+    // while an OpenAI-style gateway must not.
+    let mut providers = HashMap::new();
+    providers.insert("my-claude-proxy".to_string(), custom_provider("anthropic"));
+    providers.insert("my-oai-gateway".to_string(), custom_provider("openai"));
+    let cfg = Config {
+        custom_providers: Some(providers),
+        ..Config::default()
+    };
+    assert!(cfg.is_anthropic_native("my-claude-proxy"));
+    assert!(!cfg.is_anthropic_native("my-oai-gateway"));
+    // Unknown name with no custom entry falls back to the literal kind.
+    assert!(!cfg.is_anthropic_native("totally-unknown"));
+}
 
 #[test]
 fn mid_turn_threshold_unset_by_default() {

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -84,6 +84,23 @@ fn calibration_ignores_zero_usage() {
     assert_eq!(s.effective_context_tokens(), s.total_estimated_tokens);
 }
 
+#[test]
+fn real_input_tokens_native_route_adds_cache_fields() {
+    // The Anthropic-native route reports input_tokens excluding cached/
+    // cache-creation tokens, so the real prompt size is the sum of all three.
+    // A cache hit (input ~0, cached large) must NOT collapse the measured context.
+    assert_eq!(Session::real_input_tokens(true, 10, 7000, 0), 7010);
+    assert_eq!(Session::real_input_tokens(true, 0, 7000, 0), 7000);
+    assert_eq!(Session::real_input_tokens(true, 50, 0, 6000), 6050);
+}
+
+#[test]
+fn real_input_tokens_non_native_uses_input_only() {
+    // OpenAI/Gemini/OpenRouter fold the cached subset into input_tokens and
+    // report no cache-creation; adding the cache fields would double-count.
+    assert_eq!(Session::real_input_tokens(false, 7000, 5600, 0), 7000);
+}
+
 // Helper: a session with `n` ASCII messages of `len` chars each, so every
 // message has a predictable estimated_tokens == len/4.
 fn session_with_messages(n: usize, len: usize) -> Session {

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -262,11 +262,15 @@ pub async fn handle_agent_event(
             response,
             input_tokens,
             output_tokens,
+            cached_input_tokens,
+            cache_creation_input_tokens,
         } => {
             handle_agent_done(
                 response,
                 input_tokens,
                 output_tokens,
+                cached_input_tokens,
+                cache_creation_input_tokens,
                 renderer,
                 session,
                 cfg,
@@ -297,12 +301,22 @@ pub async fn handle_agent_event(
         AgentEvent::CompletionCall {
             input_tokens,
             output_tokens,
+            cached_input_tokens,
+            cache_creation_input_tokens,
         } => {
             // Real provider-reported usage for the call that just finished.
             // The local len()/4 heuristic in session.total_estimated_tokens
             // undercounts code-heavy turns; trust the real number as a floor
-            // so the status bar's x/y/% reflects what llama.cpp actually saw.
-            let real = input_tokens.saturating_add(output_tokens);
+            // so the status bar's x/y/% reflects what the provider actually saw.
+            // Use the cache-inclusive prompt size so Anthropic cache hits (which
+            // report input_tokens excluding cached tokens) don't deflate it.
+            let real = Session::real_input_tokens(
+                cfg.is_anthropic_native(&session.provider),
+                input_tokens,
+                cached_input_tokens,
+                cache_creation_input_tokens,
+            )
+            .saturating_add(output_tokens);
             if real > session.total_estimated_tokens {
                 session.total_estimated_tokens = real;
             }
@@ -329,6 +343,8 @@ async fn handle_agent_done(
     response: CompactString,
     input_tokens: u64,
     output_tokens: u64,
+    cached_input_tokens: u64,
+    cache_creation_input_tokens: u64,
     renderer: &mut Renderer,
     session: &mut Session,
     cfg: &Config,
@@ -370,6 +386,8 @@ async fn handle_agent_done(
     renderer.write_line("", Color::White)?;
     renderer.write_line("", Color::White)?;
     session.add_message(MessageRole::Assistant, &response);
+    // Cost tracking uses the raw reported `input_tokens` (for Anthropic this is
+    // the billed uncached portion; cache reads are billed separately/cheaper).
     session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
     session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
     session.total_cost += crate::pricing::estimate_cost(
@@ -378,9 +396,18 @@ async fn handle_agent_done(
         session.input_token_cost,
         session.output_token_cost,
     );
-    // Anchor context-size accounting to the provider's real usage.
+    // Anchor context-size accounting to the provider's real usage. Context
+    // measurement needs the full prompt size, so use the cache-inclusive count
+    // (Anthropic reports input_tokens excluding cached/cache-creation tokens,
+    // which would otherwise collapse the context meter to ~0 on cache hits).
     // Must come after add_message so the anchor includes the just-appended response.
-    session.set_calibration(input_tokens, output_tokens);
+    let context_input_tokens = Session::real_input_tokens(
+        cfg.is_anthropic_native(&session.provider),
+        input_tokens,
+        cached_input_tokens,
+        cache_creation_input_tokens,
+    );
+    session.set_calibration(context_input_tokens, output_tokens);
     *agent_line_started = false;
     response_buf.clear();
     *response_start_line = None;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1924,7 +1924,12 @@ pub async fn run_interactive(
                 let loop_running = loop_state.as_ref().is_some_and(|ls| ls.active);
                 #[cfg(not(feature = "loop"))]
                 let loop_running = false;
-                if let AgentEvent::CompletionCall { input_tokens, .. } = &event
+                if let AgentEvent::CompletionCall {
+                    input_tokens,
+                    cached_input_tokens,
+                    cache_creation_input_tokens,
+                    ..
+                } = &event
                     && is_running
                     && !loop_running
                     && !cli.no_session
@@ -1932,7 +1937,16 @@ pub async fn run_interactive(
                     && session.context_window > 0
                     && let Some(threshold) = cfg.resolve_mid_turn_compact_threshold()
                 {
-                    let pressure = *input_tokens as f64 / session.context_window as f64;
+                    // Use the cache-inclusive prompt size so Anthropic cache hits
+                    // (input_tokens excludes cached/cache-creation) don't understate
+                    // real context pressure and suppress mid-turn compaction.
+                    let real_input_tokens = crate::session::Session::real_input_tokens(
+                        cfg.is_anthropic_native(&session.provider),
+                        *input_tokens,
+                        *cached_input_tokens,
+                        *cache_creation_input_tokens,
+                    );
+                    let pressure = real_input_tokens as f64 / session.context_window as f64;
                     if pressure > threshold {
                         if awaiting_compaction_relief {
                             // We already compacted this turn and the very next
@@ -1940,7 +1954,7 @@ pub async fn run_interactive(
                             // exceeds the budget, so compacting again is futile.
                             // Stop the turn and show the user the arithmetic.
                             stop_turn_context_exhausted(
-                                *input_tokens, threshold, &mut renderer, session, cfg,
+                                real_input_tokens, threshold, &mut renderer, session, cfg,
                                 &mut agent_rx, &mut main_abort, &mut is_running,
                                 &status_signals, &mut turn_trace, &mut response_buf,
                                 &mut response_start_line, &mut agent_line_started,


### PR DESCRIPTION
## TL;DR
With prompt caching enabled, Anthropic reports `input_tokens` **excluding** the cached portion of the prompt.
Our context accounting looked only at `input_tokens`, so once the prompt prefix was cached, the measurement **collapsed toward zero**: the status bar showed a near-empty context, and `needs_compaction` (and mid-turn compaction) never fired, even though the conversation was actually approaching the window limit.

This PR anchors context accounting to the **true, cache-inclusive prompt size**, using a provider-aware check so only the Anthropic-native route is adjusted, and other providers are left untouched (to avoid double-counting).

## Root cause

1. We enables prompt caching for the Anthropic-native route (`provider.rs`: `with_prompt_caching()`).
2. In Anthropic's usage payload, `input_tokens` counts **only the uncached** portion of the prompt; the cached tokens are reported in separate fields:
   - `cached_input_tokens` (cache-read)
   - `cache_creation_input_tokens` (cache-write)
   - rig (`0.38.1`) faithfully surfaces these as distinct fields.
3. `set_calibration(input_tokens, output_tokens)` used `input_tokens` as the anchor for "total prompt size". On a cache hit that value is tiny, so `effective_context_tokens()` collapses → the status-bar `%` is wrong and the compaction gate is never satisfied.
4. The same blind spot existed in the mid-turn compaction pressure check (`pressure = input_tokens / context_window`).

**Why we can't just add the cache fields for every provider**, the reporting conventions differ:

| Provider | Meaning of `input_tokens` | Already includes cached? | `cache_creation` reported? |
|---|---|---|---|
| **Anthropic (native)** | uncached portion only | ❌ No — cached is separate | Yes |
| **OpenAI / GPT** | `prompt_tokens` (full prompt) | ✅ Yes — `cached_tokens` is a subset | No (0) |
| **Gemini** | `prompt_token_count` (full prompt) | ✅ Yes — `cached_content_token_count` is a subset | No (0) |
| **OpenRouter** | OpenAI-compatible `prompt_tokens` | ✅ Yes — subset | No (0) |

So `input + cached + cache_creation` is **correct only for Anthropic**; for the others it would **double-count** the cached subset already inside `input_tokens`. (`total - output` is not safe either, Gemini's `total_token_count` also folds in reasoning tokens.)
The only reliable discriminator is the **underlying protocol**.

## The fix
- **`Session::real_input_tokens(anthropic_native, input, cached, cache_creation)`** (`session/mod.rs`)
  - `anthropic_native == true` → `input + cached + cache_creation`
  - otherwise → `input` (already the full prompt; do not add)
- **`Config::is_anthropic_native(provider)`** (`config/mod.rs`)
  - Resolves the protocol via `ProviderKind::from_name`; for a custom provider it first looks up its `provider_type`.
  - Result: direct `anthropic` **and** a custom gateway with `provider_type = "anthropic"` are treated as native; **OpenRouter is treated as non-native even when it serves a Claude model** (it normalizes usage to the OpenAI shape).
- **Event plumbing**: `AgentEvent::Done` / `CompletionCall` carry `cached_input_tokens` and `cache_creation_input_tokens`; `runner.rs` populates them from rig usage.
- **Cost vs. context split** (`event_handler.rs`):
  - Cost (`total_input_tokens` / `total_cost`) keeps the raw `input_tokens` (cache reads are billed separately and cheaper).
  - Context calibration and the `CompletionCall` floor use `real_input_tokens(...)`.
- **Mid-turn pressure** (`ui/mod.rs`): `pressure` uses `real_input_tokens(...)`, and the value passed to `stop_turn_context_exhausted` is updated to match.

> Design note: the gate keys on the **resolved protocol kind**, not a literal provider-name string. 
> This avoids a fragile special-case and also covers future custom Anthropic gateways.

## Test report

### 1. Automated tests
- `cargo test --release`: **460 passed / 0 failed**.
- New tests:
  - `real_input_tokens_native_route_adds_cache_fields` — native route sums
    `input + cached + cache_creation` (incl. the cache-hit case `input=0, cached=7000`).
  - `real_input_tokens_non_native_uses_input_only` — non-native uses `input` only even when `cached != 0` (no double-count).
  - `is_anthropic_native_builtin_providers` — `anthropic` (case-insensitive) → true;
    `openai/gemini/google/openrouter/ollama` → false.
  - `is_anthropic_native_resolves_custom_provider_type` — custom
    `provider_type="anthropic"` → true, `"openai"` → false, unknown name → false.

### 2. End-to-end (PTY-driven real binary)
**(a) Context-meter collapse — before vs. after (window=16k, same large message each turn)**

| Provider | Before (per-turn %) | After (per-turn %) |
|---|---|---|
| **Anthropic direct** | 20 → 24 → **0** (collapses on cache hit) ❌ | 20 → 24 → **28** (monotonic) ✅ |
| OpenAI gpt-4o-mini | 0 → 17 → 20 → 24 | 0 → 17 → 20 → 24 (unchanged) ✅ |
| Gemini | normal | normal (logically unaffected) ✅ |
| OpenRouter (non-anthropic) | 0 → 17 → 20 → 24 | 0 → 17 → 20 → 24 (unchanged) ✅ |

**(b) OpenRouter serving an Anthropic model (edge case)**

- `anthropic/claude-haiku-4.5`: context `%` grows monotonically, no collapse → the provider-aware check is correct (treated as non-native; no cache add).
- Corroboration: its `⇑` (cumulative input) keeps growing (4k→9k), confirming OpenRouter's `input_tokens` already includes cached tokens, so they must not be added again.

**(c) Actually triggering compaction (window=4000, reserve=500, gate ~3500)**
| Provider | Model | Context trajectory (%) | Compaction |
|---|---|---|---|
| **Anthropic direct** | claude-haiku-4-5 | 0→51→103→155→**55** | ✅ saved ~2077 tok |
| **OpenRouter + Anthropic** | anthropic/claude-haiku-4.5 | 0→51→103→155→**54** | ✅ saved ~2077 tok |
| **OpenAI** | gpt-4o-mini | 0→51→89→141→**55** | ✅ saved ~2077 tok |
| **Gemini** | gemini-2.5-flash | 0→51→92→144→**56** | ✅ saved ~2077 tok |

All four routes show the expected lifecycle: context crosses the gate → `auto-compacting...` → `compressed 2 messages` → context drops back to ~55%.
Key cross-check: on Anthropic direct, `⇑` (cost-side, raw, cache-excluded) stays low while the context `%` grows correctly and fires compaction, confirming the cost/context split works as intended.