### PR TITLE
fix(acp): import schema types from v1 submodule

### DIFF
--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use agent_client_protocol::on_receive_request;
-use agent_client_protocol::schema::*;
+use agent_client_protocol::schema::v1::*;
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectTo, ConnectionTo, Dispatch, Responder, Role, Stdio,
 };


### PR DESCRIPTION
agent-client-protocol-schema v1.1.0 moved all protocol types (SessionId, InitializeRequest, PromptResponse, etc.) into a `v1` submodule, so the previous `schema::*` glob import no longer brought them into scope, causing 55 compile errors under --features acp / --all-features. Switched to `schema::v1::*`.