### PR TITLE
feat(mcp): add OAuth 2.0 support for URL servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
  "num-traits",
  "pastey 0.1.1",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -3304,7 +3304,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "ureq",
  "windows-sys 0.60.2",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -4753,7 +4753,7 @@ dependencies = [
  "serde_json",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4837,7 +4837,7 @@ dependencies = [
  "rayon",
  "sha2 0.10.9",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "ttf-parser",
  "weezl",
@@ -5260,6 +5260,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,7 +5295,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5817,7 +5836,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5839,7 +5858,7 @@ dependencies = [
  "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6039,7 +6058,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -6113,7 +6132,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6340,7 +6359,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -6388,7 +6407,7 @@ dependencies = [
  "rig-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6474,6 +6493,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.0",
+ "oauth2",
  "pastey 0.2.2",
  "pin-project-lite",
  "process-wrap",
@@ -6483,11 +6503,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6827,6 +6848,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7345,11 +7377,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7487,7 +7539,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -7801,7 +7853,7 @@ dependencies = [
  "rustls 0.23.40",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -7933,6 +7985,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8774,7 +8827,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ mcp = [
     "rmcp?/client",
     "rmcp?/transport-child-process",
     "rmcp?/transport-streamable-http-client-reqwest",
+    "rmcp?/auth",
 ]
 acp = ["dep:agent-client-protocol", "dep:blocking"]
 memory = []                              

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -142,6 +142,8 @@ older daily logs are accessible via `/memory read` and `memory_search`.
 | ------- | ----------- |
 | `/mcp` | List connected MCP servers and their tool counts. |
 | `/mcp <server>` | List tools of a specific MCP server. |
+| `/mcp login <server>` | Run the OAuth 2.0 login flow for a URL server, then reconnect it. |
+| `/mcp logout <server>` | Remove a server's stored OAuth token. |
 
 ## Advisor (feature-gated)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -427,6 +427,47 @@ servers:
 }
 ```
 
+### OAuth for URL servers
+
+URL-based servers can authenticate with OAuth 2.0 (authorization code + PKCE).
+Add an `oauth` field. Use `true` for defaults (dynamic client registration, no
+extra scopes), or an object for explicit settings:
+
+```json
+{
+  "mcp_servers": {
+    "my-oauth-server": {
+      "url": "https://example.com/mcp",
+      "oauth": true
+    },
+    "scoped-server": {
+      "url": "https://api.example.com/mcp",
+      "oauth": {
+        "scopes": ["read", "write"],
+        "client_id": "pre-registered-client-id",
+        "redirect_port": 8970
+      }
+    }
+  }
+}
+```
+
+OAuth fields (all optional):
+
+| Field           | Default                        | Description                                                              |
+| --------------- | ------------------------------ | ------------------------------------------------------------------------ |
+| `scopes`        | none                           | Scopes to request during authorization.                                  |
+| `client_id`     | dynamic registration           | Pre-registered client id. When omitted, the client registers on the fly. |
+| `redirect_port` | `8970`                         | Loopback port for the redirect URI `http://127.0.0.1:<port>/callback`.   |
+
+The first time you connect, run `/mcp login <server>` inside the TUI. zerostack
+prints an authorization URL; open it in a browser, approve access, and the
+redirect is caught on the loopback port. The token is saved to
+`<data_dir>/mcp-oauth/<server>.json` (mode 0600 on unix). Later sessions reuse
+the stored refresh token and reconnect without a browser. Use
+`/mcp logout <server>` to remove a stored token. A server with OAuth enabled but
+no stored token fails to connect until you log in.
+
 ### Recommended MCP servers
 
 When `mcp_servers` is not explicitly set, three recommended MCP servers are

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -461,10 +461,13 @@ OAuth fields (all optional):
 | `redirect_port` | `8970`                         | Loopback port for the redirect URI `http://127.0.0.1:<port>/callback`.   |
 
 The first time you connect, run `/mcp login <server>` inside the TUI. zerostack
-prints an authorization URL; open it in a browser, approve access, and the
-redirect is caught on the loopback port. The token is saved to
-`<data_dir>/mcp-oauth/<server>.json` (mode 0600 on unix). Later sessions reuse
-the stored refresh token and reconnect without a browser. Use
+prints an authorization URL and copies it to your clipboard; open it in a
+browser, approve access, and the redirect is caught on the loopback port. The
+browser wait runs in the background, so the TUI stays responsive (you can keep
+working or select the URL with the mouse to copy it). The token is saved to
+`<data_dir>/mcp-oauth/<server>.json` (mode 0600 on unix), and the server
+reconnects automatically once authorization completes. Later sessions reuse the
+stored refresh token and reconnect without a browser. Use
 `/mcp logout <server>` to remove a stored token. A server with OAuth enabled but
 no stored token fails to connect until you log in.
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -223,6 +223,7 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
             .or_insert(McpServerConfig::Url {
                 url: "https://mcp.exa.ai/mcp".to_string(),
                 headers,
+                oauth: None,
             });
     } else {
         servers.remove("Exa Web Search");
@@ -238,6 +239,7 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
             .or_insert(McpServerConfig::Url {
                 url: "https://mcp.context7.com/mcp".to_string(),
                 headers,
+                oauth: None,
             });
     } else {
         servers.remove("Context7");
@@ -253,6 +255,7 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
             .or_insert(McpServerConfig::Url {
                 url: "https://mcp.grep.app".to_string(),
                 headers,
+                oauth: None,
             });
     } else {
         servers.remove("Grep.app");

--- a/src/event.rs
+++ b/src/event.rs
@@ -76,4 +76,11 @@ pub enum UserEvent {
         row: u16,
         col: u16,
     },
+    /// An interactive MCP OAuth login finished in a background task. `error` is
+    /// `None` on success. Handled by the TUI loop to reconnect the server.
+    #[cfg(feature = "mcp")]
+    McpLoginDone {
+        server: CompactString,
+        error: Option<CompactString>,
+    },
 }

--- a/src/extras/mcp/client.rs
+++ b/src/extras/mcp/client.rs
@@ -33,15 +33,34 @@ impl McpClientHandle {
                     running_service,
                 })
             }
-            McpServerConfig::Url { url, headers } => {
+            McpServerConfig::Url {
+                url,
+                headers,
+                oauth,
+            } => {
                 let custom_headers = parse_headers(headers)?;
                 let cfg = rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig::with_uri(url.as_str())
                     .custom_headers(custom_headers);
-                type HttpClient = rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
-                let transport = HttpClient::from_config(cfg);
-                let running_service = serve_client((), transport).await.map_err(|e| {
-                    anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
-                })?;
+
+                let oauth_settings = oauth.as_ref().and_then(|o| o.settings());
+                let running_service = if let Some(settings) = oauth_settings {
+                    let auth_client =
+                        super::oauth::build_auth_client(&server_name, url, &settings).await?;
+                    type AuthHttpClient = rmcp::transport::StreamableHttpClientTransport<
+                        rmcp::transport::auth::AuthClient<reqwest::Client>,
+                    >;
+                    let transport = AuthHttpClient::with_client(auth_client, cfg);
+                    serve_client((), transport).await.map_err(|e| {
+                        anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
+                    })?
+                } else {
+                    type HttpClient =
+                        rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
+                    let transport = HttpClient::from_config(cfg);
+                    serve_client((), transport).await.map_err(|e| {
+                        anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
+                    })?
+                };
                 Ok(Self {
                     server_name,
                     running_service,

--- a/src/extras/mcp/config.rs
+++ b/src/extras/mcp/config.rs
@@ -16,5 +16,54 @@ pub enum McpServerConfig {
         url: String,
         #[serde(default)]
         headers: HashMap<String, String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        oauth: Option<OAuthConfig>,
     },
+}
+
+/// OAuth settings for a URL-based MCP server.
+///
+/// Accepts either a bare `true` (enable with all defaults: dynamic client
+/// registration, no extra scopes) or an object with explicit fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OAuthConfig {
+    Enabled(bool),
+    Settings(OAuthSettings),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OAuthSettings {
+    /// OAuth scopes to request. Empty means none are requested explicitly.
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// Pre-registered client id. When absent, dynamic client registration is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// Loopback port for the redirect URI. Defaults to [`DEFAULT_REDIRECT_PORT`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redirect_port: Option<u16>,
+}
+
+pub const DEFAULT_REDIRECT_PORT: u16 = 8970;
+
+impl OAuthConfig {
+    /// Returns the resolved settings if OAuth is enabled, or `None` if disabled.
+    pub fn settings(&self) -> Option<OAuthSettings> {
+        match self {
+            OAuthConfig::Enabled(false) => None,
+            OAuthConfig::Enabled(true) => Some(OAuthSettings::default()),
+            OAuthConfig::Settings(s) => Some(s.clone()),
+        }
+    }
+}
+
+impl OAuthSettings {
+    pub fn redirect_port(&self) -> u16 {
+        self.redirect_port.unwrap_or(DEFAULT_REDIRECT_PORT)
+    }
+
+    pub fn redirect_uri(&self) -> String {
+        format!("http://127.0.0.1:{}/callback", self.redirect_port())
+    }
 }

--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod config;
+pub mod oauth;
 pub mod tool;
 
 use std::collections::HashMap;
@@ -61,6 +62,20 @@ impl McpClientManager {
             }
         }
         all_tools
+    }
+
+    /// (Re)connect a single server, replacing any existing handle for it.
+    /// Used after an interactive OAuth login so the server's tools become
+    /// available without restarting the session.
+    pub async fn reconnect(
+        &mut self,
+        name: &str,
+        cfg: &config::McpServerConfig,
+    ) -> anyhow::Result<()> {
+        let handle = client::McpClientHandle::connect(CompactString::new(name), cfg).await?;
+        self.handles.retain(|h| h.server_name != name);
+        self.handles.push(handle);
+        Ok(())
     }
 
     pub async fn shutdown(self) {

--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -13,11 +13,16 @@ use crate::permission::checker::PermCheck;
 
 pub struct McpClientManager {
     pub handles: Vec<client::McpClientHandle>,
+    /// Connection failures collected during `connect_all`, to be surfaced by the
+    /// TUI via the renderer. We do NOT log these at `warn` because that writes to
+    /// stderr, which corrupts the alt-screen TUI (overlapping the input box).
+    pub notices: Vec<CompactString>,
 }
 
 impl McpClientManager {
     pub async fn connect_all(configs: &HashMap<String, config::McpServerConfig>) -> Self {
         let mut handles = Vec::new();
+        let mut notices = Vec::new();
         for (name, cfg) in configs {
             match client::McpClientHandle::connect(CompactString::new(name.clone()), cfg).await {
                 Ok(handle) => {
@@ -25,11 +30,19 @@ impl McpClientManager {
                     handles.push(handle);
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to connect to MCP server '{}': {e}", name);
+                    tracing::debug!("Failed to connect to MCP server '{}': {e}", name);
+                    notices.push(CompactString::new(format!(
+                        "MCP server '{name}' not connected: {e}"
+                    )));
                 }
             }
         }
-        Self { handles }
+        Self { handles, notices }
+    }
+
+    /// Drain and return any pending connection notices.
+    pub fn take_notices(&mut self) -> Vec<CompactString> {
+        std::mem::take(&mut self.notices)
     }
 
     pub async fn collect_tools(

--- a/src/extras/mcp/oauth.rs
+++ b/src/extras/mcp/oauth.rs
@@ -1,0 +1,354 @@
+//! OAuth 2.0 (authorization code + PKCE) support for URL-based MCP servers.
+//!
+//! Tokens are persisted per server under `<data_dir>/mcp-oauth/<server>.json`
+//! (mode 0600 on unix) via a file-backed [`CredentialStore`]. The interactive
+//! login is driven from the `/mcp login <server>` slash command; afterwards the
+//! stored refresh token lets startup reconnect without a browser.
+
+use std::future::Future;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+
+use rmcp::transport::auth::{
+    AuthClient, AuthError, AuthorizationManager, AuthorizationSession, CredentialStore,
+    StoredCredentials,
+};
+
+use super::config::OAuthSettings;
+
+const CLIENT_NAME: &str = "zerostack";
+
+fn oauth_dir() -> PathBuf {
+    crate::session::storage::data_dir().join("mcp-oauth")
+}
+
+/// Sanitize a server name into a single safe filename component.
+pub(crate) fn token_filename(server_name: &str) -> String {
+    let sanitized: String = server_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{sanitized}.json")
+}
+
+fn token_path(server_name: &str) -> PathBuf {
+    oauth_dir().join(token_filename(server_name))
+}
+
+/// File-backed credential store. One JSON file per MCP server.
+struct FileCredentialStore {
+    path: PathBuf,
+}
+
+impl FileCredentialStore {
+    fn new(server_name: &str) -> Self {
+        Self {
+            path: token_path(server_name),
+        }
+    }
+
+    fn read_blocking(&self) -> Result<Option<StoredCredentials>, AuthError> {
+        let bytes = match std::fs::read(&self.path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(AuthError::InternalError(format!("read token file: {e}"))),
+        };
+        let creds = serde_json::from_slice(&bytes)
+            .map_err(|e| AuthError::InternalError(format!("parse token file: {e}")))?;
+        Ok(Some(creds))
+    }
+
+    fn write_blocking(&self, creds: &StoredCredentials) -> Result<(), AuthError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| AuthError::InternalError(format!("create token dir: {e}")))?;
+        }
+        let bytes = serde_json::to_vec_pretty(creds)
+            .map_err(|e| AuthError::InternalError(format!("serialize token: {e}")))?;
+        let tmp = self.path.with_extension("json.tmp");
+        let mut f = std::fs::File::create(&tmp)
+            .map_err(|e| AuthError::InternalError(format!("create token file: {e}")))?;
+        set_owner_only(&f);
+        f.write_all(&bytes)
+            .map_err(|e| AuthError::InternalError(format!("write token file: {e}")))?;
+        f.sync_all().ok();
+        std::fs::rename(&tmp, &self.path)
+            .map_err(|e| AuthError::InternalError(format!("persist token file: {e}")))?;
+        Ok(())
+    }
+
+    fn clear_blocking(&self) -> Result<(), AuthError> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(AuthError::InternalError(format!("remove token file: {e}"))),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_owner_only(f: &std::fs::File) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_f: &std::fs::File) {}
+
+// The `CredentialStore` trait is declared with `#[async_trait]`, so its methods
+// desugar to `-> Pin<Box<dyn Future + Send>>`. We implement that shape directly
+// to avoid pulling in the `async-trait` proc-macro as a dependency.
+type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, AuthError>> + Send + 'a>>;
+
+impl CredentialStore for FileCredentialStore {
+    fn load<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> StoreFuture<'async_trait, Option<StoredCredentials>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { self.read_blocking() })
+    }
+
+    fn save<'life0, 'async_trait>(
+        &'life0 self,
+        credentials: StoredCredentials,
+    ) -> StoreFuture<'async_trait, ()>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { self.write_blocking(&credentials) })
+    }
+
+    fn clear<'life0, 'async_trait>(&'life0 self) -> StoreFuture<'async_trait, ()>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { self.clear_blocking() })
+    }
+}
+
+/// Delete the stored token for a server. Returns whether a file was removed.
+pub fn logout(server_name: &str) -> anyhow::Result<bool> {
+    let path = token_path(server_name);
+    if !path.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_file(&path)?;
+    Ok(true)
+}
+
+/// Build an [`AuthClient`] for a server that already has stored credentials.
+///
+/// Returns an error (without prompting) when no usable token is stored, so the
+/// caller can tell the user to run `/mcp login`.
+pub async fn build_auth_client(
+    server_name: &str,
+    url: &str,
+    _settings: &OAuthSettings,
+) -> anyhow::Result<AuthClient<reqwest::Client>> {
+    let mut manager = AuthorizationManager::new(url)
+        .await
+        .map_err(|e| anyhow::anyhow!("OAuth init failed: {e}"))?;
+    manager.set_credential_store(FileCredentialStore::new(server_name));
+
+    let restored = manager
+        .initialize_from_store()
+        .await
+        .map_err(|e| anyhow::anyhow!("OAuth restore failed: {e}"))?;
+    if !restored {
+        anyhow::bail!("no OAuth token stored; run `/mcp login {server_name}`");
+    }
+
+    Ok(AuthClient::new(reqwest::Client::new(), manager))
+}
+
+/// Result of starting an interactive login: the URL to open and the live session.
+pub struct LoginSession {
+    pub auth_url: String,
+    session: AuthorizationSession,
+    redirect_port: u16,
+}
+
+/// Begin an interactive OAuth login: discover metadata, register/authorize, and
+/// return the URL the user must open. Call [`LoginSession::wait_for_callback`]
+/// to complete the flow.
+pub async fn begin_login(
+    server_name: &str,
+    url: &str,
+    settings: &OAuthSettings,
+) -> anyhow::Result<LoginSession> {
+    let mut manager = AuthorizationManager::new(url)
+        .await
+        .map_err(|e| anyhow::anyhow!("OAuth init failed: {e}"))?;
+    manager.set_credential_store(FileCredentialStore::new(server_name));
+
+    let metadata = manager
+        .discover_metadata()
+        .await
+        .map_err(|e| anyhow::anyhow!("OAuth metadata discovery failed: {e}"))?;
+    manager.set_metadata(metadata);
+
+    let redirect_uri = settings.redirect_uri();
+    let scope_refs: Vec<&str> = settings.scopes.iter().map(|s| s.as_str()).collect();
+
+    let session =
+        AuthorizationSession::new(manager, &scope_refs, &redirect_uri, Some(CLIENT_NAME), None)
+            .await
+            .map_err(|e| anyhow::anyhow!("OAuth authorization setup failed: {e}"))?;
+
+    Ok(LoginSession {
+        auth_url: session.get_authorization_url().to_string(),
+        session,
+        redirect_port: settings.redirect_port(),
+    })
+}
+
+impl LoginSession {
+    /// Run a one-shot loopback listener to catch the redirect, then exchange the
+    /// code for a token (persisted via the credential store). Times out after
+    /// `timeout`.
+    pub async fn wait_for_callback(self, timeout: Duration) -> anyhow::Result<()> {
+        let port = self.redirect_port;
+        let captured =
+            tokio::task::spawn_blocking(move || listen_for_callback(port, timeout)).await??;
+
+        self.session
+            .handle_callback(&captured.code, &captured.state)
+            .await
+            .map_err(|e| anyhow::anyhow!("OAuth token exchange failed: {e}"))?;
+        Ok(())
+    }
+}
+
+struct CapturedCode {
+    code: String,
+    state: String,
+}
+
+/// Blocking single-request loopback HTTP listener for the OAuth redirect.
+fn listen_for_callback(port: u16, timeout: Duration) -> anyhow::Result<CapturedCode> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port))
+        .map_err(|e| anyhow::anyhow!("cannot bind 127.0.0.1:{port} for OAuth redirect: {e}"))?;
+    listener.set_nonblocking(false).ok();
+
+    let deadline = std::time::Instant::now() + timeout;
+    // Poll accept with a short read timeout so the overall deadline is honored.
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| anyhow::anyhow!("listener config failed: {e}"))?;
+
+    loop {
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for OAuth redirect on port {port}");
+        }
+        match listener.accept() {
+            Ok((mut stream, _addr)) => {
+                stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                let request_line = read_request_line(&mut stream)?;
+                let (code, state) = parse_callback(&request_line)?;
+                let body = "<html><body><h3>zerostack: authorization complete.</h3>You can close this tab and return to the terminal.</body></html>";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+                return Ok(CapturedCode { code, state });
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return Err(anyhow::anyhow!("accept failed: {e}")),
+        }
+    }
+}
+
+fn read_request_line(stream: &mut std::net::TcpStream) -> anyhow::Result<String> {
+    let mut buf = [0u8; 4096];
+    let n = stream
+        .read(&mut buf)
+        .map_err(|e| anyhow::anyhow!("read redirect request failed: {e}"))?;
+    let text = String::from_utf8_lossy(&buf[..n]);
+    let first = text
+        .lines()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("empty redirect request"))?;
+    Ok(first.to_string())
+}
+
+/// Parse `GET /callback?code=...&state=... HTTP/1.1` and return (code, state).
+pub(crate) fn parse_callback(request_line: &str) -> anyhow::Result<(String, String)> {
+    let target = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("malformed redirect request line"))?;
+    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
+
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    for pair in query.split('&') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
+        let v = percent_decode(v);
+        match k {
+            "code" => code = Some(v),
+            "state" => state = Some(v),
+            "error" => error = Some(v),
+            _ => {}
+        }
+    }
+
+    if let Some(err) = error {
+        anyhow::bail!("authorization server returned an error: {err}");
+    }
+    match (code, state) {
+        (Some(code), Some(state)) => Ok((code, state)),
+        _ => anyhow::bail!("redirect missing code or state"),
+    }
+}
+
+/// Minimal percent-decoding for query values (handles `%XX` and `+`).
+pub(crate) fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}

--- a/src/tests/mcp_oauth_tests.rs
+++ b/src/tests/mcp_oauth_tests.rs
@@ -1,0 +1,131 @@
+use crate::extras::mcp::config::{
+    DEFAULT_REDIRECT_PORT, McpServerConfig, OAuthConfig, OAuthSettings,
+};
+use crate::extras::mcp::oauth;
+
+#[test]
+fn url_server_without_oauth_parses() {
+    let json = r#"{ "url": "https://example.com/mcp" }"#;
+    let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+    match cfg {
+        McpServerConfig::Url { url, oauth, .. } => {
+            assert_eq!(url, "https://example.com/mcp");
+            assert!(oauth.is_none());
+        }
+        _ => panic!("expected Url variant"),
+    }
+}
+
+#[test]
+fn oauth_true_enables_with_defaults() {
+    let json = r#"{ "url": "https://example.com/mcp", "oauth": true }"#;
+    let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+    let McpServerConfig::Url { oauth, .. } = cfg else {
+        panic!("expected Url variant");
+    };
+    let settings = oauth.unwrap().settings().expect("oauth enabled");
+    assert!(settings.scopes.is_empty());
+    assert!(settings.client_id.is_none());
+    assert_eq!(settings.redirect_port(), DEFAULT_REDIRECT_PORT);
+}
+
+#[test]
+fn oauth_false_disables() {
+    let json = r#"{ "url": "https://example.com/mcp", "oauth": false }"#;
+    let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+    let McpServerConfig::Url { oauth, .. } = cfg else {
+        panic!("expected Url variant");
+    };
+    assert!(oauth.unwrap().settings().is_none());
+}
+
+#[test]
+fn oauth_object_parses_fields() {
+    let json = r#"{
+        "url": "https://example.com/mcp",
+        "oauth": { "scopes": ["read", "write"], "client_id": "abc", "redirect_port": 9123 }
+    }"#;
+    let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+    let McpServerConfig::Url { oauth, .. } = cfg else {
+        panic!("expected Url variant");
+    };
+    let settings = oauth.unwrap().settings().unwrap();
+    assert_eq!(
+        settings.scopes,
+        vec!["read".to_string(), "write".to_string()]
+    );
+    assert_eq!(settings.client_id.as_deref(), Some("abc"));
+    assert_eq!(settings.redirect_port(), 9123);
+    assert_eq!(settings.redirect_uri(), "http://127.0.0.1:9123/callback");
+}
+
+#[test]
+fn default_redirect_uri_uses_loopback() {
+    let settings = OAuthSettings::default();
+    assert_eq!(
+        settings.redirect_uri(),
+        format!("http://127.0.0.1:{DEFAULT_REDIRECT_PORT}/callback")
+    );
+}
+
+#[test]
+fn token_filename_sanitizes_server_name() {
+    assert_eq!(
+        oauth::token_filename("Exa Web Search"),
+        "Exa_Web_Search.json"
+    );
+    assert_eq!(oauth::token_filename("../etc/passwd"), "___etc_passwd.json");
+    assert_eq!(oauth::token_filename("plain-name_1"), "plain-name_1.json");
+}
+
+#[test]
+fn parse_callback_extracts_code_and_state() {
+    let line = "GET /callback?code=abc123&state=xyz789 HTTP/1.1";
+    let (code, state) = oauth::parse_callback(line).unwrap();
+    assert_eq!(code, "abc123");
+    assert_eq!(state, "xyz789");
+}
+
+#[test]
+fn parse_callback_decodes_percent_escapes() {
+    let line = "GET /callback?code=a%2Fb%2Bc&state=s%20t HTTP/1.1";
+    let (code, state) = oauth::parse_callback(line).unwrap();
+    assert_eq!(code, "a/b+c");
+    assert_eq!(state, "s t");
+}
+
+#[test]
+fn parse_callback_reports_server_error() {
+    let line = "GET /callback?error=access_denied HTTP/1.1";
+    assert!(oauth::parse_callback(line).is_err());
+}
+
+#[test]
+fn parse_callback_missing_params_errors() {
+    let line = "GET /callback?code=only HTTP/1.1";
+    assert!(oauth::parse_callback(line).is_err());
+}
+
+#[test]
+fn percent_decode_handles_plus_and_hex() {
+    assert_eq!(oauth::percent_decode("a+b"), "a b");
+    assert_eq!(oauth::percent_decode("%41%42"), "AB");
+    assert_eq!(oauth::percent_decode("nochange"), "nochange");
+    // Malformed escape is left as-is.
+    assert_eq!(oauth::percent_decode("%zz"), "%zz");
+}
+
+#[test]
+fn oauth_config_round_trips_through_serde() {
+    let cfg = McpServerConfig::Url {
+        url: "https://example.com/mcp".to_string(),
+        headers: Default::default(),
+        oauth: Some(OAuthConfig::Enabled(true)),
+    };
+    let json = serde_json::to_string(&cfg).unwrap();
+    let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+    let McpServerConfig::Url { oauth, .. } = back else {
+        panic!("expected Url variant");
+    };
+    assert!(oauth.unwrap().settings().is_some());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -30,6 +30,8 @@ mod list_dir_tests;
 mod loop_tests;
 #[cfg(test)]
 mod markdown_tests;
+#[cfg(all(test, feature = "mcp"))]
+mod mcp_oauth_tests;
 #[cfg(all(test, feature = "memory"))]
 mod memory_tests;
 #[cfg(all(test, feature = "multimodal"))]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1651,6 +1651,39 @@ pub async fn run_interactive(
                                         }
                                         let _ = crate::session::storage::save_session(session);
                                     }
+                                    #[cfg(feature = "mcp")]
+                                    Err(e) if e.to_string().starts_with(crate::ui::slash::settings::DEFER_MCP_RECONNECT) => {
+                                        let server = e.to_string()
+                                            .strip_prefix(crate::ui::slash::settings::DEFER_MCP_RECONNECT)
+                                            .unwrap_or_default()
+                                            .trim()
+                                            .to_string();
+                                        let server_cfg = cfg.mcp_servers.as_ref().and_then(|m| m.get(&server).cloned());
+                                        match (mcp_manager.as_mut(), server_cfg) {
+                                            (Some(mgr), Some(scfg)) => {
+                                                match mgr.reconnect(&server, &scfg).await {
+                                                    Ok(()) => {
+                                                        let model = client.completion_model(session.model.to_string());
+                                                        let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                                                        let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+                                                        agent = Some(crate::provider::build_agent(
+                                                            model, cli, cfg, context,
+                                                            permission.clone(), ask_tx.clone(), sandbox.clone(),
+                                                            reasoning_enabled, temperature, extra_body,
+                                                            mcp_manager.as_ref(),
+                                                        ).await);
+                                                        renderer.write_line(&format!("connected '{}'", server), C_AGENT)?;
+                                                    }
+                                                    Err(err) => {
+                                                        renderer.write_line(&format!("reconnect failed for '{}': {}", server, err), C_ERROR)?;
+                                                    }
+                                                }
+                                            }
+                                            _ => {
+                                                renderer.write_line(&format!("cannot reconnect '{}' (not configured)", server), C_ERROR)?;
+                                            }
+                                        }
+                                    }
                                     #[cfg(feature = "git-worktree")]
                                     Err(e) if e.downcast_ref::<crate::extras::git_worktree::DeferredWorktreeAction>().is_some() => {
                                         let action = e.downcast_ref::<crate::extras::git_worktree::DeferredWorktreeAction>().unwrap();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1984,6 +1984,29 @@ pub async fn run_interactive(
                     }
                 }
             }
+            // Consume the background prebuild as soon as it is ready (while idle)
+            // so MCP connection notices render in the transcript instead of the
+            // prebuild's stderr logging racing against the alt-screen TUI.
+            Some(prebuilt) = async { prebuild_rx.as_mut()?.recv().await }, if agent.is_none() => {
+                #[cfg(feature = "mcp")]
+                {
+                    let (built_agent, built_mcp) = prebuilt;
+                    agent = Some(built_agent);
+                    mcp_manager = built_mcp;
+                    if let Some(m) = mcp_manager.as_mut() {
+                        for notice in m.take_notices() {
+                            renderer.write_line(&notice, C_ERROR)?;
+                        }
+                    }
+                }
+                #[cfg(not(feature = "mcp"))]
+                {
+                    agent = Some(prebuilt);
+                }
+                prebuild_rx = None;
+                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                continue;
+            }
             Some(event) = async {
                 agent_rx.as_mut()?.recv().await
             } => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1081,6 +1081,41 @@ pub async fn run_interactive(
                         refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
+                    #[cfg(feature = "mcp")]
+                    UserEvent::McpLoginDone { server, error } => {
+                        if let Some(err) = error {
+                            renderer.write_line(&format!("login failed for '{}': {}", server, err), C_ERROR)?;
+                        } else {
+                            let server = server.to_string();
+                            let server_cfg = cfg.mcp_servers.as_ref().and_then(|m| m.get(&server).cloned());
+                            match (mcp_manager.as_mut(), server_cfg) {
+                                (Some(mgr), Some(scfg)) => {
+                                    match mgr.reconnect(&server, &scfg).await {
+                                        Ok(()) => {
+                                            let model = client.completion_model(session.model.to_string());
+                                            let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
+                                            let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+                                            agent = Some(crate::provider::build_agent(
+                                                model, cli, cfg, context,
+                                                permission.clone(), ask_tx.clone(), sandbox.clone(),
+                                                reasoning_enabled, temperature, extra_body,
+                                                mcp_manager.as_ref(),
+                                            ).await);
+                                            renderer.write_line(&format!("authorized and connected '{}'", server), C_AGENT)?;
+                                        }
+                                        Err(err) => {
+                                            renderer.write_line(&format!("authorized '{}' but reconnect failed: {}", server, err), C_ERROR)?;
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    renderer.write_line(&format!("authorized '{}' (will connect on next start)", server), C_AGENT)?;
+                                }
+                            }
+                        }
+                        refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                        continue;
+                    }
                     UserEvent::Key(key) => {
                         let is_ctrl_c = key.code == KeyCode::Char('c')
                             && key.modifiers.contains(KeyModifiers::CONTROL);
@@ -1652,35 +1687,54 @@ pub async fn run_interactive(
                                         let _ = crate::session::storage::save_session(session);
                                     }
                                     #[cfg(feature = "mcp")]
-                                    Err(e) if e.to_string().starts_with(crate::ui::slash::settings::DEFER_MCP_RECONNECT) => {
+                                    Err(e) if e.to_string().starts_with(crate::ui::slash::settings::DEFER_MCP_LOGIN) => {
                                         let server = e.to_string()
-                                            .strip_prefix(crate::ui::slash::settings::DEFER_MCP_RECONNECT)
+                                            .strip_prefix(crate::ui::slash::settings::DEFER_MCP_LOGIN)
                                             .unwrap_or_default()
                                             .trim()
                                             .to_string();
-                                        let server_cfg = cfg.mcp_servers.as_ref().and_then(|m| m.get(&server).cloned());
-                                        match (mcp_manager.as_mut(), server_cfg) {
-                                            (Some(mgr), Some(scfg)) => {
-                                                match mgr.reconnect(&server, &scfg).await {
-                                                    Ok(()) => {
-                                                        let model = client.completion_model(session.model.to_string());
-                                                        let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-                                                        let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
-                                                        agent = Some(crate::provider::build_agent(
-                                                            model, cli, cfg, context,
-                                                            permission.clone(), ask_tx.clone(), sandbox.clone(),
-                                                            reasoning_enabled, temperature, extra_body,
-                                                            mcp_manager.as_ref(),
-                                                        ).await);
-                                                        renderer.write_line(&format!("connected '{}'", server), C_AGENT)?;
+                                        // Re-resolve the URL server + OAuth settings from config.
+                                        let resolved = cfg.mcp_servers.as_ref().and_then(|m| m.get(&server)).and_then(|s| {
+                                            if let crate::extras::mcp::config::McpServerConfig::Url { url, oauth, .. } = s {
+                                                oauth.as_ref().and_then(|o| o.settings()).map(|set| (url.clone(), set))
+                                            } else {
+                                                None
+                                            }
+                                        });
+                                        match resolved {
+                                            Some((url, settings)) => {
+                                                renderer.write_line(&format!("starting OAuth login for '{}'...", server), C_AGENT)?;
+                                                match crate::extras::mcp::oauth::begin_login(&server, &url, &settings).await {
+                                                    Ok(login) => {
+                                                        // Auto-copy so the user can paste it; print it on its
+                                                        // own line so terminals linkify it and it selects cleanly.
+                                                        copy_to_clipboard(&login.auth_url);
+                                                        renderer.write_line("open this URL to authorize (copied to clipboard):", C_AGENT)?;
+                                                        renderer.write_line(&login.auth_url, Color::Cyan)?;
+                                                        renderer.write_line(
+                                                            &format!("waiting for authorization on 127.0.0.1:{} in the background...", settings.redirect_port()),
+                                                            Color::DarkGrey,
+                                                        )?;
+                                                        // Run the (long) browser wait off the event loop so the
+                                                        // TUI stays responsive; report back via UserEvent.
+                                                        let tx = user_tx.clone();
+                                                        let sname = compact_str::CompactString::new(&server);
+                                                        tokio::spawn(async move {
+                                                            let error = login
+                                                                .wait_for_callback(std::time::Duration::from_secs(180))
+                                                                .await
+                                                                .err()
+                                                                .map(|e| compact_str::CompactString::new(e.to_string()));
+                                                            let _ = tx.send(crate::event::UserEvent::McpLoginDone { server: sname, error }).await;
+                                                        });
                                                     }
                                                     Err(err) => {
-                                                        renderer.write_line(&format!("reconnect failed for '{}': {}", server, err), C_ERROR)?;
+                                                        renderer.write_line(&format!("login setup failed for '{}': {}", server, err), C_ERROR)?;
                                                     }
                                                 }
                                             }
-                                            _ => {
-                                                renderer.write_line(&format!("cannot reconnect '{}' (not configured)", server), C_ERROR)?;
+                                            None => {
+                                                renderer.write_line(&format!("cannot start login for '{}' (not an OAuth URL server)", server), C_ERROR)?;
                                             }
                                         }
                                     }

--- a/src/ui/slash/help.rs
+++ b/src/ui/slash/help.rs
@@ -72,6 +72,14 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
             ctx.renderer,
             "  /mcp <server>          list tools of an MCP server",
         );
+        write_result(
+            ctx.renderer,
+            "  /mcp login <server>    OAuth login to an MCP server",
+        );
+        write_result(
+            ctx.renderer,
+            "  /mcp logout <server>   remove a server's stored OAuth token",
+        );
     }
     write_result(ctx.renderer, "  /clear [/new]          clear screen");
     write_result(ctx.renderer, "  /undo                  undo last exchange");

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -7,7 +7,7 @@ mod memory;
 mod providers;
 pub(crate) mod review;
 mod session;
-mod settings;
+pub(crate) mod settings;
 
 pub(crate) use providers::warm_model_cache;
 

--- a/src/ui/slash/settings.rs
+++ b/src/ui/slash/settings.rs
@@ -326,8 +326,20 @@ async fn handle_editsys(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resul
     Ok(())
 }
 
+/// Prefix understood by the caller in `ui::mod` to reconnect a single MCP
+/// server (and rebuild the agent) after a successful interactive OAuth login.
+#[cfg(feature = "mcp")]
+pub(crate) const DEFER_MCP_RECONNECT: &str = "DEFER_MCP_RECONNECT:";
+
 #[cfg(feature = "mcp")]
 async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    if parts.len() >= 2 && parts[1] == "login" {
+        return handle_mcp_login(parts.get(2).map(|s| s.trim()), ctx).await;
+    }
+    if parts.len() >= 2 && parts[1] == "logout" {
+        return handle_mcp_logout(parts.get(2).map(|s| s.trim()), ctx);
+    }
+
     let Some(mgr) = ctx.mcp_manager else {
         write_ok(ctx.renderer, "no MCP servers configured");
         return Ok(());
@@ -377,6 +389,106 @@ async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         } else {
             write_error(ctx.renderer, format!("unknown MCP server: '{}'", name));
         }
+    }
+    Ok(())
+}
+
+/// Resolve a URL-based server's OAuth settings + url from config, or report why not.
+#[cfg(feature = "mcp")]
+fn resolve_oauth_server(
+    ctx: &SlashCtx<'_>,
+    name: &str,
+) -> Result<(String, crate::extras::mcp::config::OAuthSettings), String> {
+    use crate::extras::mcp::config::McpServerConfig;
+    let servers = ctx
+        .cfg
+        .mcp_servers
+        .as_ref()
+        .ok_or_else(|| "no MCP servers configured".to_string())?;
+    let server = servers
+        .get(name)
+        .ok_or_else(|| format!("unknown MCP server: '{name}'"))?;
+    match server {
+        McpServerConfig::Url { url, oauth, .. } => {
+            let settings = oauth
+                .as_ref()
+                .and_then(|o| o.settings())
+                .ok_or_else(|| format!("server '{name}' does not have OAuth enabled"))?;
+            Ok((url.clone(), settings))
+        }
+        McpServerConfig::Command { .. } => Err(format!(
+            "server '{name}' is command-based; OAuth applies to URL servers"
+        )),
+    }
+}
+
+#[cfg(feature = "mcp")]
+async fn handle_mcp_login(name: Option<&str>, ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    let Some(name) = name.filter(|n| !n.is_empty()) else {
+        write_error(ctx.renderer, "usage: /mcp login <server>");
+        return Ok(());
+    };
+    let (url, settings) = match resolve_oauth_server(ctx, name) {
+        Ok(v) => v,
+        Err(e) => {
+            write_error(ctx.renderer, e);
+            return Ok(());
+        }
+    };
+
+    write_ok(
+        ctx.renderer,
+        format!("starting OAuth login for '{name}'..."),
+    );
+    let login = match crate::extras::mcp::oauth::begin_login(name, &url, &settings).await {
+        Ok(l) => l,
+        Err(e) => {
+            write_error(ctx.renderer, format!("login setup failed: {e}"));
+            return Ok(());
+        }
+    };
+
+    write_ok(ctx.renderer, "open this URL in your browser to authorize:");
+    write_result(ctx.renderer, &login.auth_url);
+    write_ok(
+        ctx.renderer,
+        format!(
+            "waiting for the redirect on 127.0.0.1:{} (up to 3 min)...",
+            settings.redirect_port()
+        ),
+    );
+    // Force a draw so the URL is visible before we block on the callback.
+    ctx.renderer.render_viewport()?;
+
+    match login
+        .wait_for_callback(std::time::Duration::from_secs(180))
+        .await
+    {
+        Ok(()) => {
+            write_ok(ctx.renderer, format!("authorized '{name}', connecting..."));
+            // Hand control back to the event loop to reconnect with the new token.
+            Err(anyhow::anyhow!("{}{}", DEFER_MCP_RECONNECT, name))
+        }
+        Err(e) => {
+            write_error(ctx.renderer, format!("login failed: {e}"));
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn handle_mcp_logout(name: Option<&str>, ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    let Some(name) = name.filter(|n| !n.is_empty()) else {
+        write_error(ctx.renderer, "usage: /mcp logout <server>");
+        return Ok(());
+    };
+    match crate::extras::mcp::oauth::logout(name) {
+        Ok(true) => write_ok(
+            ctx.renderer,
+            format!("removed stored OAuth token for '{name}' (effective next start)"),
+        ),
+        Ok(false) => write_ok(ctx.renderer, format!("no stored OAuth token for '{name}'")),
+        Err(e) => write_error(ctx.renderer, format!("logout failed: {e}")),
     }
     Ok(())
 }

--- a/src/ui/slash/settings.rs
+++ b/src/ui/slash/settings.rs
@@ -345,27 +345,9 @@ async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         write_ok(ctx.renderer, "no MCP servers configured");
         return Ok(());
     };
-    if mgr.handles.is_empty() {
-        write_ok(ctx.renderer, "no MCP servers connected");
-    } else if parts.len() == 1 {
-        write_ok(ctx.renderer, "MCP servers:");
-        for handle in &mgr.handles {
-            match handle.list_tools().await {
-                Ok(tools) => {
-                    write_result(
-                        ctx.renderer,
-                        format!("  {} ({} tools)", handle.server_name, tools.len()),
-                    );
-                }
-                Err(e) => {
-                    write_error(
-                        ctx.renderer,
-                        format!("  {} (error: {})", handle.server_name, e),
-                    );
-                }
-            }
-        }
-    } else {
+
+    // `/mcp <server>` — list tools for one server.
+    if parts.len() > 1 {
         let name = parts[1].trim();
         if let Some(handle) = mgr.handles.iter().find(|h| h.server_name == name) {
             match handle.list_tools().await {
@@ -387,11 +369,74 @@ async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
                     );
                 }
             }
+        } else if is_oauth_server(ctx, name) {
+            write_error(
+                ctx.renderer,
+                format!("server '{name}' is not connected (run /mcp login {name})"),
+            );
+        } else if server_is_configured(ctx, name) {
+            write_error(ctx.renderer, format!("server '{name}' is not connected"));
         } else {
-            write_error(ctx.renderer, format!("unknown MCP server: '{}'", name));
+            write_error(ctx.renderer, format!("unknown MCP server: '{name}'"));
+        }
+        return Ok(());
+    }
+
+    // `/mcp` — list all configured servers, green = connected, red = not.
+    let Some(servers) = ctx.cfg.mcp_servers.as_ref().filter(|s| !s.is_empty()) else {
+        write_ok(ctx.renderer, "no MCP servers configured");
+        return Ok(());
+    };
+    write_ok(ctx.renderer, "MCP servers:");
+    let mut names: Vec<&String> = servers.keys().collect();
+    names.sort();
+    for name in names {
+        if let Some(handle) = mgr
+            .handles
+            .iter()
+            .find(|h| h.server_name.as_str() == name.as_str())
+        {
+            let label = match handle.list_tools().await {
+                Ok(tools) => format!("  + {name} ({} tools)", tools.len()),
+                Err(_) => format!("  + {name} (connected)"),
+            };
+            ctx.renderer
+                .write_line(&label, crossterm::style::Color::Green)?;
+        } else {
+            let oauth = matches!(
+                servers.get(name),
+                Some(crate::extras::mcp::config::McpServerConfig::Url { oauth: Some(o), .. })
+                    if o.settings().is_some()
+            );
+            let label = if oauth {
+                format!("  - {name} (unauthenticated, run /mcp login {name})")
+            } else {
+                format!("  - {name} (not connected)")
+            };
+            ctx.renderer
+                .write_line(&label, crossterm::style::Color::Red)?;
         }
     }
     Ok(())
+}
+
+/// True if a server name exists in config.
+#[cfg(feature = "mcp")]
+fn server_is_configured(ctx: &SlashCtx<'_>, name: &str) -> bool {
+    ctx.cfg
+        .mcp_servers
+        .as_ref()
+        .is_some_and(|m| m.contains_key(name))
+}
+
+/// True if a configured server is a URL server with OAuth enabled.
+#[cfg(feature = "mcp")]
+fn is_oauth_server(ctx: &SlashCtx<'_>, name: &str) -> bool {
+    use crate::extras::mcp::config::McpServerConfig;
+    matches!(
+        ctx.cfg.mcp_servers.as_ref().and_then(|m| m.get(name)),
+        Some(McpServerConfig::Url { oauth: Some(o), .. }) if o.settings().is_some()
+    )
 }
 
 /// Resolve a URL-based server's OAuth settings + url from config, or report why not.

--- a/src/ui/slash/settings.rs
+++ b/src/ui/slash/settings.rs
@@ -326,10 +326,11 @@ async fn handle_editsys(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resul
     Ok(())
 }
 
-/// Prefix understood by the caller in `ui::mod` to reconnect a single MCP
-/// server (and rebuild the agent) after a successful interactive OAuth login.
+/// Prefix understood by the caller in `ui::mod` to start the interactive OAuth
+/// login for a server. The login (browser wait) runs there as a background task
+/// so the TUI stays responsive; on success the server is reconnected.
 #[cfg(feature = "mcp")]
-pub(crate) const DEFER_MCP_RECONNECT: &str = "DEFER_MCP_RECONNECT:";
+pub(crate) const DEFER_MCP_LOGIN: &str = "DEFER_MCP_LOGIN:";
 
 #[cfg(feature = "mcp")]
 async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
@@ -428,52 +429,14 @@ async fn handle_mcp_login(name: Option<&str>, ctx: &mut SlashCtx<'_>) -> anyhow:
         write_error(ctx.renderer, "usage: /mcp login <server>");
         return Ok(());
     };
-    let (url, settings) = match resolve_oauth_server(ctx, name) {
-        Ok(v) => v,
-        Err(e) => {
-            write_error(ctx.renderer, e);
-            return Ok(());
-        }
-    };
-
-    write_ok(
-        ctx.renderer,
-        format!("starting OAuth login for '{name}'..."),
-    );
-    let login = match crate::extras::mcp::oauth::begin_login(name, &url, &settings).await {
-        Ok(l) => l,
-        Err(e) => {
-            write_error(ctx.renderer, format!("login setup failed: {e}"));
-            return Ok(());
-        }
-    };
-
-    write_ok(ctx.renderer, "open this URL in your browser to authorize:");
-    write_result(ctx.renderer, &login.auth_url);
-    write_ok(
-        ctx.renderer,
-        format!(
-            "waiting for the redirect on 127.0.0.1:{} (up to 3 min)...",
-            settings.redirect_port()
-        ),
-    );
-    // Force a draw so the URL is visible before we block on the callback.
-    ctx.renderer.render_viewport()?;
-
-    match login
-        .wait_for_callback(std::time::Duration::from_secs(180))
-        .await
-    {
-        Ok(()) => {
-            write_ok(ctx.renderer, format!("authorized '{name}', connecting..."));
-            // Hand control back to the event loop to reconnect with the new token.
-            Err(anyhow::anyhow!("{}{}", DEFER_MCP_RECONNECT, name))
-        }
-        Err(e) => {
-            write_error(ctx.renderer, format!("login failed: {e}"));
-            Ok(())
-        }
+    // Validate config here so errors get friendly messages. The actual login
+    // (network discovery + browser wait) runs in the event loop, which spawns
+    // the wait as a background task so the TUI never freezes.
+    if let Err(e) = resolve_oauth_server(ctx, name) {
+        write_error(ctx.renderer, e);
+        return Ok(());
     }
+    Err(anyhow::anyhow!("{}{}", DEFER_MCP_LOGIN, name))
 }
 
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
## What

Adds OAuth 2.0 (authorization code + PKCE) support for URL-based MCP servers, using rmcp 1.7's `auth` module.

## Config

URL servers gain an optional `oauth` field. Use `true` for defaults (dynamic client registration, no extra scopes, loopback port 8970), or an object for explicit settings:

```json
{
  "mcp_servers": {
    "my-oauth-server": { "url": "https://example.com/mcp", "oauth": true },
    "scoped-server": {
      "url": "https://api.example.com/mcp",
      "oauth": { "scopes": ["read", "write"], "client_id": "abc", "redirect_port": 8970 }
    }
  }
}
```

## How it works

- Tokens persist per server under `<data_dir>/mcp-oauth/<server>.json` at mode 0600 (atomic write). Later sessions reconnect with the stored refresh token, no browser.
- The `CredentialStore` impl is hand-written (desugared async) so no `async-trait` crate is added; the loopback redirect uses `std::net::TcpListener` so no tokio `net` feature is needed.
- `/mcp login <server>` runs the flow in the TUI: prints the auth URL, catches the redirect, exchanges the code, then reconnects that server and rebuilds the agent live (no restart).
- `/mcp logout <server>` removes a stored token.
- OAuth URL servers connect through `AuthClient` + `StreamableHttpClientTransport::with_client`; non-OAuth paths are unchanged.

## Notes / tradeoffs

- Enables rmcp's `auth` feature (`rmcp?/auth`), which pulls in `oauth2` and a TLS/crypto backend (`aws-lc-rs`). Binary size grows somewhat; inherent to OAuth.
- During login the TUI event loop blocks until the redirect arrives (3 min timeout); not cancellable mid-wait. Could move to a background task later.
- Only authorization code + PKCE is implemented; client-credentials (M2M) is not wired up.

## Tests

12 new tests cover config parsing (`true` / object / disabled), redirect URI, filename sanitization, and callback parsing. Full suite: 475 pass with `mcp`, 463 without.

## Docs

`docs/CONFIG.md` documents the `oauth` field and login flow; `docs/COMMANDS.md` lists the new subcommands.
