### PR TITLE
fix(statusline): show context percentage honestly past 100%

### DIFF
--- a/src/tests/statusline_tests.rs
+++ b/src/tests/statusline_tests.rs
@@ -301,6 +301,61 @@ fn reasoning_shows_only_when_enabled() {
     );
 }
 
+fn first_fg(spans: &[StatusSpan]) -> Option<crossterm::style::Color> {
+    spans.iter().find_map(|s| match s {
+        StatusSpan::Text { fg, .. } => Some(*fg),
+        StatusSpan::Flex => None,
+    })?
+}
+
+#[test]
+fn context_percentage_is_not_clamped() {
+    // Past the window is a real over-budget state, so it must be reported
+    // honestly rather than capped at 100%.
+    let spec = StatusLineConfig {
+        lines: vec![StatusLineLine {
+            segments: vec![seg("context_percentage")],
+        }],
+    };
+    let mut session = Session::new("openrouter", "m", 1000);
+    session.set_calibration(1100, 0); // 110% of the window
+    assert_eq!(
+        line_text(&statusline::build_lines(&spec, &session, &ctx())[0]),
+        "110%"
+    );
+}
+
+#[test]
+fn context_percentage_color_warns_as_it_fills() {
+    use crossterm::style::Color;
+    let spec = StatusLineConfig {
+        lines: vec![StatusLineLine {
+            segments: vec![seg("context_percentage")],
+        }],
+    };
+    // Green tier keeps the configured (here: default/none) color.
+    let mut session = Session::new("openrouter", "m", 1000);
+    session.set_calibration(500, 0); // 50%
+    assert_eq!(
+        first_fg(&statusline::build_lines(&spec, &session, &ctx())[0]),
+        None
+    );
+
+    // Amber as it approaches full.
+    session.set_calibration(950, 0); // 95%
+    assert_eq!(
+        first_fg(&statusline::build_lines(&spec, &session, &ctx())[0]),
+        Some(Color::Yellow)
+    );
+
+    // Red once it crosses the window.
+    session.set_calibration(1100, 0); // 110%
+    assert_eq!(
+        first_fg(&statusline::build_lines(&spec, &session, &ctx())[0]),
+        Some(Color::Red)
+    );
+}
+
 #[test]
 fn session_age_is_short_duration() {
     let spec = StatusLineConfig {

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -122,7 +122,12 @@ fn build_line(line: &StatusLineLine, session: &Session, ctx: &StatusContext) -> 
                     if let Some(glyph) = resolve_icon(seg.icon.as_ref(), item) {
                         text = format!("{glyph} {text}");
                     }
-                    let fg = color(&seg.color);
+                    // A live-state override (e.g. the context meter turning
+                    // amber/red as it fills) wins over the configured color so
+                    // a reading at or past 100% reads as a deliberate warning
+                    // rather than a rendering glitch. The powerline cap below
+                    // derives from this fg, so the segment edge tracks it too.
+                    let fg = dynamic_item_color(item, session).or_else(|| color(&seg.color));
                     let bg = color(&seg.bg);
                     // Powerline caps: the glyph is drawn in the segment's bg color
                     // (so it reads as the segment's rounded/triangle edge) over the
@@ -171,6 +176,31 @@ fn build_line(line: &StatusLineLine, session: &Session, ctx: &StatusContext) -> 
         cleaned.pop();
     }
     cleaned.into_iter().map(|(s, _)| s).collect()
+}
+
+/// Context fill as an integer percentage of the window, or `None` when the
+/// window is unknown (so the meter shows `0%` rather than dividing by zero).
+/// Deliberately not clamped: a value past 100% is a real "over budget" state
+/// (estimated new messages stacked on the calibrated anchor, or a window
+/// configured smaller than the provider's), and hiding it would mask that
+/// compaction is overdue or could not recover.
+fn context_percentage(session: &Session) -> Option<u64> {
+    (session.effective_context_tokens() * 100).checked_div(session.context_window)
+}
+
+/// Per-item color override driven by live session state, taking precedence over
+/// the configured color. Currently only the context percentage: amber as it
+/// approaches full, red once it crosses the window, so an over-budget reading is
+/// visibly intentional. Returns `None` to keep the segment's configured color.
+fn dynamic_item_color(item: &str, session: &Session) -> Option<Color> {
+    if item != "context_percentage" {
+        return None;
+    }
+    match context_percentage(session)? {
+        pct if pct > 100 => Some(Color::Red),
+        pct if pct >= 90 => Some(Color::Yellow),
+        _ => None,
+    }
 }
 
 /// Resolve a non-separator item to display text, or `None` to skip it.
@@ -227,12 +257,7 @@ fn resolve_item(
             ))
         }
         "context_max" => Some(fmt_tokens(session.context_window)),
-        "context_percentage" => {
-            let pct = (session.effective_context_tokens() * 100)
-                .checked_div(session.context_window)
-                .unwrap_or(0);
-            Some(format!("{pct}%"))
-        }
+        "context_percentage" => Some(format!("{}%", context_percentage(session).unwrap_or(0))),
         "cost" => (session.total_cost > 0.0 || session.show_cost_always || always)
             .then(|| format!("${:.4}", session.total_cost)),
         "prompt" => ctx.prompt_name.map(|s| format!("prompt:{s}")),


### PR DESCRIPTION
## Summary

The context-usage percentage in the status bar sometimes reads above 100%. Rather than clamp it (which would hide a real condition), this surfaces it honestly: the figure stays truthful and the segment changes color as it fills, so a reading past 100% is visibly an over-budget warning instead of looking like a rendering glitch.

## Root cause

The percentage is `effective_context_tokens() * 100 / context_window`.

After the first response, `effective_context_tokens()` is anchored to the provider's real reported usage (`real_input_tokens + output_tokens`), plus the estimated tokens of any messages added since that anchor. Two things legitimately push it past 100%:

1. **Estimated delta on a near-full anchor.** Between turns, your new prompt, pasted content, and tool outputs are added to the anchor as estimates before the next turn recalibrates. On an already near-full context this can cross 100% before compaction runs.
2. **The anchor itself can exceed the input window.** Anthropic reports `max_input_tokens` (e.g. 200k for claude-haiku-4-5, confirmed against the live API) separately from `max_tokens` output (64k). A turn ending with a large input plus a large output can leave `real_input + output` above the input window the meter measures against.

Both are real "the conversation no longer fits, compaction is due" states. The denominator was verified correct: the baked catalog (`data/models.json`), live models.dev, and the Anthropic API all agree on the Anthropic context windows, so the overflow is not a window-too-small bug.

The actual defect was purely visual: the percentage segment was always drawn green, so an honest over-100% looked like a bug. Clamping to 100% would have hidden that compaction is overdue, or in the no-op compaction case (nothing old enough to summarize) could not recover.

## Fix

- Do not clamp. Keep the true percentage.
- Color the `context_percentage` segment by fill level: amber from 90%, red past 100%, otherwise the configured color. The live override wins over the segment's configured color, and the powerline cap follows it.
- Factor the percentage into a shared helper so the displayed value and the color tier can never diverge.

Color tiers use fixed percentages rather than the live compaction reserve to keep the change contained to the statusline (no plumbing `reserve`/`cfg` through the render path). Under the default 8192 reserve the compaction threshold lands at 93.6% (128k window) to 99.2% (1M), so amber at 90% always precedes it and red past 100% marks crossing the actual window.

## Before / After

| Context fill | Before | After |
|---|---|---|
| 50% | `50%` green | `50%` (configured color) |
| 95% | `95%` green | `95%` amber |
| 110% | `110%` green | `110%` red |

(The number was already shown unclamped before; only the color is new.)

## Testing

- `cargo build`
- `cargo test statusline` (21 passed), including new `context_percentage_is_not_clamped` and `context_percentage_color_warns_as_it_fills`
- `cargo fmt --check`