### PR TITLE
fix(session): refresh context window from catalog on resume

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -222,17 +222,21 @@ impl Config {
         if let Some(cw) = self.context_window {
             return cw;
         }
-        if let Some(entries) = crate::models_catalog::catalog_entries(provider) {
-            for e in entries {
-                if e.id == model_id {
-                    if let Some(cl) = e.context_length {
-                        return cl as u64;
-                    }
-                    break;
-                }
-            }
-        }
-        128_000
+        Self::catalog_context_window(provider, model_id).unwrap_or(128_000)
+    }
+
+    /// The model's context window straight from the static catalog, or `None`
+    /// when the provider/model is not listed (custom gateways, ollama, or an id
+    /// without a `context` entry). Unlike [`resolve_context_window`], this
+    /// ignores the config override and the 128k fallback, so callers can tell a
+    /// real catalog value apart from the default.
+    pub fn catalog_context_window(provider: &str, model_id: &str) -> Option<u64> {
+        let entries = crate::models_catalog::catalog_entries(provider)?;
+        entries
+            .iter()
+            .find(|e| e.id == model_id)
+            .and_then(|e| e.context_length)
+            .map(|cl| cl as u64)
     }
 
     pub fn resolve_reserve_tokens(

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,19 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    // A resumed session persisted its context_window when first saved, which can
+    // be stale if the model's catalog entry has changed since (e.g. a model that
+    // grew from 128k to 1M). Re-derive it from the catalog for the session's own
+    // model, unless the user pinned `context_window` in config (then that wins).
+    if cfg.context_window.is_none()
+        && let Some(cw) = config::Config::catalog_context_window(
+            session.provider.as_str(),
+            session.model.as_str(),
+        )
+    {
+        session.update_context_window(cw);
+    }
+
     let client = provider::create_client(
         &provider,
         cli.api_key.as_deref(),

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -123,3 +123,34 @@ fn context_exhausted_report_math() {
     );
     assert!(joined.contains("hold 18000+ tokens"), "{joined}");
 }
+
+#[test]
+fn catalog_context_window_reads_known_model() {
+    // deepseek-v4-pro is a 1M-context model in the baked openrouter catalog.
+    assert_eq!(
+        Config::catalog_context_window("openrouter", "deepseek/deepseek-v4-pro"),
+        Some(1_048_576)
+    );
+}
+
+#[test]
+fn catalog_context_window_none_for_unknown() {
+    assert!(Config::catalog_context_window("openrouter", "no/such-model").is_none());
+    // Providers without a baked catalog (custom gateways, ollama) return None.
+    assert!(Config::catalog_context_window("ollama", "llama3.1").is_none());
+}
+
+#[test]
+fn resolve_context_window_prefers_config_pin_over_catalog() {
+    let cfg: Config = serde_json::from_str(r#"{ "context_window": 128000 }"#).unwrap();
+    assert_eq!(
+        cfg.resolve_context_window("openrouter", "deepseek/deepseek-v4-pro"),
+        128_000
+    );
+    // Without a pin, the catalog's 1M wins.
+    let cfg = Config::default();
+    assert_eq!(
+        cfg.resolve_context_window("openrouter", "deepseek/deepseek-v4-pro"),
+        1_048_576
+    );
+}


### PR DESCRIPTION
## What

Fixes a resumed session showing a stale context window. For example `deepseek/deepseek-v4-pro` (1M in the catalog) kept showing 128k after resume.

## Cause

`--continue` / `--session` load a saved session as-is, and `Session.context_window` is persisted. A session first saved before its model had a catalog entry (or saved on a different model) kept the old value forever, even after the catalog became correct. Fresh sessions, `/model`, and `/provider` all re-resolve correctly; only resume did not.

## Fix

- Add `Config::catalog_context_window(provider, model) -> Option<u64>`, which returns the catalog value only (no config override, no 128k fallback), so a real catalog hit is distinguishable from the default. `resolve_context_window` now builds on it.
- On session load (`main.rs`), if the user has not pinned `context_window` in config and the catalog knows the session's model, refresh the window. A pinned config value still wins everywhere; custom or unlisted models keep their persisted value (no accidental shrink); idempotent for fresh sessions.

## Tests

Catalog lookup for a known 1M model, `None` for unknown/no-catalog providers, and config-pin precedence over the catalog.
