### PR TITLE
Make renderer margin test robust on narrow terminals

### DIFF
--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -52,7 +52,7 @@ fn chat_margin_reduces_content_width() {
     let mut r = crate::ui::renderer::Renderer::new().unwrap();
     let full = r.line_width();
     r.set_chat_margin(4);
-    assert_eq!(r.line_width(), full - 4);
+    assert_eq!(r.line_width(), full.saturating_sub(4));
     // Zero margin leaves the width unchanged.
     r.set_chat_margin(0);
     assert_eq!(r.line_width(), full);


### PR DESCRIPTION
## Summary

Fixes a renderer test assumption that can fail when the test environment has a narrow terminal width.

## Context / Motivation

The test should validate renderer behavior, not depend on the ambient terminal width available in CI or developer shells.

## Key Changes

- Adjusts the expected margin behavior in the narrow-width test case.
- Keeps the production renderer behavior unchanged.

## Verification & Testing

Reviewers can run the renderer tests in a narrow terminal or CI environment and confirm the test no longer fails due to terminal width assumptions.