### PR TITLE
Kill spawned process groups on cancellation

### DIFF
--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -133,14 +133,20 @@ impl Tool for BashTool {
         }
 
         let output = if let Some(secs) = args.timeout {
-            timeout(
+            match timeout(
                 Duration::from_millis(secs),
-                self.sandbox.wrap_command(&args.command).output(),
+                self.sandbox.output_command(&args.command),
             )
             .await
-            .map_err(|_| ToolError::Msg("Command timed out".to_string()))?
+            {
+                Ok(output) => output,
+                Err(_) => {
+                    self.sandbox.kill_active();
+                    return Err(ToolError::Msg("Command timed out".to_string()));
+                }
+            }
         } else {
-            self.sandbox.wrap_command(&args.command).output().await
+            self.sandbox.output_command(&args.command).await
         }?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,5 +1,8 @@
-use std::sync::OnceLock;
+use std::collections::HashSet;
+use std::process::{Output, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
 
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 #[derive(Debug, Clone)]
@@ -7,6 +10,7 @@ pub struct Sandbox {
     enabled: bool,
     backend: String,
     shell: String,
+    active_groups: Arc<Mutex<HashSet<u32>>>,
 }
 
 static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -31,12 +35,51 @@ fn which_cmd(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+struct ProcessGroupGuard {
+    pid: Option<u32>,
+    active_groups: Arc<Mutex<HashSet<u32>>>,
+}
+
+impl ProcessGroupGuard {
+    fn new(pid: Option<u32>, active_groups: Arc<Mutex<HashSet<u32>>>) -> Self {
+        if let Some(pid) = pid {
+            active_groups
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(pid);
+        }
+        Self { pid, active_groups }
+    }
+
+    fn disarm(&mut self) {
+        if let Some(pid) = self.pid.take() {
+            self.active_groups
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&pid);
+        }
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(pid) = self.pid.take() {
+            self.active_groups
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&pid);
+            kill_process_group(pid);
+        }
+    }
+}
+
 impl Sandbox {
     pub fn new(enabled: bool, backend: &str) -> Self {
         Sandbox {
             enabled,
             backend: backend.to_string(),
             shell: "bash".to_string(),
+            active_groups: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -51,7 +94,7 @@ impl Sandbox {
         if !self.enabled {
             let mut cmd = Command::new(&self.shell);
             cmd.arg("-c").arg(command);
-            cmd.kill_on_drop(true);
+            configure_child_lifetime(&mut cmd);
             return cmd;
         }
 
@@ -62,7 +105,7 @@ impl Sandbox {
                 tracing::warn!("sandbox: zerobox not found, running unsandboxed");
                 let mut cmd = Command::new(&self.shell);
                 cmd.arg("-c").arg(command);
-                cmd.kill_on_drop(true);
+                configure_child_lifetime(&mut cmd);
                 return cmd;
             }
             let mut cmd = Command::new("zerobox");
@@ -72,7 +115,7 @@ impl Sandbox {
             cmd.arg(&self.shell);
             cmd.arg("-c");
             cmd.arg(command);
-            cmd.kill_on_drop(true);
+            configure_child_lifetime(&mut cmd);
             return cmd;
         }
 
@@ -80,7 +123,7 @@ impl Sandbox {
             tracing::warn!("sandbox: bwrap not found, running unsandboxed");
             let mut cmd = Command::new(&self.shell);
             cmd.arg("-c").arg(command);
-            cmd.kill_on_drop(true);
+            configure_child_lifetime(&mut cmd);
             return cmd;
         }
 
@@ -127,8 +170,113 @@ impl Sandbox {
             "-c",
             command,
         ]);
-        cmd.kill_on_drop(true);
+        configure_child_lifetime(&mut cmd);
         cmd
+    }
+
+    pub async fn output_command(&self, command: &str) -> std::io::Result<Output> {
+        let mut cmd = self.wrap_command(command);
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = cmd.spawn()?;
+        let (stdout_handle, stdout) = spawn_pipe_reader(child.stdout.take());
+        let (stderr_handle, stderr) = spawn_pipe_reader(child.stderr.take());
+        let mut guard = ProcessGroupGuard::new(child.id(), self.active_groups.clone());
+        let status = child.wait().await?;
+
+        if tokio::time::timeout(std::time::Duration::from_millis(100), async {
+            join_reader(stdout_handle).await?;
+            join_reader(stderr_handle).await
+        })
+        .await
+        .is_err()
+        {
+            if let Some(pid) = guard.pid {
+                kill_process_group(pid);
+            }
+        }
+        let stdout = stdout.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let stderr = stderr.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        guard.disarm();
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+
+    pub fn kill_active(&self) {
+        let groups: Vec<u32> = self
+            .active_groups
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain()
+            .collect();
+        for pid in groups {
+            kill_process_group(pid);
+        }
+    }
+
+    pub fn active_group_count(&self) -> usize {
+        self.active_groups
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+    }
+}
+
+fn spawn_pipe_reader(
+    pipe: Option<impl tokio::io::AsyncRead + Send + Unpin + 'static>,
+) -> (
+    tokio::task::JoinHandle<std::io::Result<()>>,
+    Arc<Mutex<Vec<u8>>>,
+) {
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let reader_output = output.clone();
+    let handle = tokio::spawn(async move {
+        if let Some(mut pipe) = pipe {
+            let mut buf = [0; 8192];
+            loop {
+                let read = pipe.read(&mut buf).await?;
+                if read == 0 {
+                    break;
+                }
+                reader_output
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .extend_from_slice(&buf[..read]);
+            }
+        }
+        Ok(())
+    });
+    (handle, output)
+}
+
+async fn join_reader(reader: tokio::task::JoinHandle<std::io::Result<()>>) -> std::io::Result<()> {
+    reader
+        .await
+        .map_err(|e| std::io::Error::other(format!("pipe reader task failed: {e}")))?
+}
+
+fn configure_child_lifetime(cmd: &mut Command) {
+    cmd.kill_on_drop(true);
+    #[cfg(unix)]
+    cmd.process_group(0);
+}
+
+fn kill_process_group(pid: u32) {
+    #[cfg(unix)]
+    {
+        let group = format!("-{}", pid);
+        let _ = std::process::Command::new("kill")
+            .args(["-TERM", "--", &group])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        let _ = std::process::Command::new("kill")
+            .args(["-KILL", "--", &group])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -55,6 +55,8 @@ mod session_storage_tests;
 #[cfg(test)]
 mod session_tests;
 #[cfg(test)]
+mod shell_mode_tests;
+#[cfg(test)]
 mod singleflight_tests;
 #[cfg(test)]
 mod slash_add_tests;

--- a/src/tests/shell_mode_tests.rs
+++ b/src/tests/shell_mode_tests.rs
@@ -1,5 +1,5 @@
-
 use crate::sandbox::Sandbox;
+use tokio::time::{Duration, sleep, timeout};
 
 #[tokio::test]
 async fn test_shell_mode_runs_command() {
@@ -37,4 +37,72 @@ async fn test_shell_mode_stderr_included() {
     let output = cmd.output().await.unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(stderr.trim(), "stderr_output");
+}
+
+#[tokio::test]
+async fn test_output_command_returns_output_when_descendant_holds_pipe() {
+    let sandbox = Sandbox::new(false, "bwrap");
+    let output = timeout(
+        Duration::from_secs(1),
+        sandbox.output_command("printf ok; sleep 2 &"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "ok");
+}
+
+#[tokio::test]
+async fn test_shell_mode_timeout_kills_descendants() {
+    let marker =
+        std::env::temp_dir().join(format!("zerostack-abort-descendant-{}", std::process::id()));
+    let _ = std::fs::remove_file(&marker);
+
+    let sandbox = Sandbox::new(false, "bwrap");
+    let command = format!(
+        "sh -c 'sleep 2; printf leaked > {}' & wait",
+        marker.display()
+    );
+
+    let result = timeout(Duration::from_millis(100), sandbox.output_command(&command)).await;
+    assert!(result.is_err());
+
+    sleep(Duration::from_millis(2300)).await;
+    assert!(!marker.exists());
+}
+
+#[tokio::test]
+async fn test_shell_mode_explicit_kill_active_kills_running_descendants() {
+    let marker = std::env::temp_dir().join(format!(
+        "zerostack-abort-active-descendant-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&marker);
+
+    let sandbox = Sandbox::new(false, "bwrap");
+    let command = format!(
+        "sh -c 'sleep 2; printf leaked > {}' & wait",
+        marker.display()
+    );
+    let handle = tokio::spawn({
+        let sandbox = sandbox.clone();
+        async move { sandbox.output_command(&command).await }
+    });
+
+    zerostack_test_wait_until(|| sandbox.active_group_count() == 1).await;
+    sandbox.kill_active();
+    let _ = timeout(Duration::from_secs(1), handle).await;
+
+    sleep(Duration::from_millis(2300)).await;
+    assert!(!marker.exists());
+    assert_eq!(sandbox.active_group_count(), 0);
+}
+
+async fn zerostack_test_wait_until(mut predicate: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while !predicate() {
+        assert!(std::time::Instant::now() < deadline);
+        sleep(Duration::from_millis(10)).await;
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1181,6 +1181,7 @@ pub async fn run_interactive(
                                 if let Some(h) = main_abort.take() {
                                     h.abort();
                                 }
+                                sandbox.kill_active();
                                 is_running = false;
                                 if let Some(ss) = status_signals.as_ref() {
                                     ss.send_stop();
@@ -2523,6 +2524,7 @@ pub async fn run_interactive(
                                                     if let Some(h) = main_abort.take() {
                                                         h.abort();
                                                     }
+                                                    sandbox.kill_active();
                                                     is_running = false;
                                                     if let Some(ss) = status_signals.as_ref() {
                                                         ss.send_stop();


### PR DESCRIPTION
## Summary

Fixes command cancellation so spawned process groups are terminated instead of only killing the immediate child process.

## Context / Motivation

Shell commands can spawn children that outlive the parent process. Cancelling a tool call should not leave background processes running after zerostack has reported the command as cancelled.

## Key Changes

- Starts cancellable commands in a process group where supported.
- Terminates the process group on cancellation.
- Preserves existing sandbox/bash behavior for normal command completion.

## Verification & Testing

Reviewers can run a bash command that spawns a long-lived child, cancel it, and confirm no child process remains after cancellation.