### PR TITLE
Add conversation forking

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -281,6 +281,56 @@ impl Session {
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
     }
 
+    pub fn title(&self) -> String {
+        if !self.name.is_empty() {
+            return self.name.to_string();
+        }
+        self.messages
+            .iter()
+            .rev()
+            .find(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(80).collect())
+            .unwrap_or_else(|| "untitled".to_string())
+    }
+
+    pub fn fork_title(&self, message_index: usize) -> String {
+        let target = self
+            .messages
+            .get(message_index)
+            .filter(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(48).collect::<String>())
+            .unwrap_or_else(|| self.title());
+        format!("Fork before: {target}")
+    }
+
+    pub fn fork_before_message(&self, message_index: usize) -> Self {
+        let mut fork = self.clone();
+        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
+        fork.id = CompactString::new(Uuid::new_v4().to_string());
+        fork.name = CompactString::new(self.fork_title(message_index));
+        fork.created_at = now.clone();
+        fork.updated_at = now;
+        fork.messages
+            .truncate(message_index.min(fork.messages.len()));
+        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
+        fork.total_input_tokens = 0;
+        fork.total_output_tokens = 0;
+        fork.total_cost = 0.0;
+        fork.input_token_cost = 0.0;
+        fork.output_token_cost = 0.0;
+        fork.reset_calibration();
+        if fork.messages.is_empty()
+            || fork
+                .compactions
+                .last()
+                .is_some_and(|c| c.first_kept_index > fork.messages.len())
+        {
+            fork.compactions.clear();
+        }
+        fork
+>>>>>>> 99a78dd (Add conversation forking)
+    }
+=======
     pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) {
         self.add_message(
             MessageRole::ToolCall,
@@ -297,6 +347,105 @@ impl Session {
             MessageRole::SubagentToolCall,
             &crate::ui::utils::format_tool_call_summary(name, args),
         );
+    }
+
+    pub fn title(&self) -> String {
+        if !self.name.is_empty() {
+            return self.name.to_string();
+        }
+        self.messages
+            .iter()
+            .rev()
+            .find(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(80).collect())
+            .unwrap_or_else(|| "untitled".to_string())
+    }
+
+    pub fn fork_title(&self, message_index: usize) -> String {
+        let target = self
+            .messages
+            .get(message_index)
+            .filter(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(48).collect::<String>())
+            .unwrap_or_else(|| self.title());
+        format!("Fork before: {target}")
+    }
+
+    pub fn fork_before_message(&self, message_index: usize) -> Self {
+        let mut fork = self.clone();
+        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
+        fork.id = CompactString::new(Uuid::new_v4().to_string());
+        fork.name = CompactString::new(self.fork_title(message_index));
+        fork.created_at = now.clone();
+        fork.updated_at = now;
+        fork.messages
+            .truncate(message_index.min(fork.messages.len()));
+        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
+        fork.total_input_tokens = 0;
+        fork.total_output_tokens = 0;
+        fork.total_cost = 0.0;
+        fork.input_token_cost = 0.0;
+        fork.output_token_cost = 0.0;
+        fork.reset_calibration();
+        if fork.messages.is_empty()
+            || fork
+                .compactions
+                .last()
+                .is_some_and(|c| c.first_kept_index > fork.messages.len())
+        {
+            fork.compactions.clear();
+        }
+        fork
+    }
+=======
+    pub fn title(&self) -> String {
+        if !self.name.is_empty() {
+            return self.name.to_string();
+        }
+        self.messages
+            .iter()
+            .rev()
+            .find(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(80).collect())
+            .unwrap_or_else(|| "untitled".to_string())
+    }
+
+    pub fn fork_title(&self, message_index: usize) -> String {
+        let target = self
+            .messages
+            .get(message_index)
+            .filter(|msg| msg.role == MessageRole::User)
+            .map(|msg| msg.content.chars().take(48).collect::<String>())
+            .unwrap_or_else(|| self.title());
+        format!("Fork before: {target}")
+    }
+
+    pub fn fork_before_message(&self, message_index: usize) -> Self {
+        let mut fork = self.clone();
+        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
+        fork.id = CompactString::new(Uuid::new_v4().to_string());
+        fork.name = CompactString::new(self.fork_title(message_index));
+        fork.created_at = now.clone();
+        fork.updated_at = now;
+        fork.messages
+            .truncate(message_index.min(fork.messages.len()));
+        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
+        fork.total_input_tokens = 0;
+        fork.total_output_tokens = 0;
+        fork.total_cost = 0.0;
+        fork.input_token_cost = 0.0;
+        fork.output_token_cost = 0.0;
+        fork.reset_calibration();
+        if fork.messages.is_empty()
+            || fork
+                .compactions
+                .last()
+                .is_some_and(|c| c.first_kept_index > fork.messages.len())
+        {
+            fork.compactions.clear();
+        }
+        fork
+>>>>>>> 99a78dd (Add conversation forking)
     }
 
     #[cfg(feature = "multimodal")]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -281,56 +281,6 @@ impl Session {
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
     }
 
-    pub fn title(&self) -> String {
-        if !self.name.is_empty() {
-            return self.name.to_string();
-        }
-        self.messages
-            .iter()
-            .rev()
-            .find(|msg| msg.role == MessageRole::User)
-            .map(|msg| msg.content.chars().take(80).collect())
-            .unwrap_or_else(|| "untitled".to_string())
-    }
-
-    pub fn fork_title(&self, message_index: usize) -> String {
-        let target = self
-            .messages
-            .get(message_index)
-            .filter(|msg| msg.role == MessageRole::User)
-            .map(|msg| msg.content.chars().take(48).collect::<String>())
-            .unwrap_or_else(|| self.title());
-        format!("Fork before: {target}")
-    }
-
-    pub fn fork_before_message(&self, message_index: usize) -> Self {
-        let mut fork = self.clone();
-        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
-        fork.id = CompactString::new(Uuid::new_v4().to_string());
-        fork.name = CompactString::new(self.fork_title(message_index));
-        fork.created_at = now.clone();
-        fork.updated_at = now;
-        fork.messages
-            .truncate(message_index.min(fork.messages.len()));
-        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
-        fork.total_input_tokens = 0;
-        fork.total_output_tokens = 0;
-        fork.total_cost = 0.0;
-        fork.input_token_cost = 0.0;
-        fork.output_token_cost = 0.0;
-        fork.reset_calibration();
-        if fork.messages.is_empty()
-            || fork
-                .compactions
-                .last()
-                .is_some_and(|c| c.first_kept_index > fork.messages.len())
-        {
-            fork.compactions.clear();
-        }
-        fork
->>>>>>> 99a78dd (Add conversation forking)
-    }
-=======
     pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) {
         self.add_message(
             MessageRole::ToolCall,
@@ -396,56 +346,6 @@ impl Session {
             fork.compactions.clear();
         }
         fork
-    }
-=======
-    pub fn title(&self) -> String {
-        if !self.name.is_empty() {
-            return self.name.to_string();
-        }
-        self.messages
-            .iter()
-            .rev()
-            .find(|msg| msg.role == MessageRole::User)
-            .map(|msg| msg.content.chars().take(80).collect())
-            .unwrap_or_else(|| "untitled".to_string())
-    }
-
-    pub fn fork_title(&self, message_index: usize) -> String {
-        let target = self
-            .messages
-            .get(message_index)
-            .filter(|msg| msg.role == MessageRole::User)
-            .map(|msg| msg.content.chars().take(48).collect::<String>())
-            .unwrap_or_else(|| self.title());
-        format!("Fork before: {target}")
-    }
-
-    pub fn fork_before_message(&self, message_index: usize) -> Self {
-        let mut fork = self.clone();
-        let now = CompactString::new(chrono::Utc::now().to_rfc3339());
-        fork.id = CompactString::new(Uuid::new_v4().to_string());
-        fork.name = CompactString::new(self.fork_title(message_index));
-        fork.created_at = now.clone();
-        fork.updated_at = now;
-        fork.messages
-            .truncate(message_index.min(fork.messages.len()));
-        fork.total_estimated_tokens = fork.messages.iter().map(|m| m.estimated_tokens).sum();
-        fork.total_input_tokens = 0;
-        fork.total_output_tokens = 0;
-        fork.total_cost = 0.0;
-        fork.input_token_cost = 0.0;
-        fork.output_token_cost = 0.0;
-        fork.reset_calibration();
-        if fork.messages.is_empty()
-            || fork
-                .compactions
-                .last()
-                .is_some_and(|c| c.first_kept_index > fork.messages.len())
-        {
-            fork.compactions.clear();
-        }
-        fork
->>>>>>> 99a78dd (Add conversation forking)
     }
 
     #[cfg(feature = "multimodal")]

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -212,6 +212,51 @@ fn add_message_updates_updated_at() {
 }
 
 #[test]
+fn fork_before_message_truncates_and_resets_totals() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "first");
+    s.add_message(MessageRole::Assistant, "reply");
+    s.add_message(MessageRole::User, "second");
+    s.total_input_tokens = 10;
+    s.total_output_tokens = 20;
+    s.total_cost = 0.5;
+    s.set_calibration(100, 50);
+
+    let fork = s.fork_before_message(2);
+
+    assert_ne!(fork.id, s.id);
+    assert_eq!(fork.messages.len(), 2);
+    assert_eq!(fork.messages[0].content, "first");
+    assert_eq!(fork.messages[1].content, "reply");
+    assert_eq!(
+        fork.total_estimated_tokens,
+        fork.messages
+            .iter()
+            .map(|m| m.estimated_tokens)
+            .sum::<u64>()
+    );
+    assert_eq!(fork.total_input_tokens, 0);
+    assert_eq!(fork.total_output_tokens, 0);
+    assert_eq!(fork.total_cost, 0.0);
+    assert_eq!(fork.calibrated_tokens, 0);
+    assert_eq!(fork.name, "Fork before: second");
+    assert_eq!(fork.title(), "Fork before: second");
+    assert_eq!(s.messages.len(), 3);
+}
+
+#[test]
+fn session_title_uses_latest_user_message_or_name() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    assert_eq!(s.title(), "untitled");
+    s.add_message(MessageRole::User, "first");
+    s.add_message(MessageRole::Assistant, "reply");
+    s.add_message(MessageRole::User, "second");
+    assert_eq!(s.title(), "second");
+    s.name = "named".into();
+    assert_eq!(s.title(), "named");
+}
+
+#[test]
 fn needs_compaction_when_over_threshold() {
     let mut s = Session::new("openai", "gpt-4", 1000);
     s.add_message(MessageRole::User, &"x".repeat(900 * 4)); // ~900 tokens

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -58,7 +58,7 @@ pub fn render_session(
         )?;
         renderer.write_line("", Color::White)?;
     }
-    for msg in &session.messages {
+    for (msg_idx, msg) in session.messages.iter().enumerate() {
         let (prefix, _c) = match msg.role {
             MessageRole::User => (">", Color::Green),
             MessageRole::Assistant => ("<", Color::White),
@@ -75,15 +75,31 @@ pub fn render_session(
             if !styled.is_empty() {
                 styled[0].text = CompactString::from(format!("{} {}", prefix, styled[0].text));
             }
-            for entry in styled {
-                renderer.write_line(&entry.text, entry.color)?;
+            let source = Some(crate::ui::renderer::LineSource::SessionMessage {
+                index: msg_idx,
+                role: msg.role,
+            });
+            for mut entry in styled {
+                entry.source = source;
+                renderer.write_line_with_source(&entry.text, entry.color, entry.source)?;
             }
         } else {
+            let source = Some(crate::ui::renderer::LineSource::SessionMessage {
+                index: msg_idx,
+                role: msg.role,
+            });
             for line in msg.content.lines() {
-                renderer.write_line(&format!("{} {}", prefix, line), _c)?;
+                renderer.write_line_with_source(&format!("{} {}", prefix, line), _c, source)?;
             }
         }
-        renderer.write_line("", Color::White)?;
+        renderer.write_line_with_source(
+            "",
+            Color::White,
+            Some(crate::ui::renderer::LineSource::SessionMessage {
+                index: msg_idx,
+                role: msg.role,
+            }),
+        )?;
     }
     if session.messages.is_empty() {
         let cwd = std::env::current_dir().ok();

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -30,6 +30,7 @@ pub struct InputEditor {
     quick_model_names: Vec<String>,
     live_model_names: Vec<String>,
     provider_names: Vec<String>,
+    fork_targets: Vec<String>,
     editor: Option<String>,
     kill_ring: Vec<CompactString>,
     yank_pos: Option<usize>,
@@ -51,6 +52,7 @@ impl InputEditor {
             quick_model_names: Vec::new(),
             live_model_names: Vec::new(),
             provider_names: Vec::new(),
+            fork_targets: Vec::new(),
             editor: None,
             kill_ring: Vec::with_capacity(MAX_KILL_RING),
             yank_pos: None,
@@ -88,6 +90,10 @@ impl InputEditor {
 
     pub fn set_provider_names(&mut self, names: Vec<String>) {
         self.provider_names = names;
+    }
+
+    pub fn set_fork_targets(&mut self, targets: Vec<String>) {
+        self.fork_targets = targets;
     }
 
     pub fn set_editor(&mut self, editor: String) {
@@ -152,6 +158,16 @@ impl InputEditor {
         }
         picker.activate();
         self.picker = Some(Picker::Prefixed(picker, "/provider "));
+    }
+
+    pub fn start_fork_picker(&mut self) {
+        let mut picker = ListPicker::new();
+        picker.set_monochrome(self.monochrome);
+        if !self.fork_targets.is_empty() {
+            picker.set_items(self.fork_targets.clone());
+        }
+        picker.activate();
+        self.picker = Some(Picker::Prefixed(picker, "/fork "));
     }
 
     pub fn start_prompt_picker(&mut self) {
@@ -518,6 +534,20 @@ impl InputEditor {
                             self.start_provider_picker();
                             if let Some(Picker::Prefixed(ref mut pp, _)) = self.picker {
                                 pp.char_input(c);
+                            }
+                        }
+                    }
+                }
+                if (self.picker.is_none() || !self.picker.as_ref().is_some_and(|p| p.active()))
+                    && self.buffer.starts_with("/fork ")
+                {
+                    let after_prefix: String = self.buffer.chars().skip("/fork ".len()).collect();
+                    if !after_prefix.is_empty() && c != ' ' {
+                        let query_len = after_prefix.len();
+                        if query_len == 1 {
+                            self.start_fork_picker();
+                            if let Some(Picker::Prefixed(ref mut fp, _)) = self.picker {
+                                fp.char_input(c);
                             }
                         }
                     }

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -63,6 +63,7 @@ impl InputEditor {
                     quick_model_names: &self.quick_model_names,
                     live_model_names: &self.live_model_names,
                     provider_names: &self.provider_names,
+                    fork_targets: &self.fork_targets,
                 };
                 let (handled, replacement) =
                     handlers::handle_command_key(&mut self.buffer, &mut self.cursor, &ctx, p, key);

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -93,10 +93,15 @@ fn flush_acc(acc: &str, color: Color, max_width: usize, out: &mut Vec<LineEntry>
             out.push(LineEntry {
                 text: CompactString::new(""),
                 color,
+                source: None,
             });
         } else {
             for chunk in word_wrap(trimmed, max_width) {
-                out.push(LineEntry { text: chunk, color });
+                out.push(LineEntry {
+                    text: chunk,
+                    color,
+                    source: None,
+                });
             }
         }
     }
@@ -210,6 +215,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     result.push(LineEntry {
                         text: CompactString::new(""),
                         color: Color::White,
+                        source: None,
                     });
                 }
                 TagEnd::CodeBlock => {
@@ -219,11 +225,13 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                             result.push(LineEntry {
                                 text: CompactString::new(""),
                                 color: Color::DarkYellow,
+                                source: None,
                             });
                         } else {
                             result.push(LineEntry {
                                 text: CompactString::from(trimmed),
                                 color: Color::DarkYellow,
+                                source: None,
                             });
                         }
                     }
@@ -232,6 +240,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     result.push(LineEntry {
                         text: CompactString::new(""),
                         color: Color::White,
+                        source: None,
                     });
                 }
                 TagEnd::BlockQuote(_) => {
@@ -242,6 +251,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                             quoted.push(LineEntry {
                                 text: CompactString::new(""),
                                 color: Color::DarkGrey,
+                                source: None,
                             });
                         } else {
                             let prefixed = format!("│ {}", trimmed);
@@ -249,6 +259,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                                 quoted.push(LineEntry {
                                     text: chunk,
                                     color: Color::DarkGrey,
+                                    source: None,
                                 });
                             }
                         }
@@ -259,6 +270,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     result.push(LineEntry {
                         text: CompactString::new(""),
                         color: Color::White,
+                        source: None,
                     });
                 }
                 TagEnd::Item => {
@@ -280,16 +292,25 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                             item_lines.push(LineEntry {
                                 text: CompactString::new(""),
                                 color,
+                                source: None,
                             });
                         } else if first {
                             let prefixed = format!("{}{}", bullet, trimmed);
                             for chunk in word_wrap(&prefixed, max_width) {
-                                item_lines.push(LineEntry { text: chunk, color });
+                                item_lines.push(LineEntry {
+                                    text: chunk,
+                                    color,
+                                    source: None,
+                                });
                             }
                             first = false;
                         } else {
                             for chunk in word_wrap(trimmed, max_width) {
-                                item_lines.push(LineEntry { text: chunk, color });
+                                item_lines.push(LineEntry {
+                                    text: chunk,
+                                    color,
+                                    source: None,
+                                });
                             }
                         }
                     }
@@ -302,6 +323,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     result.push(LineEntry {
                         text: CompactString::new(""),
                         color: Color::White,
+                        source: None,
                     });
                 }
                 TagEnd::Link => {
@@ -315,6 +337,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                                 result.push(LineEntry {
                                     text: chunk,
                                     color: Color::DarkGrey,
+                                    source: None,
                                 });
                             }
                             acc.clear();
@@ -329,6 +352,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     result.push(LineEntry {
                         text: CompactString::new(""),
                         color: Color::White,
+                        source: None,
                     });
                 }
                 TagEnd::TableHead => {
@@ -382,10 +406,12 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 result.push(LineEntry {
                     text: CompactString::from(rule),
                     color: Color::DarkGrey,
+                    source: None,
                 });
                 result.push(LineEntry {
                     text: CompactString::new(""),
                     color: Color::White,
+                    source: None,
                 });
             }
             Event::Html(t) => {
@@ -515,6 +541,7 @@ fn push_table_line(text: &str, color: Color, out: &mut Vec<LineEntry>) {
     out.push(LineEntry {
         text: CompactString::from(text),
         color,
+        source: None,
     });
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1437,6 +1437,7 @@ pub async fn run_interactive(
                             continue;
                         }
 
+                        input.set_fork_targets(crate::ui::slash::session::fork_target_items(session));
                         if let Some(mut text) = input.handle_key(key) {
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {

--- a/src/ui/pickers/handlers.rs
+++ b/src/ui/pickers/handlers.rs
@@ -114,6 +114,7 @@ pub struct CommandPickerCtx<'a> {
     pub quick_model_names: &'a [String],
     pub live_model_names: &'a [String],
     pub provider_names: &'a [String],
+    pub fork_targets: &'a [String],
 }
 
 pub fn handle_command_key(
@@ -260,6 +261,13 @@ pub fn handle_command_key(
                     pp.set_items(ctx.provider_names.to_vec());
                     pp.activate();
                     return (true, Some(Picker::Prefixed(pp, "/provider ")));
+                }
+                if selected == "/fork" && !ctx.fork_targets.is_empty() {
+                    picker.deactivate();
+                    let mut fp = ListPicker::new();
+                    fp.set_items(ctx.fork_targets.to_vec());
+                    fp.activate();
+                    return (true, Some(Picker::Prefixed(fp, "/fork ")));
                 }
                 if selected == "/queue" {
                     picker.deactivate();

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -15,6 +15,7 @@ const BASE_COMMANDS: &[&str] = &[
     "/drop-all",
     "/editsys",
     "/exit",
+    "/fork",
     "/help",
     "/history",
     "/init",

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -9,14 +9,32 @@ use crossterm::style::{
 use crossterm::terminal::{Clear, ClearType, ScrollUp};
 use smallvec::{SmallVec, smallvec};
 
+use crate::session::MessageRole;
+
 use super::markdown::word_wrap;
 use super::statusline::StatusSpan;
 use super::utils::{char_display_width, display_width, resolve_color};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineSource {
+    SessionMessage { index: usize, role: MessageRole },
+}
 
 #[derive(Clone)]
 pub struct LineEntry {
     pub text: CompactString,
     pub color: Color,
+    pub source: Option<LineSource>,
+}
+
+impl LineEntry {
+    pub fn new(text: impl Into<CompactString>, color: Color) -> Self {
+        Self {
+            text: text.into(),
+            color,
+            source: None,
+        }
+    }
 }
 
 pub struct PermissionPrompt {
@@ -35,6 +53,7 @@ pub struct Renderer {
     buffer: Vec<LineEntry>,
     partial: CompactString,
     partial_color: Color,
+    partial_source: Option<LineSource>,
     scroll_offset: usize,
     input_scroll_offset: usize,
     input_vscroll_offset: usize,
@@ -75,6 +94,7 @@ impl Renderer {
             buffer: Vec::new(),
             partial: CompactString::new(""),
             partial_color: Color::White,
+            partial_source: None,
             scroll_offset: 0,
             input_scroll_offset: 0,
             input_vscroll_offset: 0,
@@ -276,12 +296,35 @@ impl Renderer {
         self.selection_end = None;
     }
 
-    pub fn selected_text(&self) -> Option<String> {
-        let (start, end) = match (self.selection_start, self.selection_end) {
-            (Some(s), Some(e)) if s <= e => (s, e),
-            (Some(s), Some(e)) => (e, s),
-            _ => return None,
+    fn selected_range(&self) -> Option<(usize, usize)> {
+        match (self.selection_start, self.selection_end) {
+            (Some(s), Some(e)) if s <= e => Some((s, e)),
+            (Some(s), Some(e)) => Some((e, s)),
+            _ => None,
+        }
+    }
+
+    pub fn selected_session_message_indices(&self) -> Vec<usize> {
+        let Some((start, end)) = self.selected_range() else {
+            return Vec::new();
         };
+        let mut indices = Vec::new();
+        for i in start..=end {
+            if let Some(LineEntry {
+                source: Some(LineSource::SessionMessage { index, .. }),
+                ..
+            }) = self.buffer.get(i)
+            {
+                if !indices.contains(index) {
+                    indices.push(*index);
+                }
+            }
+        }
+        indices
+    }
+
+    pub fn selected_text(&self) -> Option<String> {
+        let (start, end) = self.selected_range()?;
         let mut result = String::new();
         for i in start..=end {
             if let Some(entry) = self.buffer.get(i) {
@@ -306,13 +349,16 @@ impl Renderer {
         if !self.partial.is_empty() {
             let max_width = self.max_line_width();
             let c = self.partial_color;
+            let source = self.partial_source;
             for chunk in self.wrap_line(&self.partial, max_width) {
                 self.buffer.push(LineEntry {
                     text: chunk,
                     color: c,
+                    source,
                 });
             }
             self.partial.clear();
+            self.partial_source = None;
         }
     }
 
@@ -585,7 +631,12 @@ impl Renderer {
         }
     }
 
-    pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
+    pub fn write_line_with_source(
+        &mut self,
+        text: &str,
+        color: Color,
+        source: Option<LineSource>,
+    ) -> io::Result<()> {
         self.commit_partial();
         let max_width = self.max_line_width();
         for segment in text.split('\n') {
@@ -594,6 +645,7 @@ impl Renderer {
                 self.buffer.push(LineEntry {
                     text: chunk.clone(),
                     color,
+                    source,
                 });
                 if self.scroll_offset == 0 {
                     self.ensure_room();
@@ -619,6 +671,10 @@ impl Renderer {
         Ok(())
     }
 
+    pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
+        self.write_line_with_source(text, color, None)
+    }
+
     pub fn write(&mut self, text: &str, color: Color) -> io::Result<()> {
         if text.is_empty() {
             return Ok(());
@@ -642,6 +698,7 @@ impl Renderer {
                     self.buffer.push(LineEntry {
                         text: CompactString::new(""),
                         color,
+                        source: None,
                     });
                 }
                 if self.scroll_offset == 0 {
@@ -702,6 +759,7 @@ impl Renderer {
                     }
                     let chunk: String = chars[idx..end].iter().collect();
                     self.partial_color = color;
+                    self.partial_source = None;
                     self.partial.push_str(&chunk);
                     if self.scroll_offset == 0 {
                         self.ensure_room();

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -27,16 +27,6 @@ pub struct LineEntry {
     pub source: Option<LineSource>,
 }
 
-impl LineEntry {
-    pub fn new(text: impl Into<CompactString>, color: Color) -> Self {
-        Self {
-            text: text.into(),
-            color,
-            source: None,
-        }
-    }
-}
-
 pub struct PermissionPrompt {
     pub tool: CompactString,
     pub options: CompactString,

--- a/src/ui/slash/help.rs
+++ b/src/ui/slash/help.rs
@@ -83,6 +83,10 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
     }
     write_result(ctx.renderer, "  /clear [/new]          clear screen");
     write_result(ctx.renderer, "  /undo                  undo last exchange");
+    write_result(
+        ctx.renderer,
+        "  /fork [idx]            fork before selected/user message",
+    );
     write_result(ctx.renderer, "  /retry                 retry last prompt");
     write_result(
         ctx.renderer,

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -329,9 +329,8 @@ pub async fn handle_slash(
         "/reasoning" | "/thinking" | "/mode" | "/toggle" | "/mcp" | "/editsys" | "/advisor" => {
             settings::handle(&parts, &mut ctx).await
         }
-        "/sessions" | "/clear" | "/new" | "/undo" | "/retry" | "/quit" | "/exit" | "/history" => {
-            session::handle(&parts, &mut ctx).await
-        }
+        "/sessions" | "/clear" | "/new" | "/undo" | "/retry" | "/quit" | "/exit" | "/history"
+        | "/fork" => session::handle(&parts, &mut ctx).await,
         "/help" => {
             help::handle(&parts, &mut ctx);
             Ok(())

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod init;
 mod memory;
 mod providers;
 pub(crate) mod review;
-mod session;
+pub(crate) mod session;
 pub(crate) mod settings;
 
 pub(crate) use providers::warm_model_cache;

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -134,6 +134,20 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
     Ok(())
 }
 
+pub fn fork_target_items(session: &crate::session::Session) -> Vec<String> {
+    session
+        .messages
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, msg)| {
+            (msg.role == crate::session::MessageRole::User).then(|| {
+                let preview: String = msg.content.chars().take(80).collect();
+                format!("{}  {}", idx, preview.replace('\n', " "))
+            })
+        })
+        .collect()
+}
+
 async fn handle_fork(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     let target = if parts.len() >= 2 {
         match parts[1].parse::<usize>() {
@@ -164,11 +178,8 @@ async fn handle_fork(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<(
             ctx.renderer,
             "usage: select a prior user message, then /fork; or /fork <index>",
         );
-        for (idx, msg) in ctx.session.messages.iter().enumerate() {
-            if msg.role == crate::session::MessageRole::User {
-                let preview: String = msg.content.chars().take(60).collect();
-                write_result(ctx.renderer, format!("  {}  {}", idx, preview));
-            }
+        for item in fork_target_items(ctx.session) {
+            write_result(ctx.renderer, format!("  {item}"));
         }
         return Ok(());
     };
@@ -285,4 +296,24 @@ async fn handle_history(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fork_target_items;
+    use crate::session::{MessageRole, Session};
+
+    #[test]
+    fn fork_target_items_include_only_user_messages() {
+        let mut session = Session::new("openai", "gpt-4", 128_000);
+        session.add_message(MessageRole::System, "system");
+        session.add_message(MessageRole::User, "first\nline");
+        session.add_message(MessageRole::Assistant, "answer");
+        session.add_message(MessageRole::User, "second");
+
+        assert_eq!(
+            fork_target_items(&session),
+            vec!["1  first line".to_string(), "3  second".to_string()]
+        );
+    }
 }

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -11,6 +11,7 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         "/retry" => handle_retry(ctx).await,
         "/quit" | "/exit" => handle_quit(ctx).await,
         "/history" => handle_history(ctx).await,
+        "/fork" => handle_fork(parts, ctx).await,
         _ => Ok(()),
     }
 }
@@ -130,6 +131,63 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
             }
         }
     }
+    Ok(())
+}
+
+async fn handle_fork(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    let target = if parts.len() >= 2 {
+        match parts[1].parse::<usize>() {
+            Ok(idx) if idx <= ctx.session.messages.len() => Some(idx),
+            Ok(_) => {
+                write_error(ctx.renderer, "message index out of range");
+                return Ok(());
+            }
+            Err(_) => {
+                write_error(ctx.renderer, "usage: /fork <message-index>");
+                return Ok(());
+            }
+        }
+    } else {
+        ctx.renderer
+            .selected_session_message_indices()
+            .into_iter()
+            .find(|&idx| {
+                ctx.session
+                    .messages
+                    .get(idx)
+                    .is_some_and(|m| m.role == crate::session::MessageRole::User)
+            })
+    };
+
+    let Some(message_index) = target else {
+        write_ok(
+            ctx.renderer,
+            "usage: select a prior user message, then /fork; or /fork <index>",
+        );
+        for (idx, msg) in ctx.session.messages.iter().enumerate() {
+            if msg.role == crate::session::MessageRole::User {
+                let preview: String = msg.content.chars().take(60).collect();
+                write_result(ctx.renderer, format!("  {}  {}", idx, preview));
+            }
+        }
+        return Ok(());
+    };
+
+    let old_id = ctx.session.id.clone();
+    *ctx.session = ctx.session.fork_before_message(message_index);
+    if !ctx.cli.no_session {
+        crate::session::storage::save_session(ctx.session)?;
+    }
+    render_session(ctx.renderer, ctx.session, ctx.cli, ctx.cfg, ctx.context)?;
+    write_ok(
+        ctx.renderer,
+        format!(
+            "forked {} -> {} before message {}",
+            &old_id[..8],
+            &ctx.session.id[..8],
+            message_index
+        ),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Adds conversation forking so users can branch a new session from an earlier point in an existing conversation.

## Context / Motivation

Forking is useful when a user wants to explore an alternate direction without losing or mutating the original session.

## Key Changes

- Adds session helpers for deriving fork titles and truncating messages at a fork point.
- Adds `/fork` handling and a TUI picker over prior user turns.
- Resets cost/token/calibration state for the new fork while preserving the selected prior context.

## Verification & Testing

Reviewers can create a multi-turn session, use `/fork`, select a prior user turn, and confirm the new session contains only the expected prior messages while the original session is unchanged.
