### PR TITLE
Forward reasoning deltas from streamed responses

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -182,6 +182,7 @@ Accepted top-level keys:
 | `sandbox`                 | boolean | Run bash commands in the bubblewrap sandbox. Default: `false`.                                                                                                              |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Accepts: `standard` (default), `restrictive`, `readonly`, `guarded`, `yolo`.                                          |
 | `show_tool_details`       | boolean or integer | Show tool-result previews in the TUI. `false` hides output, `true` shows all lines, an integer limits to that many lines (e.g. `3`). Default: `3`. |
+| `show_reasoning`          | boolean | Show streamed reasoning text in the TUI. Can still be toggled at runtime with `Ctrl+R` or `/reasoning`. Default: `true`. |
 | `statusline`              | table   | Configurable status bar (up to 3 lines of colored segments). When absent, a built-in default layout is used. See Status bar below. |
 | `chat_left_margin`        | integer | Left padding (columns) for the chat area only; input and status rows are unaffected. Default: `0`. |
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`. If the prompt file has a `%%mode=<mode>` first-line directive, the security mode is set automatically (see Prompt directives below). |

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -25,6 +25,22 @@ pub struct BtwRunner {
     pub abort_handle: tokio::task::AbortHandle,
 }
 
+fn streamed_reasoning_text<R>(content: &StreamedAssistantContent<R>) -> Option<CompactString> {
+    match content {
+        StreamedAssistantContent::Reasoning(reasoning) => {
+            Some(CompactString::new(reasoning.display_text()))
+        }
+        StreamedAssistantContent::ReasoningDelta { reasoning, .. } => {
+            if reasoning.is_empty() {
+                None
+            } else {
+                Some(CompactString::from(reasoning.as_str()))
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Spawn an isolated, single-turn, tool-less side-question run. The full result
 /// is delivered as a single [`BtwEvent::Done`] (or [`BtwEvent::Error`]) tagged
 /// with `id`. Unlike [`spawn_agent`], it never registers a subagent event sink
@@ -261,31 +277,30 @@ where
         loop {
             while let Some(item) = stream.next().await {
                 match item {
-                    Ok(MultiTurnStreamItem::StreamAssistantItem(
-                        StreamedAssistantContent::Text(text),
-                    )) => {
-                        let _ = event_tx
-                            .send(AgentEvent::Token(CompactString::from(text.text)))
-                            .await;
-                    }
-                    Ok(MultiTurnStreamItem::StreamAssistantItem(
-                        StreamedAssistantContent::Reasoning(r),
-                    )) => {
-                        let _ = event_tx
-                            .send(AgentEvent::Reasoning(CompactString::new(r.display_text())))
-                            .await;
-                    }
-                    Ok(MultiTurnStreamItem::StreamAssistantItem(
-                        StreamedAssistantContent::ToolCall { tool_call, .. },
-                    )) => {
-                        last_tool_name = Some(tool_call.function.name.clone());
-                        tool_interactions.push(tool_call.clone().into());
-                        let _ = event_tx
-                            .send(AgentEvent::ToolCall {
-                                name: CompactString::from(tool_call.function.name),
-                                args: tool_call.function.arguments,
-                            })
-                            .await;
+                    Ok(MultiTurnStreamItem::StreamAssistantItem(content)) => {
+                        if let Some(reasoning) = streamed_reasoning_text(&content) {
+                            let _ = event_tx.send(AgentEvent::Reasoning(reasoning)).await;
+                            continue;
+                        }
+
+                        match content {
+                            StreamedAssistantContent::Text(text) => {
+                                let _ = event_tx
+                                    .send(AgentEvent::Token(CompactString::from(text.text)))
+                                    .await;
+                            }
+                            StreamedAssistantContent::ToolCall { tool_call, .. } => {
+                                last_tool_name = Some(tool_call.function.name.clone());
+                                tool_interactions.push(tool_call.clone().into());
+                                let _ = event_tx
+                                    .send(AgentEvent::ToolCall {
+                                        name: CompactString::from(tool_call.function.name),
+                                        args: tool_call.function.arguments,
+                                    })
+                                    .await;
+                            }
+                            _ => {}
+                        }
                     }
                     Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
                         tool_result,
@@ -531,4 +546,33 @@ where
     }
 
     Ok(full_response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::streamed_reasoning_text;
+    use rig::streaming::StreamedAssistantContent;
+
+    #[test]
+    fn streamed_reasoning_delta_is_forwardable_as_reasoning_text() {
+        let content = StreamedAssistantContent::<()>::ReasoningDelta {
+            id: Some("rs_demo".to_string()),
+            reasoning: "thinking in progress".to_string(),
+        };
+
+        assert_eq!(
+            streamed_reasoning_text(&content).as_deref(),
+            Some("thinking in progress")
+        );
+    }
+
+    #[test]
+    fn empty_reasoning_delta_is_ignored() {
+        let content = StreamedAssistantContent::<()>::ReasoningDelta {
+            id: None,
+            reasoning: String::new(),
+        };
+
+        assert!(streamed_reasoning_text(&content).is_none());
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -132,6 +132,8 @@ pub struct Config {
     pub permission_modes: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_tool_details: Option<ShowToolDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_reasoning: Option<bool>,
     /// Configurable status-bar (up to 3 lines). When absent, a built-in
     /// default layout is used.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -380,6 +382,10 @@ impl Config {
 
     pub fn resolve_always_show_welcome(&self) -> bool {
         self.always_show_welcome.unwrap_or(false)
+    }
+
+    pub fn resolve_show_reasoning(&self) -> bool {
+        self.show_reasoning.unwrap_or(true)
     }
 
     pub fn resolve_auto_update_prompts(&self) -> Option<bool> {

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -93,6 +93,20 @@ fn compact_enabled_default_true() {
 }
 
 #[test]
+fn show_reasoning_defaults_on() {
+    assert!(Config::default().resolve_show_reasoning());
+}
+
+#[test]
+fn show_reasoning_can_be_disabled() {
+    let cfg = Config {
+        show_reasoning: Some(false),
+        ..Config::default()
+    };
+    assert!(!cfg.resolve_show_reasoning());
+}
+
+#[test]
 fn context_exhausted_report_math() {
     // window 20000, threshold 0.80 -> ceiling 16000.
     // prompt 18000 -> 90% of window, overflow 18000 - 16000 = 2000.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -780,7 +780,7 @@ pub async fn run_interactive(
     let mut agent_line_started = false;
     let mut response_buf = String::new();
     let mut response_start_line: Option<usize> = None;
-    let mut show_reasoning = true;
+    let mut show_reasoning = cfg.resolve_show_reasoning();
     let mut reasoning_enabled = true;
     session.reasoning_enabled = reasoning_enabled;
     // Seed the context-overhead estimate so the status bar reflects the system


### PR DESCRIPTION
## Summary

Forwards reasoning deltas from streamed model responses so reasoning output reaches the UI/event pipeline.

## Context / Motivation

Some providers stream reasoning separately from normal assistant text. Dropping those deltas makes reasoning-capable responses appear incomplete or inconsistent.

## Key Changes

- Handles reasoning stream deltas in the agent runner.
- Emits reasoning events through the existing event pipeline.

## Verification & Testing

Reviewers can use a streaming reasoning-capable model and confirm reasoning text appears as it is streamed.