### PR TITLE
fix(ui): gate slash-command picker entries by compiled feature

### DIFF
--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -1,46 +1,86 @@
 use super::draw_picker_list;
 
-const COMMANDS: &[&str] = &[
+/// Slash commands that are always available, regardless of which optional
+/// features were compiled in. Feature-gated commands are appended by
+/// [`available_commands`].
+///
+/// Kept in alphabetical order for ease of maintenance.
+const BASE_COMMANDS: &[&str] = &[
     "/add",
+    "/btw",
+    "/clear",
+    "/compact",
+    "/compress",
     "/drop",
     "/drop-all",
+    "/editsys",
+    "/exit",
+    "/help",
+    "/history",
     "/init",
-    "/memory",
+    "/mode",
     "/model",
     "/models",
     "/models-add",
-    "/provider",
-    "/sessions",
-    "/reasoning",
-    "/thinking",
-    "/mode",
-    "/mcp",
-    "/toggle",
-    "/compress",
-    "/compact",
-    "/loop",
+    "/new",
     "/prompt",
-    "/theme",
-    "/history",
+    "/provider",
+    "/queue",
+    "/quit",
+    "/reasoning",
     "/regen-prompts",
     "/regen-themes",
-    "/editsys",
-    "/quit",
-    "/exit",
-    "/clear",
-    "/new",
-    "/undo",
     "/retry",
-    "/help",
-    "/welcome",
-    "/tutorial",
     "/review",
-    "/worktree",
-    "/wt-merge",
-    "/wt-exit",
-    "/btw",
-    "/queue",
+    "/sessions",
+    "/theme",
+    "/thinking",
+    "/toggle",
+    "/tutorial",
+    "/undo",
+    "/welcome",
 ];
+
+/// Build the autocomplete command list, including only the commands whose
+/// backing feature was actually compiled in.
+///
+/// `#[cfg]` cannot be attached to elements of an array literal on stable Rust
+/// (that requires the unstable `stmt_expr_attributes` feature), so the
+/// feature-gated commands are appended via conditionally-compiled statements
+/// instead. Feature blocks are ordered alphabetically by feature name, and the
+/// commands within each block are likewise alphabetical. Keep this in sync with
+/// the dispatcher in `crate::ui::slash`.
+fn available_commands() -> Vec<&'static str> {
+    #[allow(unused_mut)]
+    let mut cmds: Vec<&'static str> = BASE_COMMANDS.to_vec();
+
+    #[cfg(feature = "advisor")]
+    cmds.push("/advisor");
+
+    #[cfg(feature = "git-worktree")]
+    {
+        cmds.push("/worktree");
+        cmds.push("/wt-exit");
+        cmds.push("/wt-merge");
+    }
+
+    #[cfg(feature = "loop")]
+    cmds.push("/loop");
+
+    #[cfg(feature = "mcp")]
+    cmds.push("/mcp");
+
+    #[cfg(feature = "memory")]
+    cmds.push("/memory");
+
+    #[cfg(feature = "subagents")]
+    {
+        cmds.push("/model-subagent");
+        cmds.push("/models-subagent");
+    }
+
+    cmds
+}
 
 pub struct ListPicker {
     pub active: bool,
@@ -67,7 +107,7 @@ impl ListPicker {
 
     pub fn with_static_commands() -> Self {
         let mut picker = ListPicker::new();
-        picker.items = COMMANDS.iter().map(|s| s.to_string()).collect();
+        picker.items = available_commands().iter().map(|s| s.to_string()).collect();
         picker
     }
 


### PR DESCRIPTION
## Summary
The slash-command autocomplete picker is populated from a hardcoded static array (`COMMANDS` in `src/ui/pickers/list.rs`) that doesn't track which features were compiled in. 

This PR makes the picker list feature-aware and sorts everything alphabetically so it's easier to keep in sync going forward.

## Problem
The picker was both **incomplete** and **inaccurate**:
- **Missing commands** — `/advisor`, `/model-subagent`, and `/models-subagent` are real, dispatcher-handled commands but were never listed, so they never showed up in autocomplete even when their features were enabled. (`/advisor` was the original report: typing it worked, but it was invisible in the menu.)
- **Stale commands** — `/memory`, `/mcp`, `/loop`, `/worktree`, `/wt-merge`, and `/wt-exit` were always shown, even in builds where their feature is off. Selecting one only printed a "not available / rebuild with --features" message, which is misleading.

## Changes
- Split the old `COMMANDS` const into `BASE_COMMANDS` (always available) and a new `available_commands()` builder.
- `available_commands()` appends feature-gated commands behind `#[cfg(feature = ...)]` statements. Statement-level `#[cfg]` is required because attributes on array-literal elements need the unstable `stmt_expr_attributes` feature and won't compile on stable.
- Added a doc comment noting the list must stay in sync with the dispatcher in `crate::ui::slash`.
- Sorted `BASE_COMMANDS` alphabetically; ordered the feature blocks alphabetically by feature name; sorted commands within each block.

## Command → feature mapping
| Feature gate | Commands |
| --- | --- |
| _(none — always)_ | `/add` `/btw` `/clear` `/compact` `/compress` `/drop` `/drop-all` `/editsys` `/exit` `/help` `/history` `/init` `/mode` `/model` `/models` `/models-add` `/new` `/prompt` `/provider` `/queue` `/quit` `/reasoning` `/regen-prompts` `/regen-themes` `/retry` `/review` `/sessions` `/theme` `/thinking` `/toggle` `/tutorial` `/undo` `/welcome` |
| `advisor` | `/advisor` |
| `git-worktree` | `/worktree` `/wt-exit` `/wt-merge` |
| `loop` | `/loop` |
| `mcp` | `/mcp` |
| `memory` | `/memory` |
| `subagents` | `/model-subagent` `/models-subagent` |

`/init`, `/review`, and `/add` stay in the always-available set: only parts of their handlers are gated (`archmd`, `git-worktree`, `multimodal` respectively), the commands themselves always exist.

## Notes / caveats
- Feature-gated commands are appended after the base list, so the menu order is "alphabetical base list, then the enabled feature commands." The display isn't fully interleaved-alphabetical. If that's desired, sorting `matches` in `ListPicker::filter()` would do it, intentionally left out of this PR.
- No behavior change to the dispatcher; this only affects what autocomplete offers.

## Testing
```bash
# default features
cargo build --release && cargo test -p zerostack

# with the previously-invisible features
cargo build --release --features advisor,subagents
# then in the TUI: type `/` and confirm /advisor, /model-subagent,
# /models-subagent now appears; build without them and confirm they don't.
```