### PR TITLE
Store loop transcripts under the zerostack data directory

### DIFF
--- a/src/extras/loop/transcript.rs
+++ b/src/extras/loop/transcript.rs
@@ -3,9 +3,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 
 fn transcript_dir(session_id: &str) -> PathBuf {
-    dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from(".zerostack"))
-        .join("zerostack")
+    crate::session::storage::data_dir()
         .join("loops")
         .join(session_id)
 }

--- a/src/tests/loop_tests.rs
+++ b/src/tests/loop_tests.rs
@@ -3,6 +3,13 @@ use crate::extras::r#loop::{
 };
 use std::path::PathBuf;
 
+fn loop_test_data_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("zerostack-loop-tests-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    unsafe { std::env::set_var("ZS_DATA_DIR", &dir) };
+    dir
+}
+
 // --- LoopState tests ---
 
 #[test]
@@ -183,11 +190,7 @@ fn test_transcript_dir_contains_session_id() {
 #[test]
 fn test_save_iteration_creates_file() {
     let session_id = "test-save-iteration";
-    let dir = dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from(".zerostack"))
-        .join("zerostack")
-        .join("loops")
-        .join(session_id);
+    let dir = loop_test_data_dir().join("loops").join(session_id);
 
     // Clean up before test
     let _ = std::fs::remove_dir_all(&dir);
@@ -219,11 +222,7 @@ fn test_save_iteration_creates_file() {
 #[test]
 fn test_save_iteration_without_validation_output() {
     let session_id = "test-save-no-validation";
-    let dir = dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from(".zerostack"))
-        .join("zerostack")
-        .join("loops")
-        .join(session_id);
+    let dir = loop_test_data_dir().join("loops").join(session_id);
 
     let _ = std::fs::remove_dir_all(&dir);
 


### PR DESCRIPTION
## Summary

Fixes --loop transcript storage to use zerostack's data directory instead of the caller's working directory.

## Context / Motivation

Loop transcript files are application state, not project artifacts. Writing them relative to the process working directory can leave unexpected files in user repositories.

## Key Changes

- Routes loop transcript storage through zerostack's data directory resolution.
- Keeps transcript behavior scoped to the existing loop mode.

## Verification & Testing

Reviewers can run zerostack --loop from a temporary project directory and confirm transcript files are written under the configured zerostack data directory, not the current project.