### PR TITLE
feat(ctx): accurate context figure and recover failed sends

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -13,23 +13,12 @@ use crate::permission::ask::AskSender;
 use crate::permission::checker::PermCheck;
 use crate::sandbox::Sandbox;
 
-#[allow(clippy::too_many_arguments)]
-pub async fn build_agent_inner<M: CompletionModel + 'static>(
-    model: M,
-    cli: &Cli,
-    cfg: &Config,
-    context: &ContextFiles,
-    permission: Option<PermCheck>,
-    ask_tx: Option<AskSender>,
-    sandbox: Sandbox,
-    reasoning_enabled: bool,
-    temperature: Option<f64>,
-    // Provider-specific extra body params (e.g. OpenRouter `provider.order` to
-    // pin Claude to the Anthropic direct route so `cache_control` is honored).
-    // `None` for providers that need no extra routing.
-    additional_params: Option<serde_json::Value>,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
-) -> Agent<M> {
+/// Assemble the system-prompt preamble every request carries: the base
+/// `SYSTEM_PROMPT`, tool-use guidance, context files (AGENTS.md, ARCHITECTURE.md,
+/// active mode prompt), working directory, `/add`ed files, memory, and the user
+/// `SUFFIX.md`. Extracted from [`build_agent_inner`] so its token cost can be
+/// estimated (see [`estimate_overhead`]) without building an `Agent`.
+pub fn build_preamble(context: &ContextFiles, reasoning_enabled: bool) -> String {
     let reasoning_prefix = if reasoning_enabled {
         "You reason carefully and think step-by-step.\n\n"
     } else {
@@ -124,6 +113,35 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         preamble.push_str("\n\n---\n\n");
         preamble.push_str(s);
     }
+    preamble
+}
+
+/// Estimate the token cost of the fixed request overhead (the preamble from
+/// [`build_preamble`]). Stored on the session and added to the context figure
+/// before the first real calibration. Does not yet include tool-schema tokens;
+/// the provider's first usage report folds those into the calibration anchor.
+pub fn estimate_overhead(context: &ContextFiles, reasoning_enabled: bool) -> u64 {
+    crate::session::Session::estimate_tokens(&build_preamble(context, reasoning_enabled))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn build_agent_inner<M: CompletionModel + 'static>(
+    model: M,
+    cli: &Cli,
+    cfg: &Config,
+    context: &ContextFiles,
+    permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
+    sandbox: Sandbox,
+    reasoning_enabled: bool,
+    temperature: Option<f64>,
+    // Provider-specific extra body params (e.g. OpenRouter `provider.order` to
+    // pin Claude to the Anthropic direct route so `cache_control` is honored).
+    // `None` for providers that need no extra routing.
+    additional_params: Option<serde_json::Value>,
+    #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
+) -> Agent<M> {
+    let preamble = build_preamble(context, reasoning_enabled);
 
     let mut builder = AgentBuilder::new(model).preamble(&preamble);
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -74,6 +74,15 @@ pub struct Session {
     /// runtime, not persisted.
     #[serde(skip)]
     pub git_branch: Option<CompactString>,
+    /// Estimated tokens for the fixed request overhead that never lives in
+    /// `messages` — system prompt, tool-use preamble, context files, memory.
+    /// Used only before the first real calibration (see
+    /// [`effective_context_tokens`](Self::effective_context_tokens)); once the
+    /// provider reports real usage, the calibration anchor already includes this
+    /// overhead, so it must not be added again. Recomputed at runtime, not
+    /// persisted.
+    #[serde(skip)]
+    pub overhead_tokens: u64,
 }
 
 impl Session {
@@ -131,6 +140,7 @@ impl Session {
             pending_media: Vec::new(),
             show_cost_always: false,
             git_branch: None,
+            overhead_tokens: 0,
         }
     }
 
@@ -234,7 +244,11 @@ impl Session {
 
     pub fn effective_context_tokens(&self) -> u64 {
         if self.calibrated_tokens == 0 {
-            return self.total_estimated_tokens;
+            // No real usage yet: per-message estimates cover only `messages`, so
+            // add the fixed overhead (system prompt, tools, context files) that
+            // every request also carries. After calibration this overhead is
+            // already inside the anchor, so it is not added in that branch.
+            return self.overhead_tokens.saturating_add(self.total_estimated_tokens);
         }
         let start = self.calibrated_msg_count.min(self.messages.len());
         let delta: u64 = self.messages[start..]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -242,6 +242,17 @@ impl Session {
         self.calibrated_msg_count = 0;
     }
 
+    /// Call after removing messages (e.g. `/undo` or rolling back a failed
+    /// send). Drops the now-mismatched calibration anchor and recomputes the
+    /// per-message estimate total, so the context figure reflects the shortened
+    /// history instead of the stale pre-removal value. The figure falls back to
+    /// the estimate path (overhead + remaining messages, marked `~`) until the
+    /// next provider response recalibrates it.
+    pub fn recompute_after_removal(&mut self) {
+        self.reset_calibration();
+        self.total_estimated_tokens = self.messages.iter().map(|m| m.estimated_tokens).sum();
+    }
+
     /// True while the context figure is still an estimate — no provider usage
     /// has been reported yet (or it was reset by `/clear`). The status bar marks
     /// the estimated value so the snap to the real number on the first response

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -242,14 +242,30 @@ impl Session {
         self.calibrated_msg_count = 0;
     }
 
-    /// Call after removing messages (e.g. `/undo` or rolling back a failed
-    /// send). Drops the now-mismatched calibration anchor and recomputes the
-    /// per-message estimate total, so the context figure reflects the shortened
-    /// history instead of the stale pre-removal value. The figure falls back to
-    /// the estimate path (overhead + remaining messages, marked `~`) until the
-    /// next provider response recalibrates it.
-    pub fn recompute_after_removal(&mut self) {
-        self.reset_calibration();
+    /// Truncate the conversation to `new_len` messages while keeping the context
+    /// figure accurate (used by `/undo` and the failed-send rollback).
+    ///
+    /// If any removed message was part of the calibration anchor, subtract its
+    /// estimated tokens from the anchor rather than discarding the whole
+    /// calibration. Resetting to a cold estimate would undercount (the estimate
+    /// omits tool schemas), and leaving the anchor untouched would overcount by
+    /// the removed turn — subtracting keeps the figure ≈ the real remaining
+    /// size. Messages beyond the anchor were never in it, so removing them only
+    /// shrinks the estimated tail.
+    pub fn truncate_to(&mut self, new_len: usize) {
+        if new_len >= self.messages.len() {
+            return;
+        }
+        let cal = self.calibrated_msg_count.min(self.messages.len());
+        if self.calibrated_tokens > 0 && new_len < cal {
+            let removed: u64 = self.messages[new_len..cal]
+                .iter()
+                .map(|m| m.estimated_tokens)
+                .sum();
+            self.calibrated_tokens = self.calibrated_tokens.saturating_sub(removed);
+            self.calibrated_msg_count = new_len;
+        }
+        self.messages.truncate(new_len);
         self.total_estimated_tokens = self.messages.iter().map(|m| m.estimated_tokens).sum();
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -242,6 +242,14 @@ impl Session {
         self.calibrated_msg_count = 0;
     }
 
+    /// True while the context figure is still an estimate — no provider usage
+    /// has been reported yet (or it was reset by `/clear`). The status bar marks
+    /// the estimated value so the snap to the real number on the first response
+    /// reads as a refinement rather than a surprise.
+    pub fn ctx_is_estimated(&self) -> bool {
+        self.calibrated_tokens == 0
+    }
+
     pub fn effective_context_tokens(&self) -> u64 {
         if self.calibrated_tokens == 0 {
             // No real usage yet: per-message estimates cover only `messages`, so

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -26,7 +26,7 @@ use super::{C_AGENT, C_ERROR, C_TOOL, apply_current_prompt_mode};
 pub async fn ensure_agent(
     agent: &mut Option<AnyAgent>,
     client: &AnyClient,
-    session: &Session,
+    session: &mut Session,
     cli: &Cli,
     cfg: &Config,
     context: &ContextFiles,
@@ -58,6 +58,9 @@ pub async fn ensure_agent(
         )
         .await,
     );
+    // Keep the pre-calibration context estimate in sync with the preamble we
+    // just built (system prompt + tools + context files).
+    session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
 }
 
 #[cfg(not(feature = "mcp"))]
@@ -65,7 +68,7 @@ pub async fn ensure_agent(
 pub async fn ensure_agent(
     agent: &mut Option<AnyAgent>,
     client: &AnyClient,
-    session: &Session,
+    session: &mut Session,
     cli: &Cli,
     cfg: &Config,
     context: &ContextFiles,
@@ -95,6 +98,9 @@ pub async fn ensure_agent(
         )
         .await,
     );
+    // Keep the pre-calibration context estimate in sync with the preamble we
+    // just built (system prompt + tools + context files).
+    session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -775,6 +775,10 @@ pub async fn run_interactive(
     let mut response_start_line: Option<usize> = None;
     let mut show_reasoning = true;
     let mut reasoning_enabled = true;
+    // Seed the context-overhead estimate so the status bar reflects the system
+    // prompt + context files from T0, before the first request is calibrated.
+    // `ensure_agent` refreshes this whenever the preamble is rebuilt.
+    session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
     let mut was_reasoning = false;
     let mut todo_tools_enabled = false;
     #[allow(unused_mut)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -394,6 +394,7 @@ async fn start_main_run(
     status_signals: &Option<StatusSignals>,
     #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
     prebuild_rx: &mut Option<mpsc::Receiver<PrebuildPayload>>,
+    pending_send: &mut Option<String>,
 ) {
     // Wait for the background prebuild if it hasn't completed yet.
     #[cfg(feature = "mcp")]
@@ -442,6 +443,9 @@ async fn start_main_run(
         ss.send_start();
     }
     session.add_message(MessageRole::User, text);
+    // Mark this message as the rollback target if the turn fails (see the
+    // failed-send handling in the main event loop).
+    *pending_send = Some(text.to_string());
     #[cfg(feature = "advisor")]
     crate::extras::advisor::set_session_messages(session.messages.clone());
     if !cli.no_session {
@@ -779,6 +783,10 @@ pub async fn run_interactive(
     // prompt + context files from T0, before the first request is calibrated.
     // `ensure_agent` refreshes this whenever the preamble is rebuilt.
     session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
+    // Text of the in-flight interactive send. Set by `start_main_run`; on a
+    // failed turn it is rolled back into the input editor so the message never
+    // poisons the session (which would 400 forever until a manual `/undo`).
+    let mut pending_send: Option<String> = None;
     let mut was_reasoning = false;
     let mut todo_tools_enabled = false;
     #[allow(unused_mut)]
@@ -1349,6 +1357,7 @@ pub async fn run_interactive(
                                             &status_signals,
                                             #[cfg(feature = "mcp")] &mut mcp_manager,
                                             &mut prebuild_rx,
+                                            &mut pending_send,
                                         ).await;
                                     }
                                     refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
@@ -1471,6 +1480,7 @@ pub async fn run_interactive(
                                     &status_signals,
                                     #[cfg(feature = "mcp")] &mut mcp_manager,
                                     &mut prebuild_rx,
+                                    &mut pending_send,
                                 ).await;
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
@@ -1981,6 +1991,7 @@ pub async fn run_interactive(
                                     &status_signals,
                                     #[cfg(feature = "mcp")] &mut mcp_manager,
                                     &mut prebuild_rx,
+                                    &mut pending_send,
                                 ).await;
                             }
                             }
@@ -2118,6 +2129,9 @@ pub async fn run_interactive(
                 }
                 #[cfg(feature = "mcp")]
                 let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
+                // Peek before the event is consumed: a failed turn rolls the
+                // in-flight interactive message back into the input editor.
+                let turn_errored = matches!(&event, AgentEvent::Error(_));
                 handle_agent_event(
                     event, &mut renderer, session, cfg, cli, context,
                     &mut is_running, &mut agent_rx, &mut agent_line_started,
@@ -2130,6 +2144,24 @@ pub async fn run_interactive(
                     #[cfg(feature = "git-worktree")] &mut wt_return_path,
                     #[cfg(feature = "mcp")] mcp_ref,
                 ).await?;
+                if turn_errored {
+                    // The turn produced no response, so the trailing user message
+                    // is still pending. Remove it (so it never poisons the next
+                    // request) and restore it to the input editor for the user to
+                    // edit or resend. Provider-agnostic: works for too-long, auth,
+                    // rate-limit, and transient errors alike.
+                    if let Some(text) = pending_send.take() {
+                        let len = session.messages.len();
+                        if len > 0 && session.messages[len - 1].role == MessageRole::User {
+                            session.truncate_to(len - 1);
+                        }
+                        input.buffer = text.into();
+                        input.cursor = input.buffer.len();
+                    }
+                } else if !is_running {
+                    // Turn completed normally; the message is committed.
+                    pending_send = None;
+                }
                 if !is_running
                     && let Some(restore_name) = dot_prompt_restore.take()
                 {
@@ -2185,6 +2217,7 @@ pub async fn run_interactive(
                             &status_signals,
                             #[cfg(feature = "mcp")] &mut mcp_manager,
                             &mut prebuild_rx,
+                            &mut pending_send,
                         ).await;
                     }
                 }

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -140,27 +140,21 @@ pub fn undo_last(session: &mut Session) -> usize {
         return 0;
     }
     let removed = if session.messages[len - 1].role == MessageRole::Assistant {
-        session.messages.pop();
-        if session
-            .messages
-            .last()
-            .is_some_and(|m| m.role == MessageRole::User)
-        {
-            session.messages.pop();
+        if len >= 2 && session.messages[len - 2].role == MessageRole::User {
             2
         } else {
             1
         }
     } else if session.messages[len - 1].role == MessageRole::User {
-        session.messages.pop();
         1
     } else {
         0
     };
-    // Removing messages invalidates the calibration anchor; recompute so the
-    // context figure reflects the shortened history instead of staying stale.
+    // Truncate via the session helper so the context figure tracks the
+    // shortened history (subtracts the removed turn from the calibration anchor
+    // rather than going stale or resetting to a cold estimate).
     if removed > 0 {
-        session.recompute_after_removal();
+        session.truncate_to(len - removed);
     }
     removed
 }

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -139,7 +139,7 @@ pub fn undo_last(session: &mut Session) -> usize {
     if len == 0 {
         return 0;
     }
-    if session.messages[len - 1].role == MessageRole::Assistant {
+    let removed = if session.messages[len - 1].role == MessageRole::Assistant {
         session.messages.pop();
         if session
             .messages
@@ -147,15 +147,22 @@ pub fn undo_last(session: &mut Session) -> usize {
             .is_some_and(|m| m.role == MessageRole::User)
         {
             session.messages.pop();
-            return 2;
+            2
+        } else {
+            1
         }
-        return 1;
-    }
-    if session.messages[len - 1].role == MessageRole::User {
+    } else if session.messages[len - 1].role == MessageRole::User {
         session.messages.pop();
-        return 1;
+        1
+    } else {
+        0
+    };
+    // Removing messages invalidates the calibration anchor; recompute so the
+    // context figure reflects the shortened history instead of staying stale.
+    if removed > 0 {
+        session.recompute_after_removal();
     }
-    0
+    removed
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -46,8 +46,18 @@ impl StatusLine {
         let ctx = session.context_window;
         let used = session.effective_context_tokens();
         let pct = (used * 100).checked_div(ctx).unwrap_or(0);
-        // Current context size and the model's max, e.g. "ctx 12k/1.0M 1%".
-        let ctx_detail = format!(" ctx {}/{} {}%", fmt_tokens(used), fmt_tokens(ctx), pct);
+        // Before the first provider response the figure is a local estimate
+        // (preamble overhead + per-message guesses); prefix it with `~` so the
+        // snap to the real count on the first reply reads as a refinement.
+        let ctx_mark = if session.ctx_is_estimated() { "~" } else { "" };
+        // Current context size and the model's max, e.g. "ctx ~12k/1.0M 1%".
+        let ctx_detail = format!(
+            " ctx {}{}/{} {}%",
+            ctx_mark,
+            fmt_tokens(used),
+            fmt_tokens(ctx),
+            pct
+        );
 
         let cost_str = if session.total_cost > 0.0 || session.show_cost_always {
             format!(" ${:.4}", session.total_cost)


### PR DESCRIPTION
## Summary

Makes the status-bar context figure accurate before the first provider
response and stops a failed send from poisoning the session.

## Motivation

The main pain: sending an oversized message returns an error (e.g. `prompt is
too long`), but the message was already in history with no reply. It stayed
there and was rejected on every following turn, so the session was stuck until
a manual `/undo`. Investigating that surfaced two related context-figure
issues: the figure started at 0 and only became real after the first response,
and `/undo` left it stale.

## Changes

**Context estimate accuracy**
- Include the request preamble (system prompt, tool-use guidance, context
  files, memory) in the pre-calibration estimate. Extracted `build_preamble`
  from `build_agent_inner` and added `estimate_overhead`, seeded at startup and
  refreshed in `ensure_agent`. The figure now reflects the real baseline from
  the first frame instead of showing 0.
- A leading `~` marks the figure while it is still an estimate
  (`calibrated_tokens == 0`), dropped once the provider reports real usage, so
  the snap to the exact count reads as a refinement.

**Failed-send recovery**
- On any errored turn, the trailing pending user message is rolled back into
  the input editor instead of being left in history. This is provider-agnostic
  and needs no error classification: a failed turn produced no response, so
  rolling the message back to a pending state is the right recovery for
  too-long, auth, rate-limit, and transient errors alike. The user sees the
  error and decides whether to shorten and resend or fix the cause and resend
  unchanged.

**Context figure on removal**
- `Session::truncate_to`, shared by `/undo` and the rollback, subtracts a
  removed turn's estimated tokens from the calibration anchor instead of
  resetting it (which undercounts, since the estimate omits tool schemas) or
  leaving it stale (which overcounts). The figure tracks the real remaining
  size.

## Notes

- No new dependencies. `cargo build` clean.
- The per-message estimator is unchanged; EMA self-calibration was considered
  and left out as a display-only refinement that the `~` marker already covers.
