### PR TITLE
Flush atomic temp files before rename

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -60,6 +60,7 @@ pub async fn atomic_write(
     let write_result = async {
         let mut f = tokio::fs::File::create(&tmp_path).await?;
         f.write_all(contents.as_ref()).await?;
+        f.flush().await?;
         Ok::<(), std::io::Error>(())
     }
     .await;


### PR DESCRIPTION
## Summary

Flushes atomic-write temp files before renaming them into place.

## Context / Motivation

CI has been intermittently observing torn reads in the atomic write test. The temp file was written and then renamed after the async file handle scope ended, but the buffered writes were not explicitly flushed first.

## Key Changes

- Calls `flush()` after writing the temp file and before `rename`.

## Verification & Testing

- `cargo test no_torn_reads_during_rewrites -- --nocapture`
- `cargo test test_hash_range_edit -- --nocapture`
