### PR TITLE
feat(input): scroll, click-to-position, and a height cap for tall input boxes

### DIFF
--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -58,6 +58,18 @@ impl InputEditor {
         }
     }
 
+    /// Move the cursor to `pos` (a byte offset), clamped to a char boundary
+    /// within the buffer. Used when a mouse click places the cursor.
+    pub fn set_cursor(&mut self, pos: usize) {
+        let pos = pos.min(self.buffer.len());
+        self.cursor = if self.buffer.is_char_boundary(pos) {
+            pos
+        } else {
+            prev_char_boundary(&self.buffer, pos)
+        };
+        self.yank_pos = None;
+    }
+
     pub fn clear_buffer(&mut self) {
         self.buffer.clear();
         self.cursor = 0;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -90,6 +90,10 @@ fn refresh_display(
     btw_in: u64,
     btw_out: u64,
 ) -> io::Result<()> {
+    // Reconcile the input height first so the chat viewport is drawn against
+    // the size the input is about to occupy (avoids a stale separator when the
+    // input shrinks, or chat text hidden under it when the input grows).
+    renderer.sync_input_height(&input.buffer)?;
     renderer.render_viewport()?;
     let statusline_ctx = crate::ui::statusline::StatusContext {
         loop_label,
@@ -1061,17 +1065,31 @@ pub async fn run_interactive(
                         continue;
                     }
                     UserEvent::ScrollUp => {
-                        renderer.scroll_line_up();
+                        // Scroll the input viewport first; once it is at the top,
+                        // keep wheeling up to scroll back through the chat history.
+                        if !renderer.input_scroll_up() {
+                            renderer.scroll_line_up();
+                        }
                         refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
                     UserEvent::ScrollDown => {
-                        renderer.scroll_line_down();
+                        // Bring the chat history back down first, then the input.
+                        if renderer.is_scrolling() {
+                            renderer.scroll_line_down();
+                        } else {
+                            renderer.input_scroll_down();
+                        }
                         refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         continue;
                     }
-                    UserEvent::MouseDown { row, col: _ } => {
-                        if row < renderer.visible_lines() as u16
+                    UserEvent::MouseDown { row, col } => {
+                        // A click inside the input area moves the cursor there;
+                        // otherwise it starts a chat-history text selection.
+                        if let Some(pos) = renderer.input_cursor_for_click(row, col, &input.buffer) {
+                            input.set_cursor(pos);
+                            refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                        } else if row < renderer.visible_lines() as u16
                             && let Some(idx) = renderer.buffer_line_at_row(row) {
                                 renderer.selection_active = true;
                                 renderer.selection_start = Some(idx);

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -37,6 +37,17 @@ pub struct Renderer {
     partial_color: Color,
     scroll_offset: usize,
     input_scroll_offset: usize,
+    input_vscroll_offset: usize,
+    input_max_vscroll: usize,
+    last_input_cursor: usize,
+    // Geometry of the last-rendered input area, used to map a mouse click to a
+    // cursor position inside the input buffer.
+    input_base_row: u16,
+    input_prompt_width: usize,
+    input_first_visible: usize,
+    input_visible_line_count: usize,
+    input_h_scroll: usize,
+    input_cursor_line: usize,
     monochrome: bool,
     chat_bg: Option<Color>,
     input_bg: Option<Color>,
@@ -66,6 +77,15 @@ impl Renderer {
             partial_color: Color::White,
             scroll_offset: 0,
             input_scroll_offset: 0,
+            input_vscroll_offset: 0,
+            input_max_vscroll: 0,
+            last_input_cursor: 0,
+            input_base_row: 0,
+            input_prompt_width: 0,
+            input_first_visible: 0,
+            input_visible_line_count: 0,
+            input_h_scroll: 0,
+            input_cursor_line: 0,
             monochrome: false,
             chat_bg: None,
             input_bg: None,
@@ -179,6 +199,29 @@ impl Renderer {
         rows.saturating_sub(input_height as u16 + self.statusline_reserve()) as usize
     }
 
+    /// Number of rows the input area will occupy for the given content. Kept in
+    /// sync with the height logic used while drawing the input in `draw_bottom`.
+    fn input_visible_height(&self, input_line: &str, rows: u16) -> usize {
+        if self.permission_prompt.is_some() || self.chain_prompt.is_some() {
+            return 2;
+        }
+        let available_rows = rows.saturating_sub(self.statusline_reserve()) as usize;
+        let max_input_rows = available_rows.min((available_rows * 3 / 10).max(5));
+        input_line.split('\n').count().min(max_input_rows).max(1)
+    }
+
+    /// Recompute the input height and reconcile `prev_input_height` before the
+    /// chat viewport is drawn, so the chat is sized against the height the input
+    /// is about to use. Without this, a height change (e.g. clearing or pasting
+    /// text) leaves the viewport drawn for the old size until the next redraw.
+    pub fn sync_input_height(&mut self, input_line: &str) -> io::Result<()> {
+        let (_, rows) = self.terminal_size();
+        let new_height = self.input_visible_height(input_line, rows);
+        self.clear_shrunk_rows(self.prev_input_height, new_height)?;
+        self.prev_input_height = new_height;
+        Ok(())
+    }
+
     pub fn buffer_line_at_row(&self, row: u16) -> Option<usize> {
         let (cols, _rows) = self.terminal_size();
         let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
@@ -275,6 +318,69 @@ impl Renderer {
 
     pub fn is_scrolling(&self) -> bool {
         self.scroll_offset > 0
+    }
+
+    /// Map a mouse click at `(row, col)` to a cursor byte offset inside the
+    /// input buffer, or `None` if the click falls outside the input area.
+    pub fn input_cursor_for_click(&self, row: u16, col: u16, input_line: &str) -> Option<usize> {
+        let vlc = self.input_visible_line_count;
+        if vlc == 0 {
+            return None;
+        }
+        if row < self.input_base_row || row >= self.input_base_row + vlc as u16 {
+            return None;
+        }
+        let visible_idx = (row - self.input_base_row) as usize;
+        let line_idx = self.input_first_visible + visible_idx;
+        let lines: SmallVec<[&str; 4]> = input_line.split('\n').collect();
+        let line_text = lines.get(line_idx)?;
+
+        // Display column the click lands on, within the line's text. Clicks on
+        // the prompt (or to its left) snap to the start of the line.
+        let click_col = col as usize;
+        let mut target_display = click_col.saturating_sub(self.input_prompt_width);
+        if line_idx == self.input_cursor_line {
+            target_display += self.input_h_scroll;
+        }
+
+        // Walk the line accumulating display width until we pass the target,
+        // landing on the nearest character boundary.
+        let mut width = 0usize;
+        let mut col_chars = 0usize;
+        for ch in line_text.chars() {
+            let cw = char_display_width(ch);
+            if width + cw > target_display {
+                break;
+            }
+            width += cw;
+            col_chars += 1;
+        }
+        Some(crate::ui::input::line_col_to_cursor(
+            input_line, line_idx, col_chars,
+        ))
+    }
+
+    /// Scroll the multi-line input viewport up one line (toward earlier lines).
+    /// Returns false when the input is already showing its top line, so the
+    /// caller can fall through to scrolling the chat history instead.
+    pub fn input_scroll_up(&mut self) -> bool {
+        if self.input_vscroll_offset > 0 {
+            self.input_vscroll_offset -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Scroll the multi-line input viewport down one line (toward the end).
+    /// Returns false when the input is already at the bottom.
+    pub fn input_scroll_down(&mut self) -> bool {
+        if self.input_vscroll_offset < self.input_max_vscroll {
+            self.input_vscroll_offset += 1;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn scroll_line_up(&mut self) {
@@ -902,12 +1008,11 @@ impl Renderer {
         let line_count = lines.len();
 
         let available_rows = (rows.saturating_sub(reserve) as usize).max(1);
-        let need_scroll = line_count > available_rows;
-        let first_visible = if need_scroll {
-            line_count - available_rows
-        } else {
-            0
-        };
+        // Cap the input height to roughly 30% of the area so the chat history
+        // stays visible (and therefore scrollable) above a tall input instead
+        // of being squeezed to nothing.
+        let max_input_rows = available_rows.min((available_rows * 3 / 10).max(5));
+        let need_scroll = line_count > max_input_rows;
 
         const SPINNER: &[&str] = &["⠋ ", "⠙ ", "⠹ ", "⠸ ", "⠼ ", "⠴ ", "⠦ ", "⠧ ", "⠇ ", "⠏ "];
         let prompt = if is_running {
@@ -921,6 +1026,29 @@ impl Renderer {
 
         let (cursor_line, cursor_col) =
             crate::ui::input::cursor_to_line_col(input_line, cursor_pos);
+
+        // Vertical scroll: keep the cursor's line within the visible window so
+        // pressing Up/Down can reveal lines that don't fit on screen at once.
+        // Only follow the cursor when it actually moved, so mouse-wheel scrolling
+        // (which leaves the cursor put) is not snapped back every frame.
+        let cursor_moved = self.last_input_cursor != cursor_pos;
+        self.last_input_cursor = cursor_pos;
+        let first_visible = if need_scroll {
+            self.input_max_vscroll = line_count - max_input_rows;
+            if cursor_moved {
+                if cursor_line < self.input_vscroll_offset {
+                    self.input_vscroll_offset = cursor_line;
+                } else if cursor_line >= self.input_vscroll_offset + max_input_rows {
+                    self.input_vscroll_offset = cursor_line - max_input_rows + 1;
+                }
+            }
+            self.input_vscroll_offset = self.input_vscroll_offset.min(self.input_max_vscroll);
+            self.input_vscroll_offset
+        } else {
+            self.input_vscroll_offset = 0;
+            self.input_max_vscroll = 0;
+            0
+        };
 
         let visible_width = cols.saturating_sub(prompt_width as u16) as usize;
         let cursor_line_text = lines.get(cursor_line).unwrap_or(&"");
@@ -949,7 +1077,7 @@ impl Renderer {
 
         // Clear and draw input area
         let visible_line_count = if need_scroll {
-            available_rows
+            max_input_rows
         } else {
             line_count
         };
@@ -967,11 +1095,20 @@ impl Renderer {
             self.draw_separator(sep_above, cols)?;
         }
 
+        // Remember the input layout so a mouse click can be mapped back to a
+        // cursor position inside the input buffer.
+        self.input_base_row = input_top;
+        self.input_prompt_width = prompt_width;
+        self.input_first_visible = first_visible;
+        self.input_visible_line_count = visible_line_count;
+        self.input_h_scroll = h_scroll;
+        self.input_cursor_line = cursor_line;
+
         for (i, line) in lines
             .iter()
             .enumerate()
-            .take(line_count)
             .skip(first_visible)
+            .take(visible_line_count)
         {
             let render_row = (rows.saturating_sub(reserve) - visible_line_count as u16 + 1)
                 + (i - first_visible) as u16;
@@ -1029,8 +1166,12 @@ impl Renderer {
         // Status line
         self.draw_statusline(statusline, cols, self.scroll_offset > 0)?;
 
-        // Cursor
-        let cursor_render_idx = cursor_line.saturating_sub(first_visible);
+        // Cursor. Clamp to the visible input rows so that when the viewport is
+        // scrolled away from the cursor line, the terminal caret stays inside
+        // the input box instead of spilling onto the separator or status bar.
+        let cursor_render_idx = cursor_line
+            .saturating_sub(first_visible)
+            .min(visible_line_count.saturating_sub(1));
         let cursor_row = (rows.saturating_sub(reserve) - visible_line_count as u16 + 1)
             + cursor_render_idx as u16;
         let cursor_x = (prompt_width + cursor_display_col.saturating_sub(h_scroll)) as u16;


### PR DESCRIPTION
## What

Makes a multi-line input box that is taller than the screen actually usable.
Previously, once the input grew past the visible area you could not see or reach
earlier content: the viewport stayed pinned to the bottom, Up/Down moved the
cursor off-screen, the mouse wheel only scrolled the chat (and got stuck), and
there was no way to click to a position.

## Changes

- **Cursor-following viewport.** The input now scrolls vertically to keep the
  cursor line visible, so Up/Down reveal lines that do not fit at once instead
  of the view staying anchored to the bottom.
- **Mouse-wheel scrolling.** The wheel scrolls the input viewport first, then
  continues back through the chat history once the input is at its top;
  scrolling down brings the chat back before the input.
- **Click to position the cursor.** Clicking inside the input box moves the
  cursor to that spot (wide chars, horizontal and vertical scroll accounted
  for). Clicks outside still start a chat-history text selection.
- **Height cap (~30%).** The input never uses more than roughly 30% of the
  available area, so the chat history stays visible and scrollable above a tall
  input instead of being squeezed to nothing.
- **Caret clamp.** The terminal caret is clamped to the visible input rows so it
  never spills onto the separator or status bar while scrolled away.
- **Redraw sync.** The input height is reconciled before the chat viewport is
  drawn, so changing the input height no longer leaves a stale separator (when
  it shrinks) or chat text hidden under the input (when it grows) until the next
  redraw.

## Files

- `src/ui/renderer.rs` — viewport/height/caret/geometry logic and the
  click-to-cursor mapping.
- `src/ui/mod.rs` — wheel and mouse-down event wiring; height sync before
  rendering the chat.
- `src/ui/input/mod.rs` — `set_cursor` for click placement.

## Testing

- `cargo build` and `cargo test` pass.
- Manually: typing/pasting a long multi-line message, then Up/Down, mouse wheel
  (into chat history and back), clicking to reposition, and deleting all text to
  confirm the separator follows immediately.
