### PR TITLE
Add direct DeepSeek provider support

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -81,6 +81,18 @@
       "context": 1000000
     }
   ],
+  "deepseek": [
+    {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash",
+      "context": 1000000
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek V4 Pro",
+      "context": 1000000
+    }
+  ],
   "openai": [
     {
       "id": "gpt-3.5-turbo",

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -6,6 +6,7 @@ use std::env::VarError;
 pub enum ProviderKind {
     OpenRouter,
     OpenAI,
+    DeepSeek,
     Anthropic,
     Gemini,
     Ollama,
@@ -16,6 +17,7 @@ impl ProviderKind {
         match name.to_lowercase().as_str() {
             "openrouter" => Some(Self::OpenRouter),
             "openai" | "custom" => Some(Self::OpenAI), // "custom" is an alias for OpenAI client
+            "deepseek" => Some(Self::DeepSeek),
             "anthropic" => Some(Self::Anthropic),
             "gemini" | "google" => Some(Self::Gemini),
             "ollama" => Some(Self::Ollama),
@@ -128,6 +130,7 @@ impl AuthResolver {
     fn env_var_name(&self) -> &'static str {
         match self.provider_kind {
             ProviderKind::OpenAI => "OPENAI_API_KEY",
+            ProviderKind::DeepSeek => "DEEPSEEK_API_KEY",
             ProviderKind::Anthropic => "ANTHROPIC_API_KEY",
             ProviderKind::Gemini => "GEMINI_API_KEY",
             ProviderKind::Ollama => "OLLAMA_API_KEY",
@@ -139,6 +142,7 @@ impl AuthResolver {
         match self.provider_kind {
             ProviderKind::OpenRouter => "openrouter",
             ProviderKind::OpenAI => "openai",
+            ProviderKind::DeepSeek => "deepseek",
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::Gemini => "gemini",
             ProviderKind::Ollama => "ollama",

--- a/src/models_catalog.rs
+++ b/src/models_catalog.rs
@@ -48,5 +48,66 @@ static CATALOG: LazyLock<HashMap<String, Vec<ModelEntry>>> = LazyLock::new(|| {
 /// Baked model entries for a provider, or `None` when the provider is not in the
 /// catalog (custom gateways, ollama — those resolve live).
 pub fn catalog_entries(provider: &str) -> Option<&'static [ModelEntry]> {
+    let provider = match provider {
+        "openai-codex" | "codex" => "openai",
+        other => other,
+    };
     CATALOG.get(provider).map(|v| v.as_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(provider: &str) -> Vec<String> {
+        catalog_entries(provider)
+            .unwrap_or(&[])
+            .iter()
+            .map(|m| m.id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn catalog_parses_and_has_expected_providers() {
+        for p in ["anthropic", "deepseek", "openai", "gemini", "openrouter"] {
+            assert!(
+                !ids(p).is_empty(),
+                "missing or empty baked catalog for: {p}"
+            );
+        }
+    }
+
+    #[test]
+    fn deepseek_includes_default_models() {
+        // The direct DeepSeek defaults must be discoverable offline so the picker
+        // is useful on a fresh, network-blocked start.
+        let ids = ids("deepseek");
+        assert!(ids.contains(&"deepseek-v4-flash".to_string()));
+        assert!(ids.contains(&"deepseek-v4-pro".to_string()));
+    }
+
+    #[test]
+    fn openrouter_includes_deepseek_provider_models() {
+        // The OpenRouter-prefixed DeepSeek models remain available when using
+        // OpenRouter explicitly.
+        // offline so the picker is useful on a fresh, network-blocked start.
+        assert!(
+            ids("openrouter").contains(&"deepseek/deepseek-v4-pro".to_string()),
+            "default model missing from baked openrouter catalog"
+        );
+    }
+
+    #[test]
+    fn unbaked_provider_has_no_catalog() {
+        // ollama resolves live (local), so it is intentionally not baked.
+        assert!(catalog_entries("ollama").is_none());
+    }
+
+    #[test]
+    fn openai_codex_uses_openai_catalog() {
+        let openai = catalog_entries("openai").unwrap();
+        let codex = catalog_entries("openai-codex").unwrap();
+        assert_eq!(openai.len(), codex.len());
+        assert!(codex.iter().any(|m| m.id == "gpt-5.5"));
+    }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -25,6 +25,8 @@ use crate::permission::checker::PermCheck;
 use crate::sandbox::Sandbox;
 use crate::session::SessionMessage;
 
+const DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com";
+
 pub struct ProviderConfig {
     pub kind: ProviderKind,
     pub base_url: Option<String>,
@@ -48,7 +50,7 @@ pub fn resolve_provider_config(
     }
     let kind = ProviderKind::from_name(name).ok_or_else(|| {
         anyhow::anyhow!(
-            "Unknown provider: '{}'. Supported: openrouter, openai, anthropic, gemini, ollama",
+            "Unknown provider: '{}'. Supported: openrouter, openai, deepseek, anthropic, gemini, ollama",
             name
         )
     })?;
@@ -98,6 +100,7 @@ pub(crate) fn default_model_for_provider(
     let m = match provider {
         "anthropic" => "claude-sonnet-4-6",
         "openai" => "gpt-5.1",
+        "deepseek" => "deepseek-v4-pro",
         "gemini" | "google" => "gemini-2.5-pro",
         "openrouter" => "openrouter/auto", // OpenRouter's always-valid auto-router
         "ollama" => "llama3.1",
@@ -124,13 +127,16 @@ fn resolve_base_url(config: &ProviderConfig) -> Option<String> {
 pub enum OpenAiClient {
     Responses(openai::Client),
     Completions(openai::CompletionsClient),
+    DeepSeek(openai::CompletionsClient),
 }
 
 impl OpenAiClient {
     fn completion_model(&self, name: String) -> OpenAiModel {
         match self {
             OpenAiClient::Responses(c) => OpenAiModel::Responses(c.completion_model(name)),
-            OpenAiClient::Completions(c) => OpenAiModel::Completions(c.completion_model(name)),
+            OpenAiClient::Completions(c) | OpenAiClient::DeepSeek(c) => {
+                OpenAiModel::Completions(c.completion_model(name))
+            }
         }
     }
 }
@@ -202,6 +208,7 @@ impl AnyClient {
     pub fn provider_name(&self) -> &'static str {
         match self {
             AnyClient::OpenRouter(_) => "openrouter",
+            AnyClient::OpenAI(OpenAiClient::DeepSeek(_)) => "deepseek",
             AnyClient::OpenAI(_) => "openai",
             AnyClient::Anthropic(_) => "anthropic",
             AnyClient::Gemini(_) => "gemini",
@@ -311,6 +318,12 @@ pub fn is_agent_model(m: &ModelEntry) -> bool {
     !DENY.iter().any(|d| id.contains(d))
 }
 
+fn catalog_model_entries(provider: &str) -> Vec<ModelEntry> {
+    crate::models_catalog::catalog_entries(provider)
+        .unwrap_or(&[])
+        .to_vec()
+}
+
 impl AnyClient {
     /// Built-in providers: rig's ModelListingClient.
     pub async fn list_models(&self) -> anyhow::Result<Vec<ModelEntry>> {
@@ -322,6 +335,9 @@ impl AnyClient {
             AnyClient::Ollama(c) => c.list_models().await?,
             // If any arm above does NOT impl ModelListingClient it won't compile —
             // move it down here to the manual fallback.
+            AnyClient::OpenAI(OpenAiClient::DeepSeek(_)) => {
+                return Ok(catalog_model_entries("deepseek"));
+            }
             AnyClient::OpenAI(OpenAiClient::Completions(_)) => {
                 anyhow::bail!("rig model listing unavailable for this client")
             }
@@ -707,6 +723,7 @@ pub fn create_client(
                 http_client,
             )?))
         }
+        ProviderKind::DeepSeek => build_deepseek_client(&key),
         ProviderKind::Anthropic => build_anthropic_client(&key, base_url.as_deref()),
         ProviderKind::Gemini => build_gemini_client(&key, base_url.as_deref()),
         ProviderKind::Ollama => build_ollama_client(&key, base_url.as_deref()),
@@ -723,6 +740,14 @@ macro_rules! build_provider_client {
         };
         Ok(AnyClient::$variant(builder.build()?))
     }};
+}
+
+fn build_deepseek_client(key: &str) -> anyhow::Result<AnyClient> {
+    let client = openai::CompletionsClient::builder()
+        .api_key(key)
+        .base_url(DEEPSEEK_BASE_URL)
+        .build()?;
+    Ok(AnyClient::OpenAI(OpenAiClient::DeepSeek(client)))
 }
 
 fn build_anthropic_client(key: &str, base_url: Option<&str>) -> anyhow::Result<AnyClient> {

--- a/src/tests/auth_tests.rs
+++ b/src/tests/auth_tests.rs
@@ -159,3 +159,21 @@ fn provider_kind_from_name_case_insensitive() {
 fn provider_kind_from_name_returns_none_for_unknown() {
     assert_eq!(ProviderKind::from_name("unknown"), None);
 }
+
+#[test]
+fn deepseek_uses_deepseek_api_key_env() {
+    use crate::auth::{AuthResolver, ProviderKind};
+    use std::env::VarError;
+
+    let resolver = AuthResolver::new(ProviderKind::DeepSeek);
+    let key = resolver
+        .resolve_with_env(|name| {
+            if name == "DEEPSEEK_API_KEY" {
+                Ok("deepseek-key".to_string())
+            } else {
+                Err(VarError::NotPresent)
+            }
+        })
+        .unwrap();
+    assert_eq!(key, "deepseek-key");
+}

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -306,3 +306,38 @@ fn leaves_non_anthropic_openrouter_models_untouched() {
         );
     }
 }
+
+#[test]
+fn resolve_builtin_deepseek() {
+    use crate::auth::ProviderKind;
+    use crate::provider::resolve_provider_config;
+    use std::collections::HashMap;
+
+    let cfg = resolve_provider_config("deepseek", &HashMap::new()).unwrap();
+    assert_eq!(cfg.kind, ProviderKind::DeepSeek);
+    assert!(cfg.base_url.is_none());
+}
+
+#[test]
+fn deepseek_client_builds_as_openai_compatible() {
+    use crate::provider::{AnyClient, OpenAiClient, create_client};
+    use std::collections::HashMap;
+
+    let client = create_client("deepseek", Some("sk-test"), &HashMap::new(), None).unwrap();
+    assert_eq!(client.provider_name(), "deepseek");
+    assert!(matches!(
+        client,
+        AnyClient::OpenAI(OpenAiClient::DeepSeek(_))
+    ));
+}
+
+#[tokio::test]
+async fn deepseek_lists_static_zerostack_defaults() {
+    use crate::provider::create_client;
+    use std::collections::HashMap;
+
+    let client = create_client("deepseek", Some("sk-test"), &HashMap::new(), None).unwrap();
+    let models = client.list_models().await.unwrap();
+    let ids: Vec<_> = models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["deepseek-v4-flash", "deepseek-v4-pro"]);
+}


### PR DESCRIPTION
## Summary

Adds DeepSeek as a first-class provider with model catalog entries and direct API-key resolution.

## Context / Motivation

DeepSeek can be configured as an OpenAI-compatible custom provider, but a first-class provider removes setup friction and makes the default model/catalog experience clearer for users who want direct DeepSeek access.

## Key Changes

- Adds DeepSeek provider selection and client construction.
- Adds `DEEPSEEK_API_KEY` resolution through the existing provider auth path.
- Adds DeepSeek model catalog entries.
- Adds provider/auth tests for DeepSeek behavior.

## Verification & Testing

Reviewers can set a DeepSeek API key, select the DeepSeek provider, start a session with a DeepSeek catalog model, and confirm missing-key behavior matches other direct providers.
