### PR TITLE
fix(compaction): announce only when compaction runs and let /compress force it

### DIFF
--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -442,9 +442,9 @@ async fn handle_agent_done(
         && session.needs_compaction(reserve)
         && !cli.no_session
     {
-        renderer.write_line("auto-compacting...", Color::DarkGrey)?;
         let compress_result = handle_compress(
             None,
+            true,
             agent,
             client,
             renderer,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -535,9 +535,15 @@ async fn mid_turn_compact_and_respawn(
     *response_start_line = None;
     *agent_line_started = false;
 
+    // Unlike the between-turn gate, this announces unconditionally: the relief
+    // here is dropping the aborted run's in-flight tool context via the respawn
+    // below, which always happens even when the `handle_compress` step is a
+    // no-op. So the message describes the restart rather than promising a
+    // summarize step (which may not run and would otherwise leave the user
+    // waiting on a "compressed N messages" line that never comes).
     renderer.write_line(
         &format!(
-            "mid-turn auto-compacting (context at {}%)...",
+            "mid-turn context relief, restarting (at {}%)...",
             (pressure * 100.0).round() as u64
         ),
         Color::DarkGrey,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -548,6 +548,7 @@ async fn mid_turn_compact_and_respawn(
     let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
     let compress_result = handle_compress(
         None,
+        true,
         agent,
         client,
         renderer,
@@ -1722,6 +1723,7 @@ pub async fn run_interactive(
                                         let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
                                         let compress_result = handle_compress(
                                             instructions.as_deref(),
+                                            false,
                                             &mut agent, &mut client, &mut renderer, session, cli, cfg, context,
                                             reasoning_enabled,
                                             &permission, &ask_tx, &sandbox,

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -178,7 +178,16 @@ pub async fn handle_compress(
     renderer.write_line("compressing...", C_AGENT)?;
     renderer.write_line("", crossterm::style::Color::White)?;
 
+    // Mirror the auto-compaction trigger's reserve exactly (including memory's
+    // effective_reserve) so the budget gate here can never disagree with the
+    // gate that decided to call us.
     let qm = crate::config::quick_models_map(cfg);
+    #[cfg(feature = "memory")]
+    let reserve = crate::extras::memory::effective_reserve(
+        cfg.resolve_reserve_tokens(&session.model, &qm),
+        context.memory.as_deref(),
+    );
+    #[cfg(not(feature = "memory"))]
     let reserve = cfg.resolve_reserve_tokens(&session.model, &qm);
     let keep_recent = cfg.resolve_keep_recent_tokens();
     let max_tokens = session.context_window.saturating_sub(reserve);

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -263,7 +263,6 @@ pub async fn handle_compress(
         )
         .await,
     );
-    renderer.write_line("prompt cleared (back to default behavior)", C_AGENT)?;
 
     render_session(renderer, session, cli, cfg, context)?;
     renderer.write_line(

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -162,6 +162,7 @@ pub fn undo_last(session: &mut Session) -> usize {
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_compress(
     instructions: Option<&str>,
+    auto: bool,
     agent: &mut Option<AnyAgent>,
     client: &mut AnyClient,
     renderer: &mut Renderer,
@@ -175,9 +176,6 @@ pub async fn handle_compress(
     sandbox: &Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
 ) -> anyhow::Result<()> {
-    renderer.write_line("compressing...", C_AGENT)?;
-    renderer.write_line("", crossterm::style::Color::White)?;
-
     // Mirror the auto-compaction trigger's reserve exactly (including memory's
     // effective_reserve) so the budget gate here can never disagree with the
     // gate that decided to call us.
@@ -192,17 +190,33 @@ pub async fn handle_compress(
     let keep_recent = cfg.resolve_keep_recent_tokens();
     let max_tokens = session.context_window.saturating_sub(reserve);
 
-    if session.effective_context_tokens() <= max_tokens {
-        renderer.write_line("context within limits, no compression needed", C_AGENT)?;
+    // Auto-compaction only makes sense when actually over budget; manual
+    // /compress is the user's explicit intent, so it skips the budget gate and
+    // proceeds regardless of how full the context is.
+    if auto && session.effective_context_tokens() <= max_tokens {
         return Ok(());
     }
 
     let cut_idx = crate::session::Session::select_compaction_cut(&session.messages, keep_recent);
 
+    // Nothing old enough to summarize (everything is within keep_recent). This
+    // is a real physical limit even when forced, so report it for manual runs;
+    // stay silent under auto so an over-budget-but-unsummarizable turn does not
+    // announce a no-op on every completion.
     if cut_idx == 0 {
-        renderer.write_line("nothing to compress (entire context is recent)", C_AGENT)?;
+        if !auto {
+            renderer.write_line("not enough conversation history to compact yet", C_AGENT)?;
+        }
         return Ok(());
     }
+
+    // Announce only once we know compression will actually run.
+    if auto {
+        renderer.write_line("auto-compacting...", crossterm::style::Color::DarkGrey)?;
+    } else {
+        renderer.write_line("compressing...", C_AGENT)?;
+    }
+    renderer.write_line("", crossterm::style::Color::White)?;
 
     let messages_to_summarize = &session.messages[..cut_idx];
     let previous_summary = session.compactions.last().map(|c| c.summary.as_str());


### PR DESCRIPTION
## Summary

Auto-compaction announced itself before it knew whether it could do anything, so an over-budget turn whose message history was still short produced "auto-compacting" plus "nothing to compress" noise on every completion while doing nothing. At the same time, a manual `/compress` or `/compact` could refuse to run with "context within limits, no compression needed", so the user could not compact on demand. This PR makes auto-compaction silent unless it actually compresses, makes manual compaction always honor the user's intent, and aligns the mid-turn notice with what that path actually does.

The compaction engine itself (`select_compaction_cut`, summarization, `compress`) was correct. The bug was in output timing and in a guard that did not distinguish automatic from manual invocation.

## Root Cause

The auto path and the worker function had two layers of trouble:

1. **Announcement printed before the decision.** `handle_agent_done` printed `auto-compacting...` and then `handle_compress` printed `compressing...`, both before the two early-return guards ran. When real usage was over budget but the message history still fit inside `keep_recent` (so `select_compaction_cut` returns `cut_idx == 0`, the documented case where a large system prompt or context files push real usage over budget while the messages stay small), every turn announced compaction and then printed `nothing to compress` without doing anything.

2. **Manual compaction blocked by the budget gate.** `handle_compress` applied `effective_context_tokens() <= max_tokens` to every caller, so a manual `/compress` below the threshold returned `context within limits, no compression needed`. The user had no way to force compaction.

Related issues surfaced while investigating:

3. **Mismatched reserve between the two gates.** The auto trigger computed its reserve through memory's `effective_reserve`, while `handle_compress` recomputed a bare `resolve_reserve_tokens`. With the memory feature active the budgets differed, so the auto gate and the worker's own within-budget check could disagree.

4. **A stale "prompt cleared" notice.** `handle_compress` printed `prompt cleared (back to default behavior)` after rebuilding the agent, but it never touches `current_prompt` / `current_prompt_name` and rebuilds from the same `context`, so `build_preamble` re-includes any active prompt. The line claimed a state change that does not happen. It is an orphaned copy left by an earlier refactor; the accurate version lives in `/prompt default`.

5. **Mid-turn notice implied a summarize step that may not run.** `mid_turn_compact_and_respawn` printed `mid-turn auto-compacting (context at X%)...` before its `handle_compress` step. But the mid-turn path's real pressure relief is aborting the in-flight run and respawning on a trimmed history, which always happens; the inner `handle_compress` is incidental and may be a no-op. The wording promised a summarize step that does not always run, so it could read as a no-op announcement and leave the user waiting on a `compressed N messages` line that never comes.

## Key Changes

- `handle_compress` takes an `auto` flag. The announcement moves after both guards, so it prints only when compression will actually run.
- Auto runs return silently on a no-op (within budget, or `cut_idx == 0`). The between-turn call site (`handle_agent_done`) and `handle_compress` itself no longer print premature announcements.
- The mid-turn respawn (`mid_turn_compact_and_respawn`, `auto = true`) keeps an unconditional notice on purpose, because its abort + respawn always relieves pressure even when the inner `handle_compress` is a no-op. The notice is reworded from `mid-turn auto-compacting...` to `mid-turn context relief, restarting...` so it describes the restart that always happens rather than a summarize step that may not.
- Manual `/compress` and `/compact` (`auto = false`) skip the budget gate, so they always compact unless nothing is old enough to summarize.
- The worker's reserve now mirrors the auto trigger exactly, including memory's `effective_reserve`, so the two gates can never contradict each other.
- Removed the orphaned `prompt cleared (back to default behavior)` line.
- Reworded the manual `cut_idx == 0` message to be self-explanatory.

## User-facing messages: before and after

| Situation | Before | After |
| --- | --- | --- |
| Manual `/compact`, over budget, has old messages | `compressing...` then `prompt cleared...` then result | `compressing...` then result |
| Manual `/compact`, under budget, has old messages | `context within limits, no compression needed` (blocked) | `compressing...` then `compressed N messages (saved ~T tokens)` |
| Manual `/compact`, history too short | `compressing...` then `nothing to compress (entire context is recent)` | `not enough conversation history to compact yet` |
| Auto, has old messages | `auto-compacting...` then `compressing...` then `prompt cleared...` then result | `auto-compacting...` then result |
| Auto, over budget but history too short (`cut_idx == 0`) | every turn: `auto-compacting...` then `compressing...` then `nothing to compress...` | silent |
| Mid-turn relief (abort + respawn), inner compress no-op | `mid-turn auto-compacting (context at X%)...` then no result line | `mid-turn context relief, restarting (at X%)...` then no result line |
| Manual or auto, summary call fails | `compress error: {e}` / `auto-compact error: {e}` | unchanged |

## Files

- `src/ui/slash/mod.rs` adds the `auto` flag, the gate split, the relocated announcement, the reserve alignment, the reworded message, and removes the stale notice.
- `src/ui/event_handler.rs` drops the premature announcement and passes `auto = true`.
- `src/ui/mod.rs` passes `auto = true` for the mid-turn respawn and `auto = false` for manual `/compress`, and rewords the mid-turn notice.

## Verification

- `cargo build`, `cargo fmt --check`, and `cargo test session` (57 passed) all pass.
- Reproduced against built binaries for both the no-op-silence and manual-force behaviors using throwaway configs (tiny `context_window` to force the auto no-op, tiny `keep_recent_tokens` to make manual force summarize under budget).