### PR TITLE
 feat(config): add extra_body for provider-specific request body params

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -145,6 +145,7 @@ Accepted top-level keys:
 | `max_tokens`              | integer | Maximum response tokens. Default: `16384`.                                                                                                                                  |
 | `max_agent_turns`         | integer | Maximum agent turns per response. Default: `200`.                                                                                                                           |
 | `temperature`             | number  | Model temperature value. Only configurable via the `--temperature` CLI flag (`0.0` to `2.0`). Config-file value is parsed but not currently applied.                        |
+| `extra_body`              | object  | Provider-specific JSON shallow-merged into every completion request body as a global default (e.g. OpenRouter `plugins` routing presets). A matching `quick_models` entry's `extra_body` overrides this. See Provider-specific request body parameters below. |
 | `no_tools`                | boolean | Disable all tools. Default: `false`.                                                                                                                                        |
 | `no_context_files`        | boolean | Disable loading global/project `AGENTS.md`, `CLAUDE.md`, and `ARCHITECTURE.md` (if `archmd` feature enabled) context files. Default: `false`.                               |
 | `context_window`          | integer | Session context-window size used for status and auto-compaction. When unset, auto-detected from the selected model's catalog entry; falls back to `128000` if the model is not in the catalog. A value of `0` disables auto-compaction. |
@@ -174,7 +175,7 @@ Accepted top-level keys:
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`. If the prompt file has a `%%mode=<mode>` first-line directive, the security mode is set automatically (see Prompt directives below). |
 | `editor`                  | string  | Editor command for `Ctrl+G` (default: `$EDITOR` env var, then `editor`, then `nano`).                                                                                        |
 | `api_keys`                | object  | Map of provider names to API keys (e.g. `"openai": "sk-..."`). Used as fallback when the corresponding env var is not set.                                                   |
-| `quick_models`            | object  | Map of quick-model names to `{ "provider", "model", "reserve_tokens"?, "input_token_cost"?, "output_token_cost"? }`. Can be switched with `/models <name>` or `--quick-model=<name>`.                                                      |
+| `quick_models`            | object  | Map of quick-model names to `{ "provider", "model", "reserve_tokens"?, "input_token_cost"?, "output_token_cost"?, "temperature"?, "extra_body"? }`. Can be switched with `/models <name>` or `--quick-model=<name>`. See Provider-specific request body parameters below for `extra_body`. |
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, recommended MCPs are auto-configured (see below).                                                   |
 | `enable-exa-mcp`          | boolean | Auto-configure the Exa Web Search MCP server. Default: `true`.                                                                                                         |
 | `enable-context7-mcp`     | boolean | Auto-configure the Context7 MCP server. Default: `false`.                                                                                                              |
@@ -257,6 +258,65 @@ The optional `timeout_secs` field overrides the default HTTP timeout for the
 provider. TLS certificate verification can be disabled with
 `"danger_accept_invalid_certs": true` (for self-signed or internal-CA
 gateways) — use with care, as it makes the connection vulnerable to MITM.
+
+## Provider-specific request body parameters
+
+`headers` only touches HTTP headers. Some providers also accept parameters in
+the JSON request *body* — for example OpenRouter's `plugins` presets that select
+a routing strategy:
+
+```json
+{
+  "model": "openrouter/fusion",
+  "plugins": { "preset": "general-budget" }
+}
+```
+
+`extra_body` injects arbitrary JSON into the completion request body. It is
+shallow-merged (top-level keys win on collision) and works for **every**
+provider — OpenAI, Anthropic, Gemini, Ollama, OpenRouter, and any custom
+provider — not just OpenRouter. The same value is applied to the main agent and
+the isolated `/btw` agent so they behave identically.
+
+It can be set at two levels, resolved most-specific first:
+
+1. **Per `quick_models` entry** — applies only when that model is active.
+2. **Global top-level `extra_body`** — applies to every model, including the
+   base `model`, unless a matching `quick_models` entry overrides it.
+
+```toml
+# Global default — applies to the base model and any model without its own value.
+model = "openrouter/fusion"
+provider = "openrouter"
+extra_body = { plugins = { preset = "general-budget" } }
+
+# A quick-model entry overrides the global value for that model.
+[quick_models.quality]
+provider = "openrouter"
+model = "openrouter/fusion"
+extra_body = { plugins = { preset = "quality" } }
+```
+
+In JSON:
+
+```json
+{
+  "extra_body": { "plugins": { "preset": "general-budget" } },
+  "quick_models": {
+    "quality": {
+      "provider": "openrouter",
+      "model": "openrouter/fusion",
+      "extra_body": { "plugins": { "preset": "quality" } }
+    }
+  }
+}
+```
+
+Note that body parameters are **provider-specific**: a key one provider
+understands may be ignored or rejected by another. Unlike `temperature`, a
+global `extra_body` does not follow model switches, so prefer setting it per
+`quick_models` entry — bundled with the matching `provider`/`model` — when the
+parameter is tied to a specific provider.
 
 ## Colors
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -63,6 +63,7 @@ fn default_quick_models() -> HashMap<String, QuickModelConfig> {
             output_token_cost: 0.1966,
             reserve_tokens: None,
             temperature: None,
+            extra_body: None,
         },
     );
     map.insert(
@@ -74,6 +75,7 @@ fn default_quick_models() -> HashMap<String, QuickModelConfig> {
             output_token_cost: 0.87,
             reserve_tokens: None,
             temperature: None,
+            extra_body: None,
         },
     );
     map
@@ -111,6 +113,7 @@ pub fn save_quick_model(
             output_token_cost,
             reserve_tokens: None,
             temperature: None,
+            extra_body: None,
         },
     );
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,13 @@ pub struct Config {
     pub max_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+    /// Provider-specific JSON shallow-merged into every completion request body
+    /// as a global default. A matching `quick_models` entry's `extra_body`
+    /// overrides this. Note: body params are provider-specific, so a global
+    /// value does not follow model switches — bundle per-`quick_models` when in
+    /// doubt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_tools: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -247,6 +254,25 @@ impl Config {
         self.temperature.map(|t| t.clamp(0.0, 2.0))
     }
 
+    /// Resolves provider-specific request-body params: quick-model `extra_body` >
+    /// global `extra_body`. Returns `None` when neither is configured. The
+    /// resolved value is shallow-merged into the completion request body at
+    /// agent-build time.
+    pub fn resolve_extra_body(
+        &self,
+        model_id: &str,
+        qm: &HashMap<String, types::QuickModelConfig>,
+    ) -> Option<serde_json::Value> {
+        for qmc in qm.values() {
+            if qmc.model.as_str() == model_id
+                && let Some(eb) = &qmc.extra_body
+            {
+                return Some(eb.clone());
+            }
+        }
+        self.extra_body.clone()
+    }
+
     pub fn resolve_compact_enabled(&self) -> bool {
         self.compact_enabled.unwrap_or(true)
     }
@@ -389,6 +415,12 @@ pub enum ResolvedShowToolDetails {
 pub fn resolve_temperature(cli: &crate::cli::Cli, cfg: &Config, model_id: &str) -> Option<f64> {
     let qm = quick_models_map(cfg);
     cfg.resolve_temperature(cli, model_id, &qm)
+}
+
+/// Convenience: resolves extra body params (quick model, global config).
+pub fn resolve_extra_body(cfg: &Config, model_id: &str) -> Option<serde_json::Value> {
+    let qm = quick_models_map(cfg);
+    cfg.resolve_extra_body(model_id, &qm)
 }
 
 impl ShowToolDetails {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -17,6 +17,11 @@ pub struct QuickModelConfig {
     /// global `temperature` setting but is overridden by `--temperature`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+    /// Provider-specific JSON shallow-merged into the completion request body
+    /// (e.g. OpenRouter `plugins` routing presets). Overrides the global
+    /// `extra_body` for this model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -272,6 +272,7 @@ async fn run_prompt(
     };
 
     let temperature = crate::config::resolve_temperature(&state.cli, &state.cfg, &model_str);
+    let extra_body = crate::config::resolve_extra_body(&state.cfg, &model_str);
     let agent = crate::provider::build_agent(
         model,
         &state.cli,
@@ -282,6 +283,7 @@ async fn run_prompt(
         sandbox,
         false,
         temperature,
+        extra_body,
         #[cfg(feature = "mcp")]
         None::<&crate::extras::mcp::McpClientManager>,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,6 +615,7 @@ async fn main() -> anyhow::Result<()> {
             }
         } else {
             let temperature = config::resolve_temperature(&cli, &cfg, &model);
+            let extra_body = config::resolve_extra_body(&cfg, &model);
             let agent = provider::build_agent(
                 completion_model,
                 &cli,
@@ -625,6 +626,7 @@ async fn main() -> anyhow::Result<()> {
                 sandbox.clone(),
                 true,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 None,
             )
@@ -665,6 +667,7 @@ async fn main() -> anyhow::Result<()> {
         if cli.loop_mode {
             let model_completion = client.completion_model(model.to_string());
             let temperature = config::resolve_temperature(&cli, &cfg, &model);
+            let extra_body = config::resolve_extra_body(&cfg, &model);
             let agent = provider::build_agent(
                 model_completion,
                 &cli,
@@ -675,6 +678,7 @@ async fn main() -> anyhow::Result<()> {
                 sandbox.clone(),
                 true,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 None,
             )

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -177,6 +177,26 @@ fn openrouter_anthropic_routing(model_id: &str) -> Option<serde_json::Value> {
     })
 }
 
+/// Shallow-merges user-configured `extra_body` into provider-internal routing
+/// params (e.g. OpenRouter's `provider.order`). Top-level keys from `extra_body`
+/// win on collision. Returns `None` when both are absent so callers can avoid an
+/// empty `additional_params` call.
+pub(crate) fn merge_extra_body(
+    base: Option<serde_json::Value>,
+    extra: Option<serde_json::Value>,
+) -> Option<serde_json::Value> {
+    match (base, extra) {
+        (Some(serde_json::Value::Object(mut b)), Some(serde_json::Value::Object(e))) => {
+            b.extend(e);
+            Some(serde_json::Value::Object(b))
+        }
+        (base, None) => base,
+        (None, extra) => extra,
+        // Non-object base (shouldn't happen for routing) — user value takes over.
+        (Some(_), extra) => extra,
+    }
+}
+
 impl AnyClient {
     #[allow(dead_code)]
     pub fn provider_name(&self) -> &'static str {
@@ -740,6 +760,7 @@ async fn build_openai_agent(
     sandbox: Sandbox,
     reasoning_enabled: bool,
     temperature: Option<f64>,
+    extra_body: Option<serde_json::Value>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
 ) -> OpenAiAgent {
     match model {
@@ -754,7 +775,7 @@ async fn build_openai_agent(
                 sandbox,
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -771,7 +792,7 @@ async fn build_openai_agent(
                 sandbox,
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -791,10 +812,11 @@ pub async fn build_agent(
     sandbox: Sandbox,
     reasoning_enabled: bool,
     temperature: Option<f64>,
+    extra_body: Option<serde_json::Value>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
 ) -> AnyAgent {
     match model {
-        AnyModel::OpenRouter(m, extra) => AnyAgent::OpenRouter(
+        AnyModel::OpenRouter(m, routing) => AnyAgent::OpenRouter(
             builder::build_agent_inner(
                 m,
                 cli,
@@ -805,7 +827,7 @@ pub async fn build_agent(
                 sandbox.clone(),
                 reasoning_enabled,
                 temperature,
-                extra,
+                merge_extra_body(routing, extra_body),
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -822,6 +844,7 @@ pub async fn build_agent(
                 sandbox.clone(),
                 reasoning_enabled,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -838,7 +861,7 @@ pub async fn build_agent(
                 sandbox.clone(),
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -855,7 +878,7 @@ pub async fn build_agent(
                 sandbox.clone(),
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -872,7 +895,7 @@ pub async fn build_agent(
                 sandbox,
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp_manager,
             )
@@ -892,9 +915,10 @@ pub fn build_btw_agent(
     ask_tx: &Option<AskSender>,
     reasoning_enabled: bool,
     temperature: Option<f64>,
+    extra_body: Option<serde_json::Value>,
 ) -> AnyAgent {
     match model {
-        AnyModel::OpenRouter(m, extra) => AnyAgent::OpenRouter(builder::build_btw_agent_inner(
+        AnyModel::OpenRouter(m, routing) => AnyAgent::OpenRouter(builder::build_btw_agent_inner(
             m,
             cli,
             cfg,
@@ -903,7 +927,7 @@ pub fn build_btw_agent(
             ask_tx,
             reasoning_enabled,
             temperature,
-            extra,
+            merge_extra_body(routing, extra_body),
         )),
         AnyModel::OpenAI(m) => AnyAgent::OpenAI(match m {
             OpenAiModel::Responses(m) => OpenAiAgent::Responses(builder::build_btw_agent_inner(
@@ -915,7 +939,7 @@ pub fn build_btw_agent(
                 ask_tx,
                 reasoning_enabled,
                 temperature,
-                None,
+                extra_body,
             )),
             OpenAiModel::Completions(m) => {
                 OpenAiAgent::Completions(builder::build_btw_agent_inner(
@@ -927,7 +951,7 @@ pub fn build_btw_agent(
                     ask_tx,
                     reasoning_enabled,
                     temperature,
-                    None,
+                    extra_body,
                 ))
             }
         }),
@@ -940,7 +964,7 @@ pub fn build_btw_agent(
             ask_tx,
             reasoning_enabled,
             temperature,
-            None,
+            extra_body,
         )),
         AnyModel::Gemini(m) => AnyAgent::Gemini(builder::build_btw_agent_inner(
             m,
@@ -951,7 +975,7 @@ pub fn build_btw_agent(
             ask_tx,
             reasoning_enabled,
             temperature,
-            None,
+            extra_body,
         )),
         AnyModel::Ollama(m) => AnyAgent::Ollama(builder::build_btw_agent_inner(
             m,
@@ -962,7 +986,7 @@ pub fn build_btw_agent(
             ask_tx,
             reasoning_enabled,
             temperature,
-            None,
+            extra_body,
         )),
     }
 }

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -1,4 +1,63 @@
 use crate::config::Config;
+use crate::config::types::QuickModelConfig;
+use serde_json::json;
+use std::collections::HashMap;
+
+fn qm(model: &str, extra_body: Option<serde_json::Value>) -> QuickModelConfig {
+    QuickModelConfig {
+        provider: "openrouter".into(),
+        model: model.into(),
+        input_token_cost: 0.0,
+        output_token_cost: 0.0,
+        reserve_tokens: None,
+        temperature: None,
+        extra_body,
+    }
+}
+
+#[test]
+fn extra_body_unset_by_default() {
+    let cfg = Config::default();
+    assert_eq!(cfg.resolve_extra_body("any/model", &HashMap::new()), None);
+}
+
+#[test]
+fn extra_body_global_applies_to_base_model() {
+    let cfg = Config {
+        extra_body: Some(json!({ "plugins": { "preset": "general-budget" } })),
+        ..Config::default()
+    };
+    assert_eq!(
+        cfg.resolve_extra_body("openrouter/fusion", &HashMap::new()),
+        Some(json!({ "plugins": { "preset": "general-budget" } }))
+    );
+}
+
+#[test]
+fn extra_body_quick_model_overrides_global() {
+    let cfg = Config {
+        extra_body: Some(json!({ "plugins": { "preset": "general-budget" } })),
+        ..Config::default()
+    };
+    let mut map = HashMap::new();
+    map.insert(
+        "quality".to_string(),
+        qm(
+            "openrouter/fusion",
+            Some(json!({ "plugins": { "preset": "quality" } })),
+        ),
+    );
+    // Matching quick-model entry wins over the global default.
+    assert_eq!(
+        cfg.resolve_extra_body("openrouter/fusion", &map),
+        Some(json!({ "plugins": { "preset": "quality" } }))
+    );
+    // A different model falls back to the global default.
+    assert_eq!(
+        cfg.resolve_extra_body("other/model", &map),
+        Some(json!({ "plugins": { "preset": "general-budget" } }))
+    );
+}
 
 #[test]
 fn mid_turn_threshold_unset_by_default() {

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -2,7 +2,8 @@ use crate::auth::ProviderKind;
 use crate::config::{ApiStyle, CustomProviderConfig};
 use crate::provider::ModelEntry;
 use crate::provider::{
-    expand_env, is_agent_model, resolve_api_style, resolve_provider_config, serialize_conversation,
+    expand_env, is_agent_model, merge_extra_body, resolve_api_style, resolve_provider_config,
+    serialize_conversation,
 };
 use crate::session::{MessageRole, SessionMessage};
 use compact_str::CompactString;
@@ -226,4 +227,33 @@ fn resolve_custom_provider() {
     let cfg = resolve_provider_config("my-gw", &custom).unwrap();
     assert_eq!(cfg.kind, ProviderKind::OpenAI);
     assert_eq!(cfg.base_url.as_deref(), Some("https://mygw.example/v1"));
+}
+
+#[test]
+fn merge_extra_body_combines_routing_and_user_keys() {
+    // OpenRouter routing (provider.order) plus a user `plugins` preset must both
+    // survive in the request body.
+    let routing = serde_json::json!({
+        "provider": { "order": ["Anthropic"], "allow_fallbacks": true }
+    });
+    let user = serde_json::json!({ "plugins": { "preset": "general-budget" } });
+    let merged = merge_extra_body(Some(routing), Some(user)).unwrap();
+    assert_eq!(merged["provider"]["order"][0], "Anthropic");
+    assert_eq!(merged["plugins"]["preset"], "general-budget");
+}
+
+#[test]
+fn merge_extra_body_user_key_overrides_base() {
+    let base = serde_json::json!({ "provider": { "order": ["Anthropic"] } });
+    let user = serde_json::json!({ "provider": { "order": ["OpenAI"] } });
+    let merged = merge_extra_body(Some(base), Some(user)).unwrap();
+    assert_eq!(merged["provider"]["order"][0], "OpenAI");
+}
+
+#[test]
+fn merge_extra_body_handles_absent_sides() {
+    let val = serde_json::json!({ "plugins": { "preset": "quality" } });
+    assert_eq!(merge_extra_body(None, Some(val.clone())), Some(val.clone()));
+    assert_eq!(merge_extra_body(Some(val.clone()), None), Some(val));
+    assert_eq!(merge_extra_body(None, None), None);
 }

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -41,6 +41,7 @@ pub async fn ensure_agent(
     }
     let model = client.completion_model(session.model.to_string());
     let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
     *agent = Some(
         crate::provider::build_agent(
             model,
@@ -52,6 +53,7 @@ pub async fn ensure_agent(
             sandbox.clone(),
             reasoning_enabled,
             temperature,
+            extra_body,
             mcp_manager,
         )
         .await,
@@ -77,6 +79,7 @@ pub async fn ensure_agent(
     }
     let model = client.completion_model(session.model.to_string());
     let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
     *agent = Some(
         crate::provider::build_agent(
             model,
@@ -88,6 +91,7 @@ pub async fn ensure_agent(
             sandbox.clone(),
             reasoning_enabled,
             temperature,
+            extra_body,
         )
         .await,
     );
@@ -504,6 +508,7 @@ async fn handle_agent_done(
             *agent = Some({
                 let model = client.completion_model(session.model.to_string());
                 let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
                 crate::provider::build_agent(
                     model,
                     cli,
@@ -514,6 +519,7 @@ async fn handle_agent_done(
                     sandbox.clone(),
                     true,
                     temperature,
+                    extra_body,
                     #[cfg(feature = "mcp")]
                     mcp_manager,
                 )
@@ -548,6 +554,7 @@ async fn handle_agent_done(
                 *agent = Some({
                     let model = client.completion_model(session.model.to_string());
                     let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
                     crate::provider::build_agent(
                         model,
                         cli,
@@ -558,6 +565,7 @@ async fn handle_agent_done(
                         sandbox.clone(),
                         true,
                         temperature,
+                        extra_body,
                         #[cfg(feature = "mcp")]
                         mcp_manager,
                     )

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -859,6 +859,7 @@ pub async fn run_interactive(
                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
                 let model = client.completion_model(session.model.to_string());
                 let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
                 agent = Some(
                     crate::provider::build_agent(
                         model,
@@ -870,6 +871,7 @@ pub async fn run_interactive(
                         sandbox.clone(),
                         reasoning_enabled,
                         temperature,
+                        extra_body,
                         #[cfg(feature = "mcp")]
                         mcp_ref,
                     )
@@ -900,6 +902,7 @@ pub async fn run_interactive(
                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
                 let model = client.completion_model(session.model.to_string());
                 let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
                 agent = Some(
                     crate::provider::build_agent(
                         model,
@@ -911,6 +914,7 @@ pub async fn run_interactive(
                         sandbox.clone(),
                         reasoning_enabled,
                         temperature,
+                        extra_body,
                         #[cfg(feature = "mcp")]
                         mcp_ref,
                     )
@@ -998,6 +1002,7 @@ pub async fn run_interactive(
             let model = client_clone.completion_model(session_model.clone());
             let temperature =
                 crate::config::resolve_temperature(&cli_clone, &cfg_clone, &session_model);
+            let extra_body = crate::config::resolve_extra_body(&cfg_clone, &session_model);
             let a = crate::provider::build_agent(
                 model,
                 &cli_clone,
@@ -1008,6 +1013,7 @@ pub async fn run_interactive(
                 sandbox_clone,
                 reasoning_enabled,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 mcp.as_ref(),
             )
@@ -1506,8 +1512,10 @@ pub async fn run_interactive(
                                         let model = client.completion_model(session.model.to_string());
                                         let temperature =
                                             crate::config::resolve_temperature(cli, cfg, &session.model);
+                                        let extra_body =
+                                            crate::config::resolve_extra_body(cfg, &session.model);
                                         let btw_agent = crate::provider::build_btw_agent(
-                                            model, cli, cfg, context, &permission, &ask_tx, reasoning_enabled, temperature,
+                                            model, cli, cfg, context, &permission, &ask_tx, reasoning_enabled, temperature, extra_body,
                                         );
                                         let runner = btw_agent.spawn_btw(
                                             btw_text.to_string(), snapshot, btw_tx.clone(), id,
@@ -1675,6 +1683,8 @@ pub async fn run_interactive(
                                                 let model = client.completion_model(session.model.to_string());
                                                 let temperature =
                                                     crate::config::resolve_temperature(cli, cfg, &session.model);
+                                                let extra_body =
+                                                    crate::config::resolve_extra_body(cfg, &session.model);
                                                 agent = Some(crate::provider::build_agent(
                                                     model,
                                                     cli,
@@ -1685,6 +1695,7 @@ pub async fn run_interactive(
                                                     sandbox.clone(),
                                                     reasoning_enabled,
                                                     temperature,
+                                                    extra_body,
                                                     #[cfg(feature = "mcp")] mcp_ref,
                                                 ).await);
                                                 render_session(&mut renderer, session, cli, cfg, context)?;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -56,6 +56,7 @@ impl SlashCtx<'_> {
         let model = self.client.completion_model(self.session.model.to_string());
         let temperature =
             crate::config::resolve_temperature(self.cli, self.cfg, &self.session.model);
+        let extra_body = crate::config::resolve_extra_body(self.cfg, &self.session.model);
         #[cfg(feature = "advisor")]
         {
             crate::extras::advisor::update_client(self.client.clone());
@@ -72,6 +73,7 @@ impl SlashCtx<'_> {
                 self.sandbox.clone(),
                 *self.reasoning_enabled,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 self.mcp_manager,
             )
@@ -93,6 +95,7 @@ impl SlashCtx<'_> {
         let model = self.client.completion_model(self.session.model.to_string());
         let temperature =
             crate::config::resolve_temperature(self.cli, self.cfg, &self.session.model);
+        let extra_body = crate::config::resolve_extra_body(self.cfg, &self.session.model);
         #[cfg(feature = "advisor")]
         {
             crate::extras::advisor::update_client(self.client.clone());
@@ -109,6 +112,7 @@ impl SlashCtx<'_> {
                 self.sandbox.clone(),
                 new_reasoning,
                 temperature,
+                extra_body,
                 #[cfg(feature = "mcp")]
                 self.mcp_manager,
             )
@@ -217,6 +221,7 @@ pub async fn handle_compress(
 
     let model = client.completion_model(session.model.to_string());
     let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
     *agent = Some(
         crate::provider::build_agent(
             model,
@@ -228,6 +233,7 @@ pub async fn handle_compress(
             sandbox.clone(),
             reasoning_enabled,
             temperature,
+            extra_body,
             #[cfg(feature = "mcp")]
             mcp_manager,
         )

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -101,6 +101,7 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
     let new_model = compact_str::CompactString::new(model_id);
     let model = ctx.client.completion_model(new_model.to_string());
     let temperature = crate::config::resolve_temperature(ctx.cli, ctx.cfg, &new_model);
+    let extra_body = crate::config::resolve_extra_body(ctx.cfg, &new_model);
     *ctx.agent = Some(
         crate::provider::build_agent(
             model,
@@ -112,6 +113,7 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
             ctx.sandbox.clone(),
             *ctx.reasoning_enabled,
             temperature,
+            extra_body,
             #[cfg(feature = "mcp")]
             ctx.mcp_manager,
         )
@@ -182,6 +184,7 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
     let new_model = compact_str::CompactString::new(parts[1].trim());
     let model = ctx.client.completion_model(new_model.to_string());
     let temperature = crate::config::resolve_temperature(ctx.cli, ctx.cfg, &new_model);
+    let extra_body = crate::config::resolve_extra_body(ctx.cfg, &new_model);
     *ctx.agent = Some(
         crate::provider::build_agent(
             model,
@@ -193,6 +196,7 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             ctx.sandbox.clone(),
             *ctx.reasoning_enabled,
             temperature,
+            extra_body,
             #[cfg(feature = "mcp")]
             ctx.mcp_manager,
         )


### PR DESCRIPTION
## Summary
`quick_models` entries only supported `provider` and `model`, with no way to inject provider-specific parameters into the API request body.
Custom providers have `headers`, but that only touches HTTP headers, not the payload.
This adds an optional `extra_body` map that is shallow-merged into the completion request body, so provider features like OpenRouter's `plugins` routing presets, can be used without giving up zerostack's model switching.

Closes #121.

## Changes
- Add `extra_body` to `quick_models` entries and a global top-level `extra_body` as a default.
- Resolve it most-specific first: a matching `quick_models` entry overrides the global value (mirrors how `temperature` is resolved).
- Inject via rig's `AgentBuilder::additional_params`, the same path the existing OpenRouter Anthropic-routing pin already uses.
- Merge the user value with that pin through a single `merge_extra_body` chokepoint, so the auto pin and a user `extra_body` coexist instead of overwriting each other.
- Apply the same resolved value to the main agent and the isolated `/btw` agent so they behave identically.
- This works for every provider (OpenAI, Anthropic, Gemini, Ollama, OpenRouter, and custom providers), not just OpenRouter.

## Testing
- `cargo test` (default and `--all-features`) — added unit tests for `resolve_extra_body` (global, quick-model override, fallback) and `merge_extra_body` (combine, override, absent sides).
- Verified on the wire by routing OpenRouter through a local capture server: a configured `plugins` array appears verbatim in the request body.
- Verified the merge: for an `anthropic/*` model the body carries both the auto `provider.order` pin and the user `plugins` value.
- Verified against the live OpenRouter API that a `plugins` payload is accepted and returns normally.

## Notes
- `extra_body` can be set at the top level, which applies to the base `model`, or per `quick_models` entry, which overrides the global value.
- Body parameters are usually model-specific, not just provider-specific: OpenRouter's `plugins` for `openrouter/fusion`, for example, is meaningless for a plain chat model served by the same provider.
- A top-level `extra_body` applies to whichever model is active, so keep it for parameters every model you use accepts; tie anything model-specific to a `quick_models` entry, which matches by model id.