### PR TITLE
feat: /rewind to an earlier turn and a reversible /undo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8759,7 +8759,7 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerostack"
-version = "1.5.1-rc1"
+version = "1.5.1-rc2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,6 +29,19 @@ pub struct SessionMessage {
     pub estimated_tokens: u64,
 }
 
+/// A single-step restore point captured before a conversation rewind, so the
+/// destructive truncation can be undone with `/unrewind`. Holds the full
+/// message list and the calibration/estimate fields that `truncate_to` mutates,
+/// which is everything needed to put the session back exactly as it was. Not
+/// persisted: a rewind is only undoable within the session that made it.
+#[derive(Debug, Clone)]
+pub struct RewindUndo {
+    messages: Vec<SessionMessage>,
+    total_estimated_tokens: u64,
+    calibrated_tokens: u64,
+    calibrated_msg_count: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Compaction {
     pub summary: CompactString,
@@ -100,6 +113,10 @@ pub struct Session {
     /// persisted.
     #[serde(skip)]
     pub overhead_tokens: u64,
+    /// Restore point for the most recent `/unrewind`-able rewind, captured by
+    /// [`rewind_to`](Self::rewind_to). Runtime only, not persisted.
+    #[serde(skip)]
+    pub rewind_undo: Option<RewindUndo>,
 }
 
 /// Working-tree summary parsed from `git status --porcelain=v2 --branch`.
@@ -177,6 +194,7 @@ impl Session {
             git_status: None,
             reasoning_enabled: false,
             overhead_tokens: 0,
+            rewind_undo: None,
         }
     }
 
@@ -285,6 +303,9 @@ impl Session {
         });
         self.total_estimated_tokens = self.total_estimated_tokens.saturating_add(tokens);
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
+        // The conversation has moved forward, so the last rewind's restore point
+        // no longer lines up — drop it so /redo can't splice in a stale tail.
+        self.rewind_undo = None;
     }
 
     pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) {
@@ -395,6 +416,47 @@ impl Session {
         }
         self.messages.truncate(new_len);
         self.total_estimated_tokens = self.messages.iter().map(|m| m.estimated_tokens).sum();
+    }
+
+    /// Rewind the conversation to `new_len` messages, capturing a single-step
+    /// restore point first so the cut can be undone with [`redo`](Self::redo).
+    ///
+    /// This is the shared primitive behind both `/undo` (rewind by one turn) and
+    /// the double-Esc rewind picker (rewind to a chosen earlier point): the only
+    /// difference between them is which `new_len` they pass. Returns the number
+    /// of messages removed (0 if `new_len` is already at or past the end, in
+    /// which case no restore point is recorded).
+    pub fn rewind_to(&mut self, new_len: usize) -> usize {
+        if new_len >= self.messages.len() {
+            return 0;
+        }
+        let removed = self.messages.len() - new_len;
+        self.rewind_undo = Some(RewindUndo {
+            messages: self.messages.clone(),
+            total_estimated_tokens: self.total_estimated_tokens,
+            calibrated_tokens: self.calibrated_tokens,
+            calibrated_msg_count: self.calibrated_msg_count,
+        });
+        self.truncate_to(new_len);
+        removed
+    }
+
+    /// Restore the messages removed by the most recent [`rewind_to`](Self::rewind_to)
+    /// (i.e. the last `/undo` or rewind). Returns false when there is nothing to
+    /// restore. The restore point is consumed, and is also invalidated as soon
+    /// as the conversation moves forward again (see [`add_message`](Self::add_message)),
+    /// so `/redo` only ever reaches back to the cut it directly reverses.
+    pub fn redo(&mut self) -> bool {
+        match self.rewind_undo.take() {
+            Some(u) => {
+                self.messages = u.messages;
+                self.total_estimated_tokens = u.total_estimated_tokens;
+                self.calibrated_tokens = u.calibrated_tokens;
+                self.calibrated_msg_count = u.calibrated_msg_count;
+                true
+            }
+            None => false,
+        }
     }
 
     /// True while the context figure is still an estimate — no provider usage

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -339,3 +339,70 @@ fn parse_porcelain_counts_changes_and_sync() {
     assert_eq!(g.behind, 1);
     assert!(g.is_dirty());
 }
+
+#[test]
+fn rewind_to_truncates_and_records_restore_point() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "first");
+    s.add_message(MessageRole::Assistant, "reply");
+    s.add_message(MessageRole::User, "second");
+    s.add_message(MessageRole::Assistant, "reply2");
+
+    let removed = s.rewind_to(2);
+
+    assert_eq!(removed, 2);
+    assert_eq!(s.messages.len(), 2);
+    assert_eq!(s.messages[0].content, "first");
+    assert_eq!(s.messages[1].content, "reply");
+    assert!(s.rewind_undo.is_some());
+    assert_eq!(
+        s.total_estimated_tokens,
+        s.messages.iter().map(|m| m.estimated_tokens).sum::<u64>()
+    );
+}
+
+#[test]
+fn rewind_to_at_or_past_end_is_a_noop() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "only");
+
+    assert_eq!(s.rewind_to(1), 0);
+    assert_eq!(s.rewind_to(5), 0);
+    assert_eq!(s.messages.len(), 1);
+    assert!(s.rewind_undo.is_none());
+}
+
+#[test]
+fn redo_restores_the_messages_a_rewind_removed() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "first");
+    s.add_message(MessageRole::Assistant, "reply");
+    s.add_message(MessageRole::User, "second");
+    let before: Vec<_> = s.messages.iter().map(|m| m.content.clone()).collect();
+    let est_before = s.total_estimated_tokens;
+
+    s.rewind_to(1);
+    assert_eq!(s.messages.len(), 1);
+
+    assert!(s.redo());
+    let after: Vec<_> = s.messages.iter().map(|m| m.content.clone()).collect();
+    assert_eq!(before, after);
+    assert_eq!(s.total_estimated_tokens, est_before);
+    // The restore point is consumed, so a second redo finds nothing.
+    assert!(!s.redo());
+}
+
+#[test]
+fn adding_a_message_invalidates_the_redo_point() {
+    let mut s = Session::new("openai", "gpt-4", 128000);
+    s.add_message(MessageRole::User, "first");
+    s.add_message(MessageRole::Assistant, "reply");
+    s.add_message(MessageRole::User, "second");
+
+    s.rewind_to(1);
+    assert!(s.rewind_undo.is_some());
+    // Moving the conversation forward must drop the stale restore point.
+    s.add_message(MessageRole::User, "a fresh direction");
+    assert!(s.rewind_undo.is_none());
+    assert!(!s.redo());
+}

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use crate::ui::pickers::file::FilePicker;
 use crate::ui::pickers::list::ListPicker;
 use crate::ui::pickers::models::ModelsPicker;
+use crate::ui::pickers::rewind::{RewindOutcome, RewindPicker};
 
 const MAX_KILL_RING: usize = 30;
 
@@ -73,6 +74,19 @@ impl InputEditor {
     pub fn clear_buffer(&mut self) {
         self.buffer.clear();
         self.cursor = 0;
+        self.history_pos = None;
+        self.draft = None;
+        self.yank_pos = None;
+    }
+
+    /// Replace the input buffer with `text`, cursor at the end. Used by the
+    /// rewind flow to drop the chosen user turn back into the box for editing.
+    pub fn load_text(&mut self, text: &str) {
+        self.buffer = CompactString::new(text);
+        // `cursor` is a byte offset into `buffer` (sliced as `buffer[..cursor]`
+        // and advanced by `len_utf8()` elsewhere), so end-of-buffer is the byte
+        // length, not the char count — they differ for multi-byte (e.g. CJK) text.
+        self.cursor = self.buffer.len();
         self.history_pos = None;
         self.draft = None;
         self.yank_pos = None;
@@ -152,6 +166,31 @@ impl InputEditor {
         }
         picker.activate();
         self.picker = Some(Picker::Prefixed(picker, "/provider "));
+    }
+
+    /// Open the double-Esc rewind picker over the given `(message_index,
+    /// preview)` user turns. No-op when there is nothing to rewind to.
+    pub fn start_rewind_picker(&mut self, targets: Vec<(usize, String)>) {
+        if targets.is_empty() {
+            return;
+        }
+        let mut picker = RewindPicker::new(targets);
+        picker.set_monochrome(self.monochrome);
+        picker.activate();
+        self.picker = Some(Picker::Rewind(picker));
+    }
+
+    /// Take the rewind picker's resolved outcome, if it has one. Also clears the
+    /// finished picker so the input box returns to normal.
+    pub fn take_rewind_outcome(&mut self) -> Option<RewindOutcome> {
+        let outcome = match self.picker.as_mut() {
+            Some(Picker::Rewind(p)) => p.take_outcome(),
+            _ => None,
+        };
+        if outcome.is_some() {
+            self.picker = None;
+        }
+        outcome
     }
 
     pub fn start_prompt_picker(&mut self) {

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -4,12 +4,14 @@ use crate::ui::pickers::file::FilePicker;
 use crate::ui::pickers::handlers;
 use crate::ui::pickers::list::ListPicker;
 use crate::ui::pickers::models::ModelsPicker;
+use crate::ui::pickers::rewind::RewindPicker;
 
 pub enum Picker {
     File(FilePicker),
     Command(ListPicker),
     Prefixed(ListPicker, &'static str),
     Models(ModelsPicker),
+    Rewind(RewindPicker),
 }
 
 impl Picker {
@@ -19,6 +21,7 @@ impl Picker {
             Picker::Command(p) => p.active,
             Picker::Prefixed(p, _) => p.active,
             Picker::Models(p) => p.active,
+            Picker::Rewind(p) => p.active(),
         }
     }
 
@@ -28,6 +31,7 @@ impl Picker {
             Picker::Command(p) => p.set_monochrome(monochrome),
             Picker::Prefixed(p, _) => p.set_monochrome(monochrome),
             Picker::Models(p) => p.set_monochrome(monochrome),
+            Picker::Rewind(p) => p.set_monochrome(monochrome),
         }
     }
 
@@ -44,6 +48,7 @@ impl Picker {
                 p.draw(msg)
             }
             Picker::Models(p) => p.draw(),
+            Picker::Rewind(p) => p.draw(),
         }
     }
 }
@@ -77,6 +82,7 @@ impl InputEditor {
             Some(Picker::Models(p)) => {
                 handlers::handle_models_key(&mut self.buffer, &mut self.cursor, p, key)
             }
+            Some(Picker::Rewind(p)) => p.handle(key),
             None => false,
         };
         if handled {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,6 +39,7 @@ use crate::ui::event_handler::{ensure_agent, handle_agent_event};
 use crate::ui::events::{render_session, sanitize_output};
 use crate::ui::input::InputEditor;
 use crate::ui::permission_handler::handle_permission_request;
+use crate::ui::pickers::rewind::RewindOutcome;
 use crate::ui::renderer::{Renderer, copy_to_clipboard};
 use crate::ui::slash::{handle_compress, handle_slash};
 use crate::ui::terminal::TerminalGuard;
@@ -208,6 +209,22 @@ pub(crate) enum SubmitAction {
 pub(crate) fn allowed_while_running(text: &str) -> bool {
     let t = text.trim_start();
     t == "/queue" || t.starts_with("/queue ") || t == "/btw" || t.starts_with("/btw ")
+}
+
+/// Build the rewind picker's list of `(message_index, preview)` for every user
+/// turn in the conversation, oldest first. Only user turns are offered: a rewind
+/// lands just before a message you sent, dropping everything after it.
+pub(crate) fn rewind_targets(session: &Session) -> Vec<(usize, String)> {
+    session
+        .messages
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.role == MessageRole::User)
+        .map(|(idx, m)| {
+            let preview: String = m.content.chars().take(80).collect();
+            (idx, preview.replace('\n', " "))
+        })
+        .collect()
 }
 
 pub(crate) fn classify_submission(is_running: bool, text: &str) -> SubmitAction {
@@ -1242,7 +1259,6 @@ pub async fn run_interactive(
                             refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                             continue;
                         }
-
                         let ctrl_r = key.code == KeyCode::Char('r')
                             && key.modifiers.contains(KeyModifiers::CONTROL);
                         if ctrl_r {
@@ -1281,6 +1297,28 @@ pub async fn run_interactive(
 
                         if input.picker.as_ref().is_some_and(|p| p.active())
                             && input.handle_picker_key(key) {
+                                // The rewind picker resolves through here: once it
+                                // confirms, perform the rewind on the live session
+                                // and drop the chosen turn back into the input box.
+                                if let Some(RewindOutcome::Confirmed(idx)) =
+                                    input.take_rewind_outcome()
+                                {
+                                    let text =
+                                        session.messages.get(idx).map(|m| m.content.to_string());
+                                    if session.rewind_to(idx) > 0 {
+                                        if let Some(text) = text {
+                                            input.load_text(&text);
+                                        }
+                                        if !cli.no_session {
+                                            let _ = crate::session::storage::save_session(session);
+                                        }
+                                        render_session(&mut renderer, session, cli, cfg, context)?;
+                                        renderer.write_line(
+                                            "rewound; /redo to restore",
+                                            Color::Green,
+                                        )?;
+                                    }
+                                }
                                 refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                                 continue;
                             }

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -33,6 +33,7 @@ const BASE_COMMANDS: &[&str] = &[
     "/regen-themes",
     "/retry",
     "/review",
+    "/rewind",
     "/sessions",
     "/theme",
     "/thinking",

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -28,6 +28,7 @@ const BASE_COMMANDS: &[&str] = &[
     "/queue",
     "/quit",
     "/reasoning",
+    "/redo",
     "/regen-prompts",
     "/regen-themes",
     "/retry",

--- a/src/ui/pickers/mod.rs
+++ b/src/ui/pickers/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod file;
 pub(crate) mod handlers;
 pub(crate) mod list;
 pub(crate) mod models;
+pub(crate) mod rewind;
 
 use std::io::Write;
 

--- a/src/ui/pickers/rewind.rs
+++ b/src/ui/pickers/rewind.rs
@@ -1,0 +1,201 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::ui::pickers::list::ListPicker;
+
+/// What the user settled on after driving the rewind picker to completion.
+pub enum RewindOutcome {
+    /// Rewind the conversation to just before the message at this index.
+    Confirmed(usize),
+    /// Back out without changing anything.
+    Cancelled,
+}
+
+enum Stage {
+    /// Choosing which earlier user turn to rewind to.
+    PickMessage,
+    /// Confirming the rewind for the chosen turn.
+    Confirm,
+}
+
+const CONFIRM_REWIND: &str = "Rewind and start from here";
+const CONFIRM_CANCEL: &str = "Cancel";
+
+/// A two-level modal picker for the double-Esc rewind: first pick an earlier
+/// user turn, then confirm the (destructive) rewind. Reuses [`ListPicker`] for
+/// rendering and selection at each level; the outcome is read back by the event
+/// loop, which owns the session and performs the actual rewind.
+pub struct RewindPicker {
+    active: bool,
+    stage: Stage,
+    list: ListPicker,
+    /// `(message_index, preview)` for each rewind-able user turn, in order. The
+    /// list shows the previews, so `list.selected` indexes straight into this.
+    targets: Vec<(usize, String)>,
+    chosen: Option<usize>,
+    outcome: Option<RewindOutcome>,
+}
+
+impl RewindPicker {
+    pub fn new(targets: Vec<(usize, String)>) -> Self {
+        let mut list = ListPicker::new();
+        list.set_items(targets.iter().map(|(_, p)| p.clone()).collect());
+        RewindPicker {
+            active: false,
+            stage: Stage::PickMessage,
+            list,
+            targets,
+            chosen: None,
+            outcome: None,
+        }
+    }
+
+    pub fn set_monochrome(&mut self, monochrome: bool) {
+        self.list.set_monochrome(monochrome);
+    }
+
+    pub fn activate(&mut self) {
+        self.active = true;
+        self.stage = Stage::PickMessage;
+        self.list.activate();
+    }
+
+    pub fn active(&self) -> bool {
+        self.active
+    }
+
+    pub fn take_outcome(&mut self) -> Option<RewindOutcome> {
+        self.outcome.take()
+    }
+
+    pub fn draw(&self) -> std::io::Result<()> {
+        self.list.draw(None)
+    }
+
+    /// Handle a key while the picker is open. Always returns `true`: the picker
+    /// is modal, so it swallows every keystroke until it resolves.
+    pub fn handle(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Up => self.list.select_prev(),
+            KeyCode::Down => self.list.select_next(),
+            KeyCode::Tab => {
+                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    self.list.select_prev();
+                } else {
+                    self.list.select_next();
+                }
+            }
+            KeyCode::BackTab => self.list.select_prev(),
+            KeyCode::Enter => self.confirm(),
+            KeyCode::Esc => self.back_or_cancel(),
+            _ => {}
+        }
+        true
+    }
+
+    fn confirm(&mut self) {
+        match self.stage {
+            Stage::PickMessage => {
+                if let Some(&(idx, _)) = self.targets.get(self.list.selected) {
+                    self.chosen = Some(idx);
+                    self.stage = Stage::Confirm;
+                    self.list
+                        .set_items(vec![CONFIRM_REWIND.to_string(), CONFIRM_CANCEL.to_string()]);
+                    self.list.activate();
+                }
+            }
+            Stage::Confirm => {
+                self.outcome = Some(if self.list.selected == 0 {
+                    RewindOutcome::Confirmed(self.chosen.unwrap_or(0))
+                } else {
+                    RewindOutcome::Cancelled
+                });
+                self.finish();
+            }
+        }
+    }
+
+    fn back_or_cancel(&mut self) {
+        match self.stage {
+            // Esc at the confirm step backs up to the message list rather than
+            // bailing out entirely, so a mis-step is cheap to correct.
+            Stage::Confirm => {
+                self.stage = Stage::PickMessage;
+                self.list
+                    .set_items(self.targets.iter().map(|(_, p)| p.clone()).collect());
+                self.list.activate();
+                if let Some(pos) = self
+                    .chosen
+                    .and_then(|idx| self.targets.iter().position(|(i, _)| *i == idx))
+                {
+                    self.list.selected = pos;
+                }
+            }
+            Stage::PickMessage => {
+                self.outcome = Some(RewindOutcome::Cancelled);
+                self.finish();
+            }
+        }
+    }
+
+    fn finish(&mut self) {
+        self.active = false;
+        self.list.deactivate();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn picker() -> RewindPicker {
+        let mut p = RewindPicker::new(vec![(1, "first".to_string()), (3, "second".to_string())]);
+        p.activate();
+        p
+    }
+
+    #[test]
+    fn enter_then_confirm_yields_the_chosen_message_index() {
+        let mut p = picker();
+        p.handle(key(KeyCode::Down)); // select second target (message index 3)
+        p.handle(key(KeyCode::Enter)); // open confirm step
+        assert!(matches!(p.stage, Stage::Confirm));
+        p.handle(key(KeyCode::Enter)); // confirm "Rewind and start from here"
+        assert!(matches!(
+            p.take_outcome(),
+            Some(RewindOutcome::Confirmed(3))
+        ));
+        assert!(!p.active());
+    }
+
+    #[test]
+    fn confirm_step_cancel_option_backs_out() {
+        let mut p = picker();
+        p.handle(key(KeyCode::Enter)); // confirm step for first target
+        p.handle(key(KeyCode::Down)); // move to "Cancel"
+        p.handle(key(KeyCode::Enter));
+        assert!(matches!(p.take_outcome(), Some(RewindOutcome::Cancelled)));
+        assert!(!p.active());
+    }
+
+    #[test]
+    fn esc_at_confirm_returns_to_message_list_without_resolving() {
+        let mut p = picker();
+        p.handle(key(KeyCode::Enter)); // into confirm
+        p.handle(key(KeyCode::Esc)); // back to message list
+        assert!(matches!(p.stage, Stage::PickMessage));
+        assert!(p.take_outcome().is_none());
+        assert!(p.active());
+    }
+
+    #[test]
+    fn esc_at_message_list_cancels() {
+        let mut p = picker();
+        p.handle(key(KeyCode::Esc));
+        assert!(matches!(p.take_outcome(), Some(RewindOutcome::Cancelled)));
+        assert!(!p.active());
+    }
+}

--- a/src/ui/slash/help.rs
+++ b/src/ui/slash/help.rs
@@ -83,6 +83,14 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
     }
     write_result(ctx.renderer, "  /clear [/new]          clear screen");
     write_result(ctx.renderer, "  /undo                  undo last exchange");
+    write_result(
+        ctx.renderer,
+        "  /redo                  restore the last /undo or rewind",
+    );
+    write_result(
+        ctx.renderer,
+        "  /rewind                rewind to an earlier turn (picker)",
+    );
     write_result(ctx.renderer, "  /retry                 retry last prompt");
     write_result(
         ctx.renderer,

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -330,8 +330,8 @@ pub async fn handle_slash(
         "/reasoning" | "/thinking" | "/mode" | "/toggle" | "/mcp" | "/editsys" | "/advisor" => {
             settings::handle(&parts, &mut ctx).await
         }
-        "/sessions" | "/clear" | "/new" | "/undo" | "/redo" | "/retry" | "/quit" | "/exit"
-        | "/history" => session::handle(&parts, &mut ctx).await,
+        "/sessions" | "/clear" | "/new" | "/undo" | "/redo" | "/rewind" | "/retry" | "/quit"
+        | "/exit" | "/history" => session::handle(&parts, &mut ctx).await,
         "/help" => {
             help::handle(&parts, &mut ctx);
             Ok(())

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -150,11 +150,12 @@ pub fn undo_last(session: &mut Session) -> usize {
     } else {
         0
     };
-    // Truncate via the session helper so the context figure tracks the
-    // shortened history (subtracts the removed turn from the calibration anchor
-    // rather than going stale or resetting to a cold estimate).
+    // Rewind via the session helper so the context figure tracks the shortened
+    // history (subtracts the removed turn from the calibration anchor rather than
+    // going stale or resetting to a cold estimate) and the cut is reversible with
+    // /redo.
     if removed > 0 {
-        session.truncate_to(len - removed);
+        session.rewind_to(len - removed);
     }
     removed
 }
@@ -329,9 +330,8 @@ pub async fn handle_slash(
         "/reasoning" | "/thinking" | "/mode" | "/toggle" | "/mcp" | "/editsys" | "/advisor" => {
             settings::handle(&parts, &mut ctx).await
         }
-        "/sessions" | "/clear" | "/new" | "/undo" | "/retry" | "/quit" | "/exit" | "/history" => {
-            session::handle(&parts, &mut ctx).await
-        }
+        "/sessions" | "/clear" | "/new" | "/undo" | "/redo" | "/retry" | "/quit" | "/exit"
+        | "/history" => session::handle(&parts, &mut ctx).await,
         "/help" => {
             help::handle(&parts, &mut ctx);
             Ok(())

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -9,6 +9,7 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         "/clear" | "/new" => handle_clear(ctx).await,
         "/undo" => handle_undo(ctx).await,
         "/redo" => handle_redo(ctx).await,
+        "/rewind" => handle_rewind(ctx).await,
         "/retry" => handle_retry(ctx).await,
         "/quit" | "/exit" => handle_quit(ctx).await,
         "/history" => handle_history(ctx).await,
@@ -185,6 +186,18 @@ async fn handle_redo(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     }
     render_session(ctx.renderer, ctx.session, ctx.cli, ctx.cfg, ctx.context)?;
     write_ok(ctx.renderer, "restored the last rewind");
+    Ok(())
+}
+
+async fn handle_rewind(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    let targets = crate::ui::rewind_targets(ctx.session);
+    if targets.is_empty() {
+        write_ok(ctx.renderer, "nothing to rewind to");
+        return Ok(());
+    }
+    // Opens the two-level rewind picker; the event loop performs the rewind once
+    // the user confirms a turn.
+    ctx.input.start_rewind_picker(targets);
     Ok(())
 }
 

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -8,6 +8,7 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         "/sessions" => handle_sessions(parts, ctx).await,
         "/clear" | "/new" => handle_clear(ctx).await,
         "/undo" => handle_undo(ctx).await,
+        "/redo" => handle_redo(ctx).await,
         "/retry" => handle_retry(ctx).await,
         "/quit" | "/exit" => handle_quit(ctx).await,
         "/history" => handle_history(ctx).await,
@@ -174,6 +175,16 @@ async fn handle_undo(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
         }
     }
 
+    Ok(())
+}
+
+async fn handle_redo(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    if !ctx.session.redo() {
+        write_ok(ctx.renderer, "nothing to redo");
+        return Ok(());
+    }
+    render_session(ctx.renderer, ctx.session, ctx.cli, ctx.cfg, ctx.context)?;
+    write_ok(ctx.renderer, "restored the last rewind");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Adds a way to rewind the conversation and makes `/undo` reversible:

- **`/rewind`** opens a picker over earlier user turns. Pick one, confirm "Rewind and start from here", and the conversation rewinds in place to just before that turn, with the turn loaded back into the input box for editing.
- **`/redo`** restores the messages removed by the last `/undo` or rewind.

## Behavior

- `/undo` keeps working as before, but is now reversible with `/redo`.
- `/rewind` opens a two-level picker: pick a turn, then confirm "Rewind and start from here" or "Cancel". Esc within the picker backs out, consistent with the other pickers. Nothing changes until you confirm.

## Design notes

- **One rewind primitive.** `/undo` and `/rewind` both go through `Session::rewind_to`, which records a single-step restore point and then truncates. Rather than add a parallel "undo of a rewind" mechanism, this generalizes the existing one, so `/undo` gains `/redo` for free. It reuses the existing calibration-aware `truncate_to`, so the context figure stays accurate after a rewind instead of going stale.
- **Restore point is single-step.** It is dropped as soon as the conversation moves forward again (a new message), so `/redo` only ever reverses the cut it directly follows.
- **Rewind is conversation-only.** It never touches the git working tree; the conversation and the code state stay independent.
- **The chosen turn is loaded back into the input** for editing, since the common case is revising that message rather than starting from a blank line.
- **No new key bindings.** Exposed as a slash command so it does not reserve Esc (or any other key), which a host TUI may use for its own navigation.
- **Useful as a context-management tool.** Jumping back to a clean point after an off-topic tangent reclaims the context that the tangent consumed (the truncation is calibration-aware, so the figure drops correctly), then you re-add just the insight you want to keep. It complements `/compress`: a surgical cut rather than a summary.

## Testing

- Unit tests for the rewind primitive (`rewind_to`, `redo`, restore-point invalidation) and the two-level picker state machine (confirm, cancel, back-out).
- Full suite green; clippy clean.
- Verified live in the TUI: `/rewind`, rewind to an earlier turn, edit the loaded message, and `/redo` to restore, plus the picker back-out paths.
