### PR TITLE
fix: cost tracking for multi-turn tool calls + OpenRouter context window

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -305,21 +305,31 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // Fetch OpenRouter pricing at startup so cost tracking works from the first turn
-    if provider == "openrouter"
-        && session.input_token_cost == 0.0
-        && session.output_token_cost == 0.0
-    {
-        if let Ok(prices) = provider::fetch_openrouter_pricing(
-            cli.api_key.as_deref(),
-            &cfg.custom_providers_map(),
-            cfg.api_keys.as_ref(),
-        )
-        .await
-        {
-            if let Some((input, output)) = prices.get(model.as_str()) {
-                session.input_token_cost = *input;
-                session.output_token_cost = *output;
+    // Fetch OpenRouter pricing and context window at startup so cost tracking
+    // and the context meter work from the first turn. The static catalog only
+    // covers a handful of models; models like z-ai/glm-5.2 fall through to the
+    // 128k default, which silently breaks compaction and the context meter.
+    if provider == "openrouter" {
+        let need_pricing = session.input_token_cost == 0.0 && session.output_token_cost == 0.0;
+        let need_ctx = cfg.context_window.is_none()
+            && config::Config::catalog_context_window("openrouter", model.as_str()).is_none();
+        if need_pricing || need_ctx {
+            if let Ok(infos) = provider::fetch_openrouter_pricing(
+                cli.api_key.as_deref(),
+                &cfg.custom_providers_map(),
+                cfg.api_keys.as_ref(),
+            )
+            .await
+            {
+                if let Some(info) = infos.get(model.as_str()) {
+                    if need_pricing {
+                        session.input_token_cost = info.input_cost;
+                        session.output_token_cost = info.output_cost;
+                    }
+                    if need_ctx && let Some(cw) = info.context_length {
+                        session.update_context_window(cw);
+                    }
+                }
             }
         }
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -384,11 +384,18 @@ pub async fn list_models_manual(
         .collect())
 }
 
+#[derive(Clone, Copy, Default)]
+pub struct OpenRouterModelInfo {
+    pub input_cost: f64,
+    pub output_cost: f64,
+    pub context_length: Option<u64>,
+}
+
 pub async fn fetch_openrouter_pricing(
     api_key: Option<&str>,
     custom_providers: &HashMap<String, CustomProviderConfig>,
     config_api_keys: Option<&HashMap<String, String>>,
-) -> anyhow::Result<HashMap<String, (f64, f64)>> {
+) -> anyhow::Result<HashMap<String, OpenRouterModelInfo>> {
     let config = resolve_provider_config("openrouter", custom_providers)?;
     let key = AuthResolver::new(config.kind)
         .with_cli_key(api_key)
@@ -413,6 +420,7 @@ pub async fn fetch_openrouter_pricing(
     struct PricingEntry {
         id: String,
         pricing: Option<PricingResp>,
+        context_length: Option<u64>,
     }
     #[derive(serde::Deserialize)]
     struct PricingList {
@@ -421,12 +429,22 @@ pub async fn fetch_openrouter_pricing(
     let resp: PricingList = req.send().await?.error_for_status()?.json().await?;
     let mut map = HashMap::new();
     for entry in resp.data {
-        if let Some(p) = entry.pricing {
-            let input: f64 = p.prompt.parse().unwrap_or(0.0);
-            let output: f64 = p.completion.parse().unwrap_or(0.0);
-            if input > 0.0 || output > 0.0 {
-                map.insert(entry.id, (input * 1_000_000.0, output * 1_000_000.0));
-            }
+        let (input, output) = match entry.pricing.as_ref() {
+            Some(p) => (
+                p.prompt.parse().unwrap_or(0.0),
+                p.completion.parse().unwrap_or(0.0),
+            ),
+            None => (0.0, 0.0),
+        };
+        if input > 0.0 || output > 0.0 || entry.context_length.is_some() {
+            map.insert(
+                entry.id,
+                OpenRouterModelInfo {
+                    input_cost: input * 1_000_000.0,
+                    output_cost: output * 1_000_000.0,
+                    context_length: entry.context_length,
+                },
+            );
         }
     }
     Ok(map)

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -192,8 +192,7 @@ fn resolve_context_window_from_quick_model() {
         64_000
     );
     // Global config pin still wins over quick model.
-    let cfg: Config =
-        serde_json::from_str(r#"{ "context_window": 32000 }"#).unwrap();
+    let cfg: Config = serde_json::from_str(r#"{ "context_window": 32000 }"#).unwrap();
     assert_eq!(
         cfg.resolve_context_window("openrouter", "deepseek/deepseek-chat", &qm),
         32_000

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -337,6 +337,17 @@ pub async fn handle_agent_event(
             if real > session.total_estimated_tokens {
                 session.total_estimated_tokens = real;
             }
+            // Accumulate cost for intermediate calls (tool-use turns). The Done
+            // event only carries the final call's usage, so without this every
+            // tool-call round-trip would go uncosted.
+            session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
+            session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
+            session.total_cost += crate::pricing::estimate_cost(
+                input_tokens,
+                output_tokens,
+                session.input_token_cost,
+                session.output_token_cost,
+            );
         }
         AgentEvent::Retrying { attempt, max } => {
             *was_reasoning = false;

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -78,9 +78,9 @@ pub(crate) async fn fetch_models_cached(
         {
             Ok(prices) => {
                 for m in &mut models {
-                    if let Some((input, output)) = prices.get(&m.id) {
-                        m.input_price = Some(*input);
-                        m.output_price = Some(*output);
+                    if let Some(info) = prices.get(&m.id) {
+                        m.input_price = Some(info.input_cost);
+                        m.output_price = Some(info.output_cost);
                     }
                 }
             }
@@ -186,9 +186,16 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
         )
         .await
         {
-            if let Some((input, output)) = prices.get(model_id) {
-                ctx.session.input_token_cost = *input;
-                ctx.session.output_token_cost = *output;
+            if let Some(info) = prices.get(model_id) {
+                ctx.session.input_token_cost = info.input_cost;
+                ctx.session.output_token_cost = info.output_cost;
+                if ctx.cfg.context_window.is_none()
+                    && crate::config::Config::catalog_context_window("openrouter", model_id)
+                        .is_none()
+                    && let Some(cw) = info.context_length
+                {
+                    ctx.session.update_context_window(cw);
+                }
             }
         }
     }
@@ -291,9 +298,16 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
         )
         .await
         {
-            if let Some((input, output)) = prices.get(&*new_model) {
-                ctx.session.input_token_cost = *input;
-                ctx.session.output_token_cost = *output;
+            if let Some(info) = prices.get(&*new_model) {
+                ctx.session.input_token_cost = info.input_cost;
+                ctx.session.output_token_cost = info.output_cost;
+                if ctx.cfg.context_window.is_none()
+                    && crate::config::Config::catalog_context_window("openrouter", &new_model)
+                        .is_none()
+                    && let Some(cw) = info.context_length
+                {
+                    ctx.session.update_context_window(cw);
+                }
             }
         }
     }


### PR DESCRIPTION
Cost: the CompletionCall handler now accumulates total_input_tokens, total_output_tokens, and total_cost for every intermediate LLM call (one per tool-use round-trip). Previously only the final Done call was costed, so any turn using tools undercounted cost — often severely, since tool-result inputs are the most expensive calls.

Context window: fetch_openrouter_pricing now also returns context_length from the OpenRouter /api/v1/models endpoint (new OpenRouterModelInfo struct). At startup and on /model switch, models not in the static catalog and not config-pinned (e.g. z-ai/glm-5.2) get their real context window from OpenRouter instead of silently falling back to 128k. This fixes the context meter percentage and ensures compaction triggers at the right threshold.