### PR TITLE
Persist tool outputs in session history

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -122,12 +122,22 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
         match msg.role {
             MessageRole::User => messages.push(Message::user(msg.content.to_string())),
             MessageRole::Assistant => messages.push(Message::assistant(msg.content.to_string())),
-            // Convert any persisted System messages to Assistant for the
+            // Convert non-user transcript records to Assistant for the
             // same reason as the summary above: the templates that reject
-            // mid-stream System tolerate Assistant, and code-symmetry with
+            // mid-stream System/tool roles tolerate Assistant, and code-symmetry with
             // the summary push keeps the resumed-conversation shape
             // consistent.
             MessageRole::System => messages.push(Message::assistant(msg.content.to_string())),
+            MessageRole::ToolCall => {
+                messages.push(Message::assistant(format!("[ToolCall]: {}", msg.content)))
+            }
+            MessageRole::ToolResult => {
+                messages.push(Message::assistant(format!("[ToolResult]: {}", msg.content)))
+            }
+            MessageRole::SubagentToolCall => messages.push(Message::assistant(format!(
+                "[SubagentToolCall]: {}",
+                msg.content
+            ))),
         }
     }
 

--- a/src/extras/advisor/mod.rs
+++ b/src/extras/advisor/mod.rs
@@ -229,6 +229,9 @@ pub(crate) fn format_conversation(msgs: &[SessionMessage], kilobytes_limit: u32)
             MessageRole::User => "User",
             MessageRole::Assistant => "Assistant",
             MessageRole::System => "System",
+            MessageRole::ToolCall => "ToolCall",
+            MessageRole::ToolResult => "ToolResult",
+            MessageRole::SubagentToolCall => "SubagentToolCall",
         };
         format!("[{role}]: {}", msg.content)
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -5,12 +5,15 @@ use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageRole {
     User,
     Assistant,
     System,
+    ToolCall,
+    ToolResult,
+    SubagentToolCall,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -276,6 +279,73 @@ impl Session {
         });
         self.total_estimated_tokens = self.total_estimated_tokens.saturating_add(tokens);
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
+    }
+
+    pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) {
+        self.add_message(
+            MessageRole::ToolCall,
+            &crate::ui::utils::format_tool_call_summary(name, args),
+        );
+    }
+
+    pub fn add_tool_result(&mut self, name: &str, output: &str) {
+        self.add_message(MessageRole::ToolResult, &format!("{name}:\n{output}"));
+    }
+
+    pub fn add_subagent_tool_call(&mut self, name: &str, args: &serde_json::Value) {
+        self.add_message(
+            MessageRole::SubagentToolCall,
+            &crate::ui::utils::format_tool_call_summary(name, args),
+        );
+    }
+
+    pub fn title(&self) -> String {
+        if !self.name.is_empty() {
+            return self.name.to_string();
+        }
+        self.messages
+            .iter()
+            .rev()
+            .find(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(80).collect())
+            .unwrap_or_else(|| "untitled".to_string())
+    }
+
+    pub fn fork_title(&self, message_index: usize) -> String {
+        let target = self
+            .messages
+            .get(message_index)
+            .filter(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(48).collect::<String>())
+            .unwrap_or_else(|| self.title());
+        format!("Fork before: {target}")
+    }
+
+    pub fn fork_before_message(&self, message_index: usize) -> Self {
+        let mut fork = self.clone();
+        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
+        fork.id = CompactString::new(Uuid::new_v4().to_string());
+        fork.name = CompactString::new(self.fork_title(message_index));
+        fork.created_at = now.clone();
+        fork.updated_at = now;
+        fork.messages
+            .truncate(message_index.min(fork.messages.len()));
+        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
+        fork.total_input_tokens = 0;
+        fork.total_output_tokens = 0;
+        fork.total_cost = 0.0;
+        fork.input_token_cost = 0.0;
+        fork.output_token_cost = 0.0;
+        fork.reset_calibration();
+        if fork.messages.is_empty()
+            || fork
+                .compactions
+                .last()
+                .is_some_and(|c| c.first_kept_index > fork.messages.len())
+        {
+            fork.compactions.clear();
+        }
+        fork
     }
 
     #[cfg(feature = "multimodal")]

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -1,7 +1,7 @@
 use crate::session::MessageRole;
 use crate::session::Session;
 use crate::session::storage::{
-    delete_session, find_sessions_by_prefix, load_suffix, save_session, suffix_path,
+    delete_session, find_all_sessions, find_sessions_by_prefix, load_suffix, save_session, suffix_path,
 };
 use std::env;
 use std::sync::Mutex;
@@ -82,6 +82,50 @@ fn save_session_preserves_messages() {
     assert_eq!(found[0].messages.len(), 2);
     assert_eq!(found[0].messages[0].content, "question");
     assert_eq!(found[0].messages[1].content, "answer");
+    drop(env);
+}
+
+#[test]
+fn save_session_preserves_tool_messages() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000);
+    s.add_message(MessageRole::User, "question");
+    s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
+    s.add_tool_result("read", "file contents");
+    s.add_subagent_tool_call("task", &serde_json::json!({ "prompts": ["find x"] }));
+    s.add_message(MessageRole::Assistant, "answer");
+    save_session(&s).unwrap();
+
+    let found = find_sessions_by_prefix(&s.id[..8].to_string()).unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].messages.len(), 5);
+    assert_eq!(found[0].messages[1].role, MessageRole::ToolCall);
+    assert!(found[0].messages[1].content.contains("read"));
+    assert_eq!(found[0].messages[2].role, MessageRole::ToolResult);
+    assert_eq!(found[0].messages[2].content, "read:\nfile contents");
+    assert_eq!(found[0].messages[3].role, MessageRole::SubagentToolCall);
+    drop(env);
+}
+
+#[test]
+fn find_all_sessions_returns_saved_sessions_newest_first() {
+    let env = setup_test_env();
+    let mut older = Session::new("openai", "gpt-4", 128000);
+    older.updated_at = "2026-01-01T00:00:00Z".into();
+    older.add_message(MessageRole::User, "older");
+    older.updated_at = "2026-01-01T00:00:00Z".into();
+    save_session(&older).unwrap();
+
+    let mut newer = Session::new("anthropic", "claude", 200000);
+    newer.updated_at = "2026-01-02T00:00:00Z".into();
+    newer.add_message(MessageRole::User, "newer");
+    newer.updated_at = "2026-01-02T00:00:00Z".into();
+    save_session(&newer).unwrap();
+
+    let found = find_all_sessions().unwrap();
+    assert_eq!(found.len(), 2);
+    assert_eq!(found[0].id, newer.id);
+    assert_eq!(found[1].id, older.id);
     drop(env);
 }
 

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -14,6 +14,7 @@ use crate::permission::ask::AskSender;
 use crate::permission::checker::PermCheck;
 use crate::provider::{AnyAgent, AnyClient};
 use crate::sandbox::Sandbox;
+use crate::session::storage::save_session;
 use crate::session::{MessageRole, Session};
 use crate::ui::events::sanitize_output;
 use crate::ui::renderer::Renderer;
@@ -182,6 +183,8 @@ pub async fn handle_agent_event(
             }
             response_buf.clear();
             *response_start_line = None;
+            session.add_tool_call(&name, &args);
+            save_session_if_enabled(session, cli, renderer)?;
             let line = format!(
                 "◈ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
@@ -189,6 +192,8 @@ pub async fn handle_agent_event(
             renderer.write_line(&sanitize_output(&line), C_TOOL)?;
         }
         AgentEvent::SubagentToolCall { name, args } => {
+            session.add_subagent_tool_call(&name, &args);
+            save_session_if_enabled(session, cli, renderer)?;
             let line = format!(
                 "⌥ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
@@ -196,6 +201,8 @@ pub async fn handle_agent_event(
             renderer.write_line(&sanitize_output(&line), C_TOOL)?;
         }
         AgentEvent::ToolResult { name, output } => {
+            session.add_tool_result(&name, &output);
+            save_session_if_enabled(session, cli, renderer)?;
             if name == "todo_write" {
                 let list = TODO_LIST.lock().unwrap_or_else(|e| e.into_inner());
                 if list.is_empty() {
@@ -343,7 +350,21 @@ pub async fn handle_agent_event(
             *agent_line_started = false;
             response_buf.clear();
             *response_start_line = None;
+            save_session_if_enabled(session, cli, renderer)?;
         }
+    }
+    Ok(())
+}
+
+fn save_session_if_enabled(
+    session: &Session,
+    cli: &Cli,
+    renderer: &mut Renderer,
+) -> anyhow::Result<()> {
+    if !cli.no_session
+        && let Err(e) = save_session(session)
+    {
+        renderer.write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
     }
     Ok(())
 }
@@ -466,7 +487,7 @@ async fn handle_agent_done(
     }
 
     if !cli.no_session
-        && let Err(e) = crate::session::storage::save_session(session)
+        && let Err(e) = save_session(session)
     {
         renderer.write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
     }

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -3,7 +3,7 @@ use compact_str::CompactString;
 use crossterm::style::Color;
 
 use crate::cli::Cli;
-use crate::config::Config;
+use crate::config::{Config, ResolvedShowToolDetails};
 use crate::context::ContextFiles;
 use crate::session::{MessageRole, Session};
 use crate::ui::markdown;
@@ -63,8 +63,13 @@ pub fn render_session(
             MessageRole::User => (">", Color::Green),
             MessageRole::Assistant => ("<", Color::White),
             MessageRole::System => ("#", Color::DarkGrey),
+            MessageRole::ToolCall => ("◈", super::C_TOOL),
+            MessageRole::ToolResult => ("◈ result", Color::DarkGrey),
+            MessageRole::SubagentToolCall => ("⌥", super::C_TOOL),
         };
-        if msg.role == MessageRole::Assistant {
+        if msg.role == MessageRole::ToolResult {
+            render_tool_result(renderer, &msg.content, cfg)?;
+        } else if msg.role == MessageRole::Assistant {
             let max_width = renderer.line_width();
             let mut styled = markdown::markdown_to_styled(&msg.content, max_width);
             if !styled.is_empty() {
@@ -105,6 +110,58 @@ pub fn render_session(
         renderer.write_line("Run /welcome or /help to get started", Color::White)?;
         renderer.write_line("", Color::White)?;
         renderer.write_line("", Color::White)?;
+    }
+    Ok(())
+}
+
+fn render_tool_result(renderer: &mut Renderer, content: &str, cfg: &Config) -> anyhow::Result<()> {
+    let output = content
+        .split_once(":\n")
+        .map(|(_, output)| output)
+        .unwrap_or(content);
+    let show_details = cfg
+        .show_tool_details
+        .as_ref()
+        .map(|s| s.resolve())
+        .unwrap_or(ResolvedShowToolDetails::Limited(3));
+    match show_details {
+        ResolvedShowToolDetails::Off => {
+            renderer.write_line(
+                "◈ result hidden by show_tool_details=false",
+                Color::DarkGrey,
+            )?;
+        }
+        ResolvedShowToolDetails::Limited(max_lines) => {
+            let sanitized = sanitize_output(output);
+            let char_count = sanitized.chars().count();
+            let lines: Vec<&str> = sanitized.lines().collect();
+            if lines.len() > max_lines {
+                let shown = lines[..max_lines].join("\n");
+                renderer.write_line(
+                    &format!(
+                        "◈ result ({} chars, {} lines, showing {}):\n{}",
+                        char_count,
+                        lines.len(),
+                        max_lines,
+                        shown
+                    ),
+                    Color::DarkGrey,
+                )?;
+            } else {
+                renderer.write_line(
+                    &format!("◈ result ({} chars):\n{}", char_count, sanitized),
+                    Color::DarkGrey,
+                )?;
+            }
+        }
+        ResolvedShowToolDetails::Unlimited => {
+            let sanitized = sanitize_output(output);
+            let char_count = sanitized.chars().count();
+            renderer.write_line(
+                &format!("◈ result ({} chars):\n{}", char_count, sanitized),
+                Color::DarkGrey,
+            )?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Persists tool outputs in saved session history so restored conversations retain the tool results that informed prior assistant turns.

## Context / Motivation

When tool results are missing after restore, the transcript is less useful and future turns may lack important context about what happened earlier.

## Key Changes

- Records tool output data in session state.
- Restores persisted tool outputs when loading sessions.
- Adds session storage coverage for tool output persistence.

## Verification & Testing

Reviewers can run a tool call, save and restore the session, and confirm the restored transcript still includes the tool result.