### PR TITLE
feat(ui): configurable left margin for the chat area

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -182,6 +182,7 @@ Accepted top-level keys:
 | `sandbox`                 | boolean | Run bash commands in the bubblewrap sandbox. Default: `false`.                                                                                                              |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Accepts: `standard` (default), `restrictive`, `readonly`, `guarded`, `yolo`.                                          |
 | `show_tool_details`       | boolean or integer | Show tool-result previews in the TUI. `false` hides output, `true` shows all lines, an integer limits to that many lines (e.g. `3`). Default: `3`. |
+| `chat_left_margin`        | integer | Left padding (columns) for the chat area only; input and status rows are unaffected. Default: `0`. |
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`. If the prompt file has a `%%mode=<mode>` first-line directive, the security mode is set automatically (see Prompt directives below). |
 | `editor`                  | string  | Editor command for `Ctrl+G` (default: `$EDITOR` env var, then `editor`, then `nano`).                                                                                        |
 | `api_keys`                | object  | Map of provider names to API keys (e.g. `"openai": "sk-..."`). Used as fallback when the corresponding env var is not set.                                                   |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -132,6 +132,9 @@ pub struct Config {
     pub permission_modes: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_tool_details: Option<ShowToolDetails>,
+    /// Left padding (columns) for the chat area. Default: 0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_left_margin: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_prompt: Option<CompactString>,
     #[cfg(feature = "git-worktree")]
@@ -263,6 +266,10 @@ impl Config {
 
     pub fn resolve_keep_recent_tokens(&self) -> u64 {
         self.keep_recent_tokens.unwrap_or(10_000)
+    }
+
+    pub fn resolve_chat_left_margin(&self) -> u16 {
+        self.chat_left_margin.unwrap_or(0)
     }
 
     /// Resolves temperature: CLI `--temperature` > quick-model `temperature` >

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -46,3 +46,14 @@ fn copy_to_clipboard_does_not_panic() {
 fn copy_to_clipboard_empty_string() {
     copy_to_clipboard("");
 }
+
+#[test]
+fn chat_margin_reduces_content_width() {
+    let mut r = crate::ui::renderer::Renderer::new().unwrap();
+    let full = r.line_width();
+    r.set_chat_margin(4);
+    assert_eq!(r.line_width(), full - 4);
+    // Zero margin leaves the width unchanged.
+    r.set_chat_margin(0);
+    assert_eq!(r.line_width(), full);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -737,6 +737,7 @@ pub async fn run_interactive(
 
     let mut renderer = Renderer::new()?;
     renderer.set_monochrome(cli.no_color);
+    renderer.set_chat_margin(cfg.resolve_chat_left_margin());
     if let Some(ref theme_name) = context.current_theme_name {
         if let Some(content) = context.themes.get(theme_name.as_str()) {
             crate::context::themes::apply(content, &mut renderer);

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -44,6 +44,9 @@ pub struct Renderer {
     pub selection_start: Option<usize>,
     pub selection_end: Option<usize>,
     prev_input_height: usize,
+    /// Left padding (columns) for the chat buffer area only. Input and status
+    /// rows are unaffected.
+    chat_margin: u16,
     pub permission_prompt: Option<PermissionPrompt>,
     pub chain_prompt: Option<ChainPrompt>,
     pub chain_but_mode: bool,
@@ -68,6 +71,7 @@ impl Renderer {
             selection_start: None,
             selection_end: None,
             prev_input_height: 0,
+            chat_margin: 0,
             permission_prompt: None,
             chain_prompt: None,
             chain_but_mode: false,
@@ -76,6 +80,37 @@ impl Renderer {
 
     pub fn set_monochrome(&mut self, monochrome: bool) {
         self.monochrome = monochrome;
+    }
+
+    /// Set the chat buffer's left padding in columns. Clamped so content keeps
+    /// at least a few usable columns.
+    pub fn set_chat_margin(&mut self, margin: u16) {
+        let (cols, _) = self.terminal_size();
+        self.chat_margin = margin.min(cols.saturating_sub(8));
+    }
+
+    /// Emit the chat left-margin gutter (spaces in the chat background) at the
+    /// current cursor position. Caller has already positioned to column 0 and
+    /// set the background.
+    fn write_chat_margin(&self, stdout: &mut impl Write) -> io::Result<()> {
+        if self.chat_margin > 0 {
+            write!(stdout, "{}", " ".repeat(self.chat_margin as usize))?;
+        }
+        Ok(())
+    }
+
+    /// Position the cursor at the chat content column on row `r`, accounting for
+    /// the left margin. At the start of a line it first paints the margin gutter.
+    fn move_to_content(&self, stdout: &mut impl Write, r: u16) -> io::Result<()> {
+        if self.chat_margin > 0 && self.col == 0 {
+            stdout.execute(MoveTo(0, r))?;
+            if let Some(bg) = self.chat_bg {
+                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            }
+            self.write_chat_margin(stdout)?;
+        }
+        stdout.execute(MoveTo(self.col + self.chat_margin, r))?;
+        Ok(())
     }
 
     pub fn set_background_colors(
@@ -99,7 +134,7 @@ impl Renderer {
 
     fn max_line_width(&self) -> usize {
         let (cols, _) = self.terminal_size();
-        cols.saturating_sub(1) as usize
+        cols.saturating_sub(1 + self.chat_margin) as usize
     }
 
     pub fn line_width(&self) -> usize {
@@ -132,7 +167,7 @@ impl Renderer {
 
     pub fn buffer_line_at_row(&self, row: u16) -> Option<usize> {
         let (cols, _rows) = self.terminal_size();
-        let max_width = cols.saturating_sub(1) as usize;
+        let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
         let visible = self.visible_lines();
         let total = self.buffer.len();
         if total == 0 {
@@ -278,7 +313,7 @@ impl Renderer {
 
     pub fn render_viewport(&mut self) -> io::Result<()> {
         let (cols, _rows) = self.terminal_size();
-        let max_width = cols.saturating_sub(1) as usize;
+        let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
         let visible = self.visible_lines();
         let total = self.buffer.len();
         let mut stdout = io::stdout();
@@ -339,6 +374,7 @@ impl Renderer {
                 if let Some(bg) = self.chat_bg {
                     write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                 }
+                self.write_chat_margin(&mut stdout)?;
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
                 }
@@ -448,6 +484,7 @@ impl Renderer {
                         write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                     }
                     write!(stdout, "{}", Clear(ClearType::CurrentLine))?;
+                    self.write_chat_margin(&mut stdout)?;
                     write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                     writeln!(stdout, "{}", chunk)?;
                     write!(stdout, "{}", ResetColor)?;
@@ -491,7 +528,7 @@ impl Renderer {
                     self.ensure_room();
                     let mut stdout = io::stdout();
                     let r = self.content_row();
-                    stdout.execute(MoveTo(self.col, r))?;
+                    self.move_to_content(&mut stdout, r)?;
                     if let Some(bg) = self.chat_bg {
                         write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                     }
@@ -550,7 +587,7 @@ impl Renderer {
                         self.ensure_room();
                         let mut stdout = io::stdout();
                         let r = self.content_row();
-                        stdout.execute(MoveTo(self.col, r))?;
+                        self.move_to_content(&mut stdout, r)?;
                         if let Some(bg) = self.chat_bg {
                             write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                         }


### PR DESCRIPTION
## What

Adds a `chat_left_margin` config option that left-pads the chat area by N columns. Only the chat buffer is affected - the input line and status bar stay flush against the edge.

```toml
chat_left_margin = 2
```

Default `0` (no change in behavior).

## How it works

- `src/ui/renderer.rs`: a `chat_margin` field (set via `set_chat_margin`, clamped to keep usable width). `max_line_width` and `buffer_line_at_row` subtract the margin so word wrapping and mouse-selection row mapping stay correct. `render_viewport` (the authoritative redraw) paints a margin-wide gutter in the chat background before each line; the live `write_line` and streaming `write` paths paint/offset by the margin too, so streaming text lands in the right column immediately.
- `src/config/mod.rs`: `chat_left_margin` key + `resolve_chat_left_margin()` (default 0), wired in `run_interactive` right after the renderer is created.

## Tests

`renderer_tests.rs` asserts the margin reduces content width and that 0 leaves it unchanged. Full suite passes.

## Note

CI may show the flaky `edit_tests::test_sim_preserves_crlf_line_endings` failure - that's the pre-existing edit-system test race fixed by #133, unrelated to this change.
