### PR TITLE
feat(ui): show git branch and context size in the status bar

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -66,6 +66,10 @@ pub struct Session {
     #[cfg(feature = "multimodal")]
     #[serde(skip)]
     pub pending_media: Vec<crate::extras::multimodal::MediaAttachment>,
+    /// Current git branch of `working_dir`, for the status bar. Refreshed at
+    /// runtime, not persisted.
+    #[serde(skip)]
+    pub git_branch: Option<CompactString>,
 }
 
 impl Session {
@@ -121,7 +125,46 @@ impl Session {
             permission_allowlist: Vec::new(),
             #[cfg(feature = "multimodal")]
             pending_media: Vec::new(),
+            git_branch: None,
         }
+    }
+
+    /// Read the current git branch for `dir`, or `None` outside a repo / on a
+    /// detached HEAD (then a short commit hash is returned instead). Reads
+    /// `.git/HEAD` directly (cheap) rather than spawning git, and follows the
+    /// `.git` file pointer used by worktrees and submodules.
+    pub fn detect_git_branch(dir: &str) -> Option<CompactString> {
+        use std::path::{Path, PathBuf};
+        let dir_path = Path::new(dir);
+        let dot_git = dir_path.join(".git");
+        let gitdir = if dot_git.is_dir() {
+            dot_git
+        } else if dot_git.is_file() {
+            let content = std::fs::read_to_string(&dot_git).ok()?;
+            let rel = content.strip_prefix("gitdir:")?.trim();
+            let p = PathBuf::from(rel);
+            if p.is_absolute() { p } else { dir_path.join(p) }
+        } else {
+            return None;
+        };
+        let head = std::fs::read_to_string(gitdir.join("HEAD")).ok()?;
+        let head = head.trim();
+        if let Some(rest) = head.strip_prefix("ref:") {
+            let r = rest.trim();
+            Some(CompactString::new(
+                r.strip_prefix("refs/heads/").unwrap_or(r),
+            ))
+        } else if !head.is_empty() {
+            // Detached HEAD: show a short commit hash.
+            Some(CompactString::new(&head[..head.len().min(8)]))
+        } else {
+            None
+        }
+    }
+
+    /// Refresh [`git_branch`](Self::git_branch) from the current `working_dir`.
+    pub fn refresh_git_branch(&mut self) {
+        self.git_branch = Self::detect_git_branch(&self.working_dir);
     }
 
     pub fn add_message(&mut self, role: MessageRole, content: &str) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -52,6 +52,8 @@ mod singleflight_tests;
 mod slash_add_tests;
 #[cfg(test)]
 mod slash_init_tests;
+#[cfg(test)]
+mod status_tests;
 #[cfg(all(test, feature = "subagents"))]
 mod subagents_tests;
 #[cfg(test)]

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -304,3 +304,16 @@ fn compacted_context_returns_summary_after_compress() {
     assert_eq!(summary, Some("the summary"));
     assert_eq!(index, 1);
 }
+
+#[test]
+fn detect_git_branch_in_repo_returns_nonempty() {
+    let b = Session::detect_git_branch(env!("CARGO_MANIFEST_DIR"));
+    assert!(b.is_some(), "repo root should resolve a branch or commit");
+    assert!(!b.unwrap().is_empty());
+}
+
+#[test]
+fn detect_git_branch_outside_repo_is_none() {
+    let p = std::env::temp_dir().join("zerostack-definitely-not-a-repo-xyz123");
+    assert!(Session::detect_git_branch(p.to_str().unwrap()).is_none());
+}

--- a/src/tests/status_tests.rs
+++ b/src/tests/status_tests.rs
@@ -1,0 +1,32 @@
+use crate::session::Session;
+use crate::ui::status::StatusLine;
+
+fn render(session: &Session) -> String {
+    StatusLine::render(session, false, 0, None, None, None, None, 0.0, 0, 0).0
+}
+
+#[test]
+fn footer_shows_branch_when_set() {
+    let mut session = Session::new("openrouter", "test-model", 1_048_576);
+    session.git_branch = Some("feat/footer-fields".into());
+    let s = render(&session);
+    assert!(s.contains("(feat/footer-fields)"), "{s}");
+}
+
+#[test]
+fn footer_hides_branch_when_unset() {
+    let session = Session::new("openrouter", "test-model", 1_048_576);
+    assert!(!render(&session).contains('('));
+}
+
+#[test]
+fn footer_shows_context_size_and_max_and_model() {
+    let session = Session::new("openrouter", "deepseek/deepseek-v4-pro", 1_048_576);
+    let s = render(&session);
+    assert!(s.contains("ctx "), "should show context segment: {s}");
+    assert!(s.contains("/1.0M"), "should show max context: {s}");
+    assert!(
+        s.contains("deepseek/deepseek-v4-pro"),
+        "should show model: {s}"
+    );
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,7 +6,7 @@ mod permission_handler;
 pub(crate) mod pickers;
 pub(crate) mod renderer;
 pub(crate) mod slash;
-mod status;
+pub(crate) mod status;
 mod terminal;
 pub(crate) mod utils;
 
@@ -723,6 +723,11 @@ pub async fn run_interactive(
 ) -> anyhow::Result<()> {
     let _guard = TerminalGuard::new()?;
 
+    // Status-bar git branch: seed now, then refresh on a throttle in the loop
+    // (covers worktree switches and external `git checkout` without per-render IO).
+    session.refresh_git_branch();
+    let mut last_branch_check = std::time::Instant::now();
+
     #[cfg(feature = "mcp")]
     let mut mcp_manager: Option<McpClientManager> = None;
 
@@ -1027,6 +1032,10 @@ pub async fn run_interactive(
     }
 
     loop {
+        if last_branch_check.elapsed() >= std::time::Duration::from_secs(1) {
+            session.refresh_git_branch();
+            last_branch_check = std::time::Instant::now();
+        }
         tokio::select! {
             Some(ev) = user_rx.recv() => {
                 match ev {

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -38,10 +38,16 @@ impl StatusLine {
             .and_then(|n| n.to_str())
             .unwrap_or(&session.working_dir);
 
+        let branch_badge = match &session.git_branch {
+            Some(b) if !b.is_empty() => format!(" ({})", b),
+            _ => String::new(),
+        };
+
         let ctx = session.context_window;
-        let pct = (session.effective_context_tokens() * 100)
-            .checked_div(ctx)
-            .unwrap_or(0);
+        let used = session.effective_context_tokens();
+        let pct = (used * 100).checked_div(ctx).unwrap_or(0);
+        // Current context size and the model's max, e.g. "ctx 12k/1.0M 1%".
+        let ctx_detail = format!(" ctx {}/{} {}%", fmt_tokens(used), fmt_tokens(ctx), pct);
 
         let cost_str = if session.total_cost > 0.0 {
             format!(" ${:.4}", session.total_cost)
@@ -96,14 +102,14 @@ impl StatusLine {
         let chain_badge = chain_label.map(|label| format!(" | {}", label));
 
         let status = format!(
-            "{}{}{} | {}{} | {}%/{}{}{} | {}{}",
+            "{}{}{}{} | {}{} |{}{}{} | {}{}",
             dir,
+            branch_badge,
             cost_str,
             btw_badge,
             session.model,
             loop_badge,
-            pct,
-            fmt_tokens(ctx),
+            ctx_detail,
             token_detail,
             compact_badge,
             state,


### PR DESCRIPTION
## What

Reworks the status footer to show the working fields at a glance:

```
zerostack (feat/footer-fields) | deepseek/deepseek-v4-pro | ctx 12k/1.0M 1% ⇑5k ⇓2k | prompt:code
```

- **folder** - working dir basename
- **branch** - in parentheses (new)
- **model**
- **context size and max** - `ctx used/max pct%` (was just `pct%/max`)
- **input / output** - `⇑in ⇓out`
- **prompt**

Existing badges (cost, `btw:`, loop `[...]`, `mode:`, `cmp:`, chain) are preserved.

## How it works

- `Session.git_branch` is a non-persisted (`#[serde(skip)]`) runtime field filled by `Session::detect_git_branch(dir)`, which reads `.git/HEAD` directly (no `git` subprocess), follows the `.git`-file pointer used by worktrees/submodules, and falls back to a short commit hash on detached HEAD.
- Refreshed in `run_interactive`: seeded at startup, then on a 1-second throttle at the top of the event loop, so worktree switches and external `git checkout` are reflected within ~1s with no per-render filesystem IO (keeps the project's CPU/perf profile intact).
- `status.rs` reads `session.git_branch` and shows context as `used/max pct%`.

## Tests

Branch detection inside and outside a repo, and footer rendering (branch shown/hidden, context size + max, model).
