### PR TITLE
Store long tool outputs as sidecar artifacts

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,9 +1,15 @@
 pub mod chat_history;
 pub mod storage;
 
+use std::path::Path;
+
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+pub const TOOL_RESULT_SAVE_THRESHOLD: usize = 12_000;
+pub const TOOL_RESULT_HEAD_CHARS: usize = 2_000;
+pub const TOOL_RESULT_TAIL_CHARS: usize = 8_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -288,8 +294,24 @@ impl Session {
         );
     }
 
-    pub fn add_tool_result(&mut self, name: &str, output: &str) {
-        self.add_message(MessageRole::ToolResult, &format!("{name}:\n{output}"));
+    pub fn add_tool_result(&mut self, name: &str, output: &str) -> String {
+        let content = self.tool_result_content(name, output);
+        self.add_message(MessageRole::ToolResult, &content);
+        content
+    }
+
+    fn tool_result_content(&self, name: &str, output: &str) -> String {
+        let output_chars = output.chars().count();
+        if output_chars <= TOOL_RESULT_SAVE_THRESHOLD {
+            return format!("{name}:\n{output}");
+        }
+
+        match storage::save_tool_output(&self.id, name, output) {
+            Ok(path) => format_truncated_tool_result(name, output, output_chars, &path),
+            Err(err) => format!(
+                "{name}:\n{output}\n\n[failed to save long tool output separately; kept full output in session to avoid data loss: {err}]"
+            ),
+        }
     }
 
     pub fn add_subagent_tool_call(&mut self, name: &str, args: &serde_json::Value) {
@@ -489,4 +511,21 @@ impl Session {
         self.reset_calibration();
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
     }
+}
+
+fn format_truncated_tool_result(
+    name: &str,
+    output: &str,
+    output_chars: usize,
+    path: &Path,
+) -> String {
+    let head: String = output.chars().take(TOOL_RESULT_HEAD_CHARS).collect();
+    let tail_start = output_chars.saturating_sub(TOOL_RESULT_TAIL_CHARS);
+    let tail: String = output.chars().skip(tail_start).collect();
+    let omitted = output_chars.saturating_sub(TOOL_RESULT_HEAD_CHARS + TOOL_RESULT_TAIL_CHARS);
+
+    format!(
+        "{name}:\n{head}\n\n[tool output truncated: {output_chars} characters; {omitted} omitted]\n[full output saved to: {}; use the read tool on this path to inspect the complete output]\n\n{tail}",
+        path.display()
+    )
 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,9 +1,17 @@
 use std::path::PathBuf;
 
+use uuid::Uuid;
+
 use crate::session::Session;
 
 fn session_dir() -> PathBuf {
     dirs_path().join("sessions")
+}
+
+pub fn tool_output_dir(session_id: &str) -> PathBuf {
+    dirs_path()
+        .join("tool-outputs")
+        .join(safe_path_component(session_id))
 }
 
 fn home_fallback() -> PathBuf {
@@ -38,6 +46,42 @@ pub fn save_session(session: &Session) -> anyhow::Result<()> {
     let json = serde_json::to_string(session)?;
     std::fs::write(path, json)?;
     Ok(())
+}
+
+pub fn save_tool_output(
+    session_id: &str,
+    tool_name: &str,
+    output: &str,
+) -> anyhow::Result<PathBuf> {
+    let dir = tool_output_dir(session_id);
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!(
+        "{}-{}.txt",
+        Uuid::new_v4(),
+        safe_path_component(tool_name)
+    ));
+    std::fs::write(&path, output)?;
+    Ok(path)
+}
+
+fn safe_path_component(value: &str) -> String {
+    let safe: String = value
+        .chars()
+        .take(64)
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if safe.is_empty() {
+        "tool".to_string()
+    } else {
+        safe
+    }
 }
 
 pub fn delete_session(id: &str) -> anyhow::Result<()> {

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -3,7 +3,9 @@ use crate::session::Session;
 use crate::session::storage::{
     delete_session, find_sessions_by_prefix, load_suffix, save_session, suffix_path,
 };
+use crate::session::{TOOL_RESULT_HEAD_CHARS, TOOL_RESULT_SAVE_THRESHOLD, TOOL_RESULT_TAIL_CHARS};
 use std::env;
+use std::path::Path;
 use std::sync::Mutex;
 
 static STORAGE_LOCK: Mutex<()> = Mutex::new(());
@@ -105,6 +107,59 @@ fn save_session_preserves_tool_messages() {
     assert_eq!(found[0].messages[2].content, "read:\nfile contents");
     assert_eq!(found[0].messages[3].role, MessageRole::SubagentToolCall);
     drop(env);
+}
+
+#[test]
+fn long_tool_result_is_saved_and_truncated_in_session() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000);
+    let head = "H".repeat(TOOL_RESULT_HEAD_CHARS);
+    let omitted = "M"
+        .repeat(TOOL_RESULT_SAVE_THRESHOLD - TOOL_RESULT_HEAD_CHARS - TOOL_RESULT_TAIL_CHARS + 1);
+    let tail = "T".repeat(TOOL_RESULT_TAIL_CHARS);
+    let output = format!("{head}{omitted}{tail}");
+
+    let returned = s.add_tool_result("bash/unsafe", &output);
+
+    let content = s.messages[0].content.as_str();
+    assert_eq!(returned, content);
+    assert!(content.starts_with(&format!("bash/unsafe:\n{head}")));
+    assert!(content.ends_with(&tail));
+    assert!(content.contains("[tool output truncated: 12001 characters; 2001 omitted]"));
+    assert!(!content.contains(&"M".repeat(80)));
+
+    let path_line = content
+        .lines()
+        .find(|line| line.starts_with("[full output saved to: "))
+        .unwrap();
+    assert!(path_line.contains("use the read tool on this path"));
+    let path = path_line
+        .trim_start_matches("[full output saved to: ")
+        .split(';')
+        .next()
+        .unwrap();
+    assert!(Path::new(path).starts_with(&env.dir));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), output);
+    drop(env);
+}
+
+#[test]
+fn long_tool_result_save_failure_keeps_full_output() {
+    let lock = STORAGE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let path = std::env::temp_dir().join(format!("zs_data_file_{}", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    std::fs::write(&path, b"not a directory").unwrap();
+    unsafe { env::set_var("ZS_DATA_DIR", path.to_str().unwrap()) };
+
+    let mut s = Session::new("anthropic", "claude", 200000);
+    let output = "x".repeat(TOOL_RESULT_SAVE_THRESHOLD + 1);
+    s.add_tool_result("bash", &output);
+
+    let content = s.messages[0].content.as_str();
+    assert!(content.contains(&output));
+    assert!(content.contains("failed to save long tool output separately"));
+    let _ = std::fs::remove_file(path);
+    drop(lock);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Moves large tool outputs into sidecar artifact files while keeping references in the session.

## Context / Motivation

Large command/tool outputs can bloat session JSON and context. Sidecars preserve access to the full output without forcing the entire payload into the main session file.

## Key Changes

- Detects long tool outputs.
- Writes oversized outputs to sidecar files under session storage.
- Stores compact references in session history.
- Keeps shorter outputs inline for readability.

## Verification & Testing

Reviewers can run a command that produces a large output, save the session, and confirm the session references a sidecar file containing the full output.
