### PR TITLE
feat: fetch OpenRouter pricing for accurate cost tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8759,7 +8759,7 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerostack"
-version = "1.5.1-rc1"
+version = "1.5.1-rc2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,25 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    // Fetch OpenRouter pricing at startup so cost tracking works from the first turn
+    if provider == "openrouter"
+        && session.input_token_cost == 0.0
+        && session.output_token_cost == 0.0
+    {
+        if let Ok(prices) = provider::fetch_openrouter_pricing(
+            cli.api_key.as_deref(),
+            &cfg.custom_providers_map(),
+            cfg.api_keys.as_ref(),
+        )
+        .await
+        {
+            if let Some((input, output)) = prices.get(model.as_str()) {
+                session.input_token_cost = *input;
+                session.output_token_cost = *output;
+            }
+        }
+    }
+
     #[cfg(feature = "acp")]
     if cli.acp_enabled {
         return extras::acp::serve(cli, cfg, context).await;

--- a/src/models_catalog.rs
+++ b/src/models_catalog.rs
@@ -24,6 +24,10 @@ struct RawModel {
     id: String,
     name: String,
     context: Option<u32>,
+    #[serde(default)]
+    input_price: Option<f64>,
+    #[serde(default)]
+    output_price: Option<f64>,
 }
 
 static CATALOG: LazyLock<HashMap<String, Vec<ModelEntry>>> = LazyLock::new(|| {
@@ -38,6 +42,8 @@ static CATALOG: LazyLock<HashMap<String, Vec<ModelEntry>>> = LazyLock::new(|| {
                     display: m.name,
                     context_length: m.context,
                     kind: None,
+                    input_price: m.input_price,
+                    output_price: m.output_price,
                 })
                 .collect();
             (provider, entries)

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -250,7 +250,9 @@ pub struct ModelEntry {
     pub id: String,
     pub display: String,
     pub context_length: Option<u32>,
-    pub kind: Option<String>, // rig Model.r#type (often None)
+    pub kind: Option<String>,
+    pub input_price: Option<f64>,
+    pub output_price: Option<f64>,
 }
 
 impl ModelEntry {
@@ -260,6 +262,8 @@ impl ModelEntry {
             display: m.display_name().to_string(),
             context_length: m.context_length,
             kind: m.r#type.clone(),
+            input_price: None,
+            output_price: None,
         }
     }
 }
@@ -373,8 +377,58 @@ pub async fn list_models_manual(
             id: i.id,
             context_length: None,
             kind: None,
+            input_price: None,
+            output_price: None,
         })
         .collect())
+}
+
+pub async fn fetch_openrouter_pricing(
+    api_key: Option<&str>,
+    custom_providers: &HashMap<String, CustomProviderConfig>,
+    config_api_keys: Option<&HashMap<String, String>>,
+) -> anyhow::Result<HashMap<String, (f64, f64)>> {
+    let config = resolve_provider_config("openrouter", custom_providers)?;
+    let key = AuthResolver::new(config.kind)
+        .with_cli_key(api_key)
+        .with_env_override(config.api_key_env.as_deref())
+        .with_config_keys(config_api_keys)
+        .with_custom_provider_name(Some("openrouter"))
+        .resolve()
+        .ok();
+    let custom = custom_providers.get("openrouter");
+    let http = build_http_client("openrouter", config.danger_accept_invalid_certs, custom)?;
+    let url = "https://openrouter.ai/api/v1/models";
+    let mut req = http.get(url);
+    if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
+        req = req.bearer_auth(k);
+    }
+    #[derive(serde::Deserialize)]
+    struct PricingResp {
+        prompt: String,
+        completion: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct PricingEntry {
+        id: String,
+        pricing: Option<PricingResp>,
+    }
+    #[derive(serde::Deserialize)]
+    struct PricingList {
+        data: Vec<PricingEntry>,
+    }
+    let resp: PricingList = req.send().await?.error_for_status()?.json().await?;
+    let mut map = HashMap::new();
+    for entry in resp.data {
+        if let Some(p) = entry.pricing {
+            let input: f64 = p.prompt.parse().unwrap_or(0.0);
+            let output: f64 = p.completion.parse().unwrap_or(0.0);
+            if input > 0.0 || output > 0.0 {
+                map.insert(entry.id, (input * 1_000_000.0, output * 1_000_000.0));
+            }
+        }
+    }
+    Ok(map)
 }
 
 async fn summarize_with_model(model: AnyModel, prompt: String) -> anyhow::Result<String> {

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -75,6 +75,8 @@ fn model(id: &str, kind: Option<&str>) -> ModelEntry {
         display: id.to_string(),
         context_length: None,
         kind: kind.map(|s| s.to_string()),
+        input_price: None,
+        output_price: None,
     }
 }
 

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -67,6 +67,29 @@ pub(crate) async fn fetch_models_cached(
         client.list_models().await?
     };
     models.retain(crate::provider::is_agent_model);
+
+    if provider == "openrouter" {
+        match crate::provider::fetch_openrouter_pricing(
+            cli.api_key.as_deref(),
+            &cfg.custom_providers_map(),
+            cfg.api_keys.as_ref(),
+        )
+        .await
+        {
+            Ok(prices) => {
+                for m in &mut models {
+                    if let Some((input, output)) = prices.get(&m.id) {
+                        m.input_price = Some(*input);
+                        m.output_price = Some(*output);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("failed to fetch OpenRouter pricing: {e}");
+            }
+        }
+    }
+
     let arc: Arc<[ModelEntry]> = Arc::from(models.into_boxed_slice());
     MODEL_CACHE
         .lock()
@@ -97,6 +120,32 @@ pub(crate) async fn warm_model_cache(
     cached_model_ids(provider)
 }
 
+fn lookup_pricing_from_cache(provider: &str, model_id: &str) -> Option<(f64, f64)> {
+    MODEL_CACHE
+        .lock()
+        .unwrap()
+        .get(provider)
+        .and_then(|models| {
+            models.iter().find_map(|m| {
+                if m.id == model_id {
+                    m.input_price.zip(m.output_price).or_else(|| {
+                        crate::models_catalog::catalog_entries(provider).and_then(|entries| {
+                            entries.iter().find_map(|e| {
+                                if e.id == model_id {
+                                    e.input_price.zip(e.output_price)
+                                } else {
+                                    None
+                                }
+                            })
+                        })
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+}
+
 async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
     let new_model = compact_str::CompactString::new(model_id);
     let model = ctx.client.completion_model(new_model.to_string());
@@ -124,6 +173,23 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
         ctx.cfg
             .resolve_context_window(&ctx.session.provider, &new_model),
     );
+    if let Some((input, output)) = lookup_pricing_from_cache(&ctx.session.provider, model_id) {
+        ctx.session.input_token_cost = input;
+        ctx.session.output_token_cost = output;
+    } else if ctx.session.provider == "openrouter" {
+        if let Ok(prices) = crate::provider::fetch_openrouter_pricing(
+            ctx.cli.api_key.as_deref(),
+            &ctx.cfg.custom_providers_map(),
+            ctx.cfg.api_keys.as_ref(),
+        )
+        .await
+        {
+            if let Some((input, output)) = prices.get(model_id) {
+                ctx.session.input_token_cost = *input;
+                ctx.session.output_token_cost = *output;
+            }
+        }
+    }
     write_ok(ctx.renderer, format!("switched to model: {}", new_model));
 }
 
@@ -208,6 +274,23 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
         ctx.cfg
             .resolve_context_window(&ctx.session.provider, &new_model),
     );
+    if let Some((input, output)) = lookup_pricing_from_cache(&ctx.session.provider, &new_model) {
+        ctx.session.input_token_cost = input;
+        ctx.session.output_token_cost = output;
+    } else if ctx.session.provider == "openrouter" {
+        if let Ok(prices) = crate::provider::fetch_openrouter_pricing(
+            ctx.cli.api_key.as_deref(),
+            &ctx.cfg.custom_providers_map(),
+            ctx.cfg.api_keys.as_ref(),
+        )
+        .await
+        {
+            if let Some((input, output)) = prices.get(&*new_model) {
+                ctx.session.input_token_cost = *input;
+                ctx.session.output_token_cost = *output;
+            }
+        }
+    }
     write_ok(ctx.renderer, format!("switched to model: {}", new_model));
     Ok(())
 }


### PR DESCRIPTION
Adds \`fetch_openrouter_pricing()\` to query OpenRouter's \`/api/v1/models\` endpoint.

- Fetches pricing at startup for OpenRouter sessions so cost tracking works from the first turn
- Extends \`ModelEntry\` with \`input_price\`/\`output_price\` fields
- Caches pricing to avoid re-fetching on model switch
- Bumps version to 1.5.1-rc2