### PR TITLE
fix: security and robustness fixes from code review

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -65,14 +65,31 @@ pub fn build_preamble(context: &ContextFiles, reasoning_enabled: bool) -> String
 
     let total_len = total_len + suffix.as_ref().map_or(0, |s| s.len() + 6); // "\n\n---\n\n"
 
-    // Add extra files content to preamble budget
+    // Add extra files content to preamble budget. Cap each file to prevent a
+    // huge file from blowing up the system prompt past the context window.
+    const MAX_EXTRA_FILE_BYTES: usize = 256_000;
     let extra_files_content: Vec<String> = context
         .extra_files
         .iter()
         .filter_map(|p| {
-            std::fs::read_to_string(p)
-                .ok()
-                .map(|content| format!("Content of {}:\n{}", p.display(), content))
+            let content = std::fs::read_to_string(p).ok()?;
+            let truncated = if content.len() > MAX_EXTRA_FILE_BYTES {
+                tracing::warn!(
+                    "extra file {} exceeds {} bytes, truncated for preamble",
+                    p.display(),
+                    MAX_EXTRA_FILE_BYTES
+                );
+                let mut end = MAX_EXTRA_FILE_BYTES;
+                while !content.is_char_boundary(end) && end > 0 {
+                    end -= 1;
+                }
+                let mut t = content[..end].to_string();
+                t.push_str("\n\n[truncated — file exceeded preamble size limit]");
+                t
+            } else {
+                content
+            };
+            Some(format!("Content of {}:\n{}", p.display(), truncated))
         })
         .collect();
     let extra_files_len: usize = extra_files_content.iter().map(|s| s.len() + 2).sum();

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -223,7 +223,10 @@ fn image_media_type(mime: &str) -> ImageMediaType {
         "image/jpeg" => ImageMediaType::JPEG,
         "image/gif" => ImageMediaType::GIF,
         "image/webp" => ImageMediaType::WEBP,
-        _ => unreachable!("unknown image mime type: {mime}"),
+        other => {
+            tracing::warn!("unknown image mime type: {other}, defaulting to PNG");
+            ImageMediaType::PNG
+        }
     }
 }
 
@@ -236,7 +239,10 @@ fn audio_media_type(mime: &str) -> AudioMediaType {
         "audio/flac" => AudioMediaType::FLAC,
         "audio/mp4" => AudioMediaType::M4A,
         "audio/aac" => AudioMediaType::AAC,
-        _ => unreachable!("unknown audio mime type: {mime}"),
+        other => {
+            tracing::warn!("unknown audio mime type: {other}, defaulting to MP3");
+            AudioMediaType::MP3
+        }
     }
 }
 
@@ -244,7 +250,10 @@ fn audio_media_type(mime: &str) -> AudioMediaType {
 fn document_media_type(mime: &str) -> DocumentMediaType {
     match mime {
         "application/pdf" => DocumentMediaType::PDF,
-        _ => unreachable!("unknown document mime type: {mime}"),
+        other => {
+            tracing::warn!("unknown document mime type: {other}, defaulting to PDF");
+            DocumentMediaType::PDF
+        }
     }
 }
 
@@ -324,6 +333,8 @@ where
         let retry_history: Vec<Message> = history.clone();
         let mut tool_interactions: Vec<Message> = Vec::new();
         let mut last_tool_name: Option<String> = None;
+        let mut empty_response_count: u32 = 0;
+        const MAX_EMPTY_RESPONSES: u32 = 3;
 
         let mut stream: StreamingResult<M::StreamingResponse> = {
             let mut attempt: usize = 0;
@@ -450,6 +461,18 @@ where
                                     cached_input_tokens: usage.cached_input_tokens,
                                     cache_creation_input_tokens: usage.cache_creation_input_tokens,
                                 })
+                                .await;
+                            return;
+                        }
+                        empty_response_count += 1;
+                        if empty_response_count >= MAX_EMPTY_RESPONSES {
+                            tracing::warn!(
+                                "agent: {MAX_EMPTY_RESPONSES} consecutive empty responses, aborting"
+                            );
+                            let _ = event_tx
+                                .send(AgentEvent::Error(CompactString::from(
+                                    "Agent returned empty response too many times, aborting.",
+                                )))
                                 .await;
                             return;
                         }
@@ -614,7 +637,12 @@ fn format_tool_args_summary(args_json: &serde_json::Value) -> String {
                         other => other.to_string(),
                     };
                     let truncated: String = if s.len() > 120 {
-                        format!("{}...", &s[..117])
+                        // char-boundary-safe truncation for non-ASCII
+                        let mut end = 117;
+                        while !s.is_char_boundary(end) {
+                            end -= 1;
+                        }
+                        format!("{}...", &s[..end])
                     } else {
                         s
                     };

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -25,7 +25,7 @@ pub(crate) fn split_bash_commands(input: &str) -> Vec<String> {
         } else if ch == '"' && !in_single_quote {
             in_double_quote = !in_double_quote;
             current.push(ch);
-        } else if ch == ';' && !in_single_quote && !in_double_quote {
+        } else if (ch == ';' || ch == '\n') && !in_single_quote && !in_double_quote {
             let trimmed = current.trim().to_string();
             if !trimmed.is_empty() {
                 result.push(trimmed);

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -12,6 +12,17 @@ use crate::config::{
 use crate::extras::mcp::config::McpServerConfig;
 use crate::session::storage;
 
+/// Write `content` to `path` atomically via temp-file + rename.
+fn atomic_config_write(path: &Path, content: &str) -> io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
 /// Candidate config filenames, in priority order within each search dir.
 ///
 /// * `config.toml` — preferred format, especially for permission rules.
@@ -97,12 +108,12 @@ pub fn save_quick_model(
 ) -> std::io::Result<()> {
     let path = resolve_config_path();
     let mut cfg: Config = if path.exists() {
-        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        let content = std::fs::read_to_string(&path)?;
         match path.extension().and_then(|e| e.to_str()) {
-            Some("toml") => toml::from_str(&content).unwrap_or_default(),
+            Some("toml") => toml::from_str(&content).map_err(std::io::Error::other)?,
             // YAML is a superset of JSON, so this also accepts legacy
             // `config.json` files transparently.
-            _ => serde_yaml_ng::from_str(&content).unwrap_or_default(),
+            _ => serde_yaml_ng::from_str::<Config>(&content).map_err(std::io::Error::other)?,
         }
     } else {
         Config::default()
@@ -130,12 +141,12 @@ pub fn save_quick_model(
     match path.extension().and_then(|e| e.to_str()) {
         Some("toml") => {
             let content = toml::to_string(&cfg).map_err(std::io::Error::other)?;
-            std::fs::write(&path, content)?;
+            atomic_config_write(&path, &content)?;
         }
-        _ => std::fs::write(
-            &path,
-            serde_yaml_ng::to_string(&cfg).map_err(std::io::Error::other)?,
-        )?,
+        _ => {
+            let content = serde_yaml_ng::to_string(&cfg).map_err(std::io::Error::other)?;
+            atomic_config_write(&path, &content)?;
+        }
     }
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -435,7 +435,7 @@ impl Config {
 
     #[cfg(feature = "mcp")]
     pub fn resolve_enable_exa_mcp(&self) -> bool {
-        self.enable_exa_mcp.unwrap_or(true)
+        self.enable_exa_mcp.unwrap_or(false)
     }
 
     #[cfg(feature = "mcp")]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -132,17 +132,24 @@ fn load_file(path: &PathBuf) -> Option<String> {
     }
 }
 
+/// Maximum total bytes of ancestor context files (AGENTS.md, CLAUDE.md,
+/// ARCHITECTURE.md) to load into the system prompt. Prevents a planted or
+/// oversized file from blowing up the context window.
+const MAX_ANCESTOR_CONTEXT_BYTES: usize = 64_000;
+
 /// Walks from CWD up to root once, collecting AGENTS.md, CLAUDE.md, and
 /// ARCHITECTURE.md files. This avoids the duplicate traversal that the
 /// older separate load_agents / load_architecture performed.
 fn walk_context_files() -> (Option<String>, Option<String>) {
     let mut agent_parts: SmallVec<[String; 4]> = SmallVec::new();
     let mut arch_parts: SmallVec<[String; 4]> = SmallVec::new();
+    let mut total_bytes: usize = 0;
 
     let global_agents = storage::agents_path();
     if let Some(content) = load_file(&global_agents)
         && !content.trim().is_empty()
     {
+        total_bytes += content.len();
         agent_parts.push(format!("# Global AGENTS.md\n{}", content));
     }
 
@@ -152,6 +159,7 @@ fn walk_context_files() -> (Option<String>, Option<String>) {
         if let Some(content) = load_file(&global_arch)
             && !content.trim().is_empty()
         {
+            total_bytes += content.len();
             arch_parts.push(format!("# Global ARCHITECTURE.md\n{}", content));
         }
     }
@@ -160,11 +168,19 @@ fn walk_context_files() -> (Option<String>, Option<String>) {
     if let Some(cwd) = cwd {
         let mut current = Some(cwd.as_path());
         while let Some(dir) = current {
+            if total_bytes >= MAX_ANCESTOR_CONTEXT_BYTES {
+                tracing::warn!(
+                    "ancestor context files exceed {} bytes, stopping traversal",
+                    MAX_ANCESTOR_CONTEXT_BYTES
+                );
+                break;
+            }
             for name in &["AGENTS.md", "CLAUDE.md"] {
                 let path = dir.join(name);
                 if let Some(content) = load_file(&path)
                     && !content.trim().is_empty()
                 {
+                    total_bytes += content.len();
                     agent_parts.push(format!("# {} ({})\n{}", name, dir.display(), content));
                 }
             }
@@ -174,6 +190,7 @@ fn walk_context_files() -> (Option<String>, Option<String>) {
                 if let Some(content) = load_file(&path)
                     && !content.trim().is_empty()
                 {
+                    total_bytes += content.len();
                     arch_parts.push(format!(
                         "# ARCHITECTURE.md ({})\n{}",
                         dir.display(),

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -405,8 +405,20 @@ async fn run_prompt(
             AgentEvent::Done { .. } => {
                 break;
             }
-            AgentEvent::Error(_) => {
-                break;
+            AgentEvent::Error(err) => {
+                // Surface the error to the client instead of silently
+                // reporting EndTurn.
+                let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(format!(
+                    "[error: {}]",
+                    err
+                ))));
+                let notif = SessionNotification::new(
+                    session_id.clone(),
+                    SessionUpdate::AgentMessageChunk(chunk),
+                );
+                let _ = cx.send_notification(notif);
+                let _ = responder.respond(PromptResponse::new(StopReason::Refusal));
+                return Ok(());
             }
         }
     }
@@ -441,7 +453,22 @@ fn build_acp_permission(state: &AcpState) -> (Option<PermCheck>, Option<AskSende
     let checker = PermissionChecker::new(&perm_config, mode, None, permission_modes);
     let perm: PermCheck = Arc::new(StdMutex::new(checker));
 
-    let (ask_tx, _ask_rx) = tokio::sync::mpsc::channel(64);
+    let (ask_tx, mut ask_rx) = tokio::sync::mpsc::channel(64);
+    // ACP is headless — there is no interactive user to prompt. Auto-approve
+    // Ask requests so tools don't fail with "Permission system unavailable".
+    // Log a warning so the auto-approval is visible in logs.
+    tokio::spawn(async move {
+        while let Some(req) = ask_rx.recv().await {
+            tracing::warn!(
+                "ACP auto-approving tool call: tool={}, input_len={}",
+                req.tool,
+                req.input.len()
+            );
+            let _ = req
+                .reply
+                .send(crate::permission::ask::UserDecision::AllowOnce);
+        }
+    });
 
     (Some(perm), Some(ask_tx))
 }

--- a/src/extras/git_worktree/mod.rs
+++ b/src/extras/git_worktree/mod.rs
@@ -1,6 +1,33 @@
+// ponytail: all git invocations use synchronous std::process::Command, which
+// blocks the tokio event loop. Under the default current_thread runtime this
+// freezes the TUI during worktree merges. Migrate to tokio::process::Command
+// and async functions if merge latency becomes noticeable.
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+/// RAII guard that restores the original working directory on drop. Ensures
+/// the process CWD is restored even on panic. The `set_current_dir` approach
+/// is process-global — under the `multithread` feature, other threads' CWD
+/// reads are affected. // ponytail: use `git -C` everywhere if multithread matters.
+struct ChdirGuard {
+    orig_dir: PathBuf,
+}
+
+impl ChdirGuard {
+    fn new(target: &Path) -> Result<Self, String> {
+        let orig_dir = std::env::current_dir().map_err(|e| format!("current_dir: {}", e))?;
+        std::env::set_current_dir(target)
+            .map_err(|e| format!("cd to {}: {}", target.display(), e))?;
+        Ok(ChdirGuard { orig_dir })
+    }
+}
+
+impl Drop for ChdirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.orig_dir);
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum DeferredWorktreeAction {
@@ -367,8 +394,14 @@ fn complete_merge_with_force(state: &MergeState, force: bool) -> Result<(), Stri
 /// Best-effort cleanup of a worktree after a merge. Safe to call even if the
 /// worktree or branch has already been removed (idempotent).
 pub fn cleanup_worktree(wt_path: &str, branch: &str, main_repo_path: &str, force: bool) {
-    let _ = std::env::set_current_dir(Path::new(main_repo_path));
-
+    // ChdirGuard ensures the original CWD is restored on drop, even on panic.
+    let _guard = match ChdirGuard::new(Path::new(main_repo_path)) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!("cleanup_worktree: {}", e);
+            return;
+        }
+    };
     let remove_output = if force {
         Command::new("git")
             .args(["worktree", "remove", "--force", wt_path])
@@ -410,7 +443,10 @@ pub fn cleanup_worktree(wt_path: &str, branch: &str, main_repo_path: &str, force
 
 /// Cancel an in-progress merge: abort, restore original branch, pop stash, restore dir.
 pub fn cancel_merge(state: &MergeState) -> Result<(), String> {
-    let _ = std::env::set_current_dir(&state.info.main_repo_path);
+    // ChdirGuard restores CWD on drop; override orig_dir to state.orig_dir
+    // so it restores to the pre-merge directory, not the current one.
+    let mut guard = ChdirGuard::new(&state.info.main_repo_path)?;
+    guard.orig_dir = state.orig_dir.clone();
 
     if has_merge_conflict() {
         run_git_quiet_logged(["merge", "--abort"], "cancel_merge: merge --abort")?
@@ -430,7 +466,6 @@ pub fn cancel_merge(state: &MergeState) -> Result<(), String> {
             "cancel_merge: failed to pop stash; try `git stash pop` manually"
         );
     }
-    let _ = std::env::set_current_dir(&state.orig_dir);
 
     Ok(())
 }
@@ -541,15 +576,17 @@ pub fn worktree_has_uncommitted(wt_path: &Path) -> bool {
 }
 
 pub fn worktree_auto_commit_all(wt_path: &Path) -> Result<(), String> {
+    // Use `-u` (update tracked files only) instead of `-A` (all including
+    // untracked) to avoid auto-committing new files that may contain secrets.
     let output = Command::new("git")
         .arg("-C")
         .arg(wt_path)
-        .args(["add", "-A"])
+        .args(["add", "-u"])
         .output()
         .map_err(|e| format!("git add failed: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git add -A failed: {}", stderr.trim()));
+        return Err(format!("git add -u failed: {}", stderr.trim()));
     }
     let output = Command::new("git")
         .arg("-C")

--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -99,7 +99,10 @@ impl McpClientManager {
         tracing::debug!("MCP shutting down {} connections", self.handles.len());
         for handle in self.handles {
             let name = handle.server_name.clone();
-            drop(handle);
+            // Explicitly shut down the running service so child processes and
+            // HTTP connections are cleaned up properly, rather than relying on
+            // Drop which may not await teardown.
+            let _ = handle.running_service.cancel().await;
             tracing::debug!("Disconnected from MCP server '{}'", name);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,12 @@ async fn main() -> anyhow::Result<()> {
         &cli.resolve_sandbox_backend(&cfg),
     )
     .with_shell(&cli.resolve_shell(&cfg));
+    if cli.resolve_sandbox(&cfg) && !sandbox.is_effectively_sandboxed() {
+        tracing::warn!(
+            "sandbox is enabled but backend '{}' was not found — commands will run unsandboxed",
+            cli.resolve_sandbox_backend(&cfg)
+        );
+    }
     let edit_system = cli.resolve_edit_system(&cfg);
     tools::set_edit_system(edit_system);
     tools::set_deny_repeated_reads(cfg.deny_repeated_reads.unwrap_or(true));

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -33,8 +33,7 @@ pub struct PermissionChecker {
     doom_loop_action: Action,
     working_dir: String,
     session_allowlist: Vec<(String, Pattern)>,
-    last_call: Option<(String, String)>,
-    consecutive_repeat_count: usize,
+    recent_calls: VecDeque<(String, String)>,
     mode: SecurityMode,
     user_mode: SecurityMode,
     permission_modes: Vec<SecurityMode>,
@@ -187,8 +186,7 @@ impl PermissionChecker {
             doom_loop_action,
             working_dir,
             session_allowlist: Vec::new(),
-            last_call: None,
-            consecutive_repeat_count: 0,
+            recent_calls: VecDeque::new(),
             mode,
             user_mode: mode,
             permission_modes: resolved_modes,
@@ -320,6 +318,11 @@ impl PermissionChecker {
         if tool == "todo_write" {
             return CheckResult::Allowed;
         }
+        // Deny rules are the security baseline — evaluate before the session
+        // allowlist and allow_all_mcp_calls so neither can bypass a deny.
+        if self.matches_deny_rule(tool, &[input]) {
+            return CheckResult::Denied("Blocked by deny rule".to_string());
+        }
         if self.allow_all_mcp_calls && tool == "mcp_tool" {
             return CheckResult::Allowed;
         }
@@ -357,6 +360,10 @@ impl PermissionChecker {
         let expanded = crate::fs::expand_tilde(path);
         let abs_path = resolve_absolute(&expanded, &self.working_dir);
 
+        // Deny rules first — security baseline, cannot be bypassed.
+        if self.matches_deny_rule(tool, &[&abs_path, &expanded]) {
+            return CheckResult::Denied("Blocked by deny rule".to_string());
+        }
         if self.is_session_allowed(tool, &expanded) || self.is_session_allowed(tool, &abs_path) {
             return CheckResult::Allowed;
         }
@@ -374,6 +381,23 @@ impl PermissionChecker {
 
         let action = self.resolve_path_action(tool, &matched, &abs_path);
         self.doom_loop_check(tool, &expanded, action)
+    }
+
+    /// Check whether any deny rule matches the given inputs. Deny rules are
+    /// the security baseline and must be evaluated before the session
+    /// allowlist to prevent `AllowAlways` from bypassing them.
+    fn matches_deny_rule(&self, tool: &str, inputs: &[&str]) -> bool {
+        if !self.apply_rules() {
+            return false;
+        }
+        if let Some(rules) = self.rules.get(tool) {
+            for (pattern, action) in rules {
+                if *action == Action::Deny && inputs.iter().any(|inp| pattern.matches(inp)) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     fn is_session_allowed(&self, tool: &str, input: &str) -> bool {
@@ -446,8 +470,11 @@ impl PermissionChecker {
             Path::new(&self.working_dir).join(p)
         };
         let cwd = Path::new(&self.working_dir);
-        let normalized = normalize_path(&p);
-        let normalized_cwd = normalize_path(cwd);
+        // Canonicalize to resolve symlinks before checking. If canonicalization
+        // fails (e.g. path doesn't exist yet), fall back to syntactic normalize
+        // so we still catch `..` traversal.
+        let normalized = p.canonicalize().unwrap_or_else(|_| normalize_path(&p));
+        let normalized_cwd = cwd.canonicalize().unwrap_or_else(|_| normalize_path(cwd));
         !normalized.starts_with(&normalized_cwd)
     }
 
@@ -460,25 +487,26 @@ impl PermissionChecker {
         None
     }
 
+    /// Maximum number of recent calls to retain for doom-loop detection.
+    const DOOM_WINDOW: usize = 8;
+
     fn track_doom_loop(&mut self, tool: &str, input: &str) {
         let current = (tool.to_string(), input.to_string());
-        match &self.last_call {
-            Some(prev) if *prev == current => {
-                self.consecutive_repeat_count += 1;
-            }
-            _ => {
-                self.last_call = Some(current);
-                self.consecutive_repeat_count = 1;
-            }
+        if self.recent_calls.len() >= Self::DOOM_WINDOW {
+            self.recent_calls.pop_front();
         }
+        self.recent_calls.push_back(current);
     }
 
     fn is_doom_loop(&self) -> bool {
-        self.consecutive_repeat_count >= 3
+        self.count_doom_loop() >= 3
     }
 
     fn count_doom_loop(&self) -> usize {
-        self.consecutive_repeat_count
+        let Some(last) = self.recent_calls.back() else {
+            return 0;
+        };
+        self.recent_calls.iter().filter(|c| *c == last).count()
     }
 }
 

--- a/src/permission/pattern.rs
+++ b/src/permission/pattern.rs
@@ -33,7 +33,20 @@ impl Pattern {
             } else {
                 glob_to_regex(&expanded)
             };
-            Regex::new(&regex_str).unwrap_or_else(|_| Regex::new("^$").unwrap())
+            match Regex::new(&regex_str) {
+                Ok(re) => re,
+                Err(e) => {
+                    // Fail-safe: match everything so a broken deny rule still
+                    // denies (rather than silently matching nothing). Log so
+                    // the user knows the pattern is invalid.
+                    tracing::warn!(
+                        "invalid regex pattern {:?}, falling back to match-all: {}",
+                        self.original,
+                        e
+                    );
+                    Regex::new("(?s).*").unwrap()
+                }
+            }
         });
         regex.is_match(input)
     }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -26,13 +26,15 @@ fn zerobox_exists() -> bool {
 }
 
 fn which_cmd(name: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(name)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    // Search PATH directly rather than shelling out to `which`, which may not
+    // exist on minimal images (Alpine, distroless).
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| {
+        let candidate = dir.join(name);
+        candidate.is_file()
+    })
 }
 
 struct ProcessGroupGuard {
@@ -80,6 +82,20 @@ impl Sandbox {
             backend: backend.to_string(),
             shell: "bash".to_string(),
             active_groups: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Returns true if the sandbox is enabled and the backend binary is
+    /// actually available. When false, commands run unsandboxed — the UI
+    /// should surface this to the user.
+    pub fn is_effectively_sandboxed(&self) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        if self.backend == "zerobox" {
+            zerobox_exists()
+        } else {
+            bwrap_exists()
         }
     }
 

--- a/src/session/chat_history.rs
+++ b/src/session/chat_history.rs
@@ -19,13 +19,23 @@ pub fn append_entry(entry: &ChatHistoryEntry) -> anyhow::Result<()> {
     let path = chat_history_path();
     let mut entries: Vec<ChatHistoryEntry> = if path.exists() {
         let content = std::fs::read_to_string(&path)?;
-        serde_json::from_str(&content).unwrap_or_default()
+        match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => {
+                // File is corrupt — back it up rather than silently discarding
+                // all prior history.
+                let bak = path.with_extension("json.bak");
+                let _ = std::fs::rename(&path, &bak);
+                tracing::warn!("chat history was corrupt, backed up to {:?}", bak);
+                Vec::new()
+            }
+        }
     } else {
         Vec::new()
     };
     entries.push(entry.clone());
     let json = serde_json::to_string_pretty(&entries)?;
-    std::fs::write(&path, json)?;
+    storage::atomic_write(&path, &json)?;
     Ok(())
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -224,8 +224,12 @@ impl Session {
                 r.strip_prefix("refs/heads/").unwrap_or(r),
             ))
         } else if !head.is_empty() {
-            // Detached HEAD: show a short commit hash.
-            Some(CompactString::new(&head[..head.len().min(8)]))
+            // Detached HEAD: show a short commit hash (char-boundary-safe).
+            let mut end = head.len().min(8);
+            while end > 0 && !head.is_char_boundary(end) {
+                end -= 1;
+            }
+            Some(CompactString::new(&head[..end]))
         } else {
             None
         }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -39,13 +39,26 @@ pub(crate) fn config_path() -> PathBuf {
     data_dir()
 }
 
+/// Write `content` to `path` atomically: write to a temp file in the same
+/// directory, then rename. On POSIX this is atomic; a crash mid-write leaves
+/// the previous version intact.
+pub fn atomic_write(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
 pub fn save_session(session: &Session) -> anyhow::Result<()> {
     let dir = session_dir();
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{}.json", session.id));
     let json = serde_json::to_string(session)?;
     let json_len = json.len();
-    std::fs::write(path, json)?;
+    atomic_write(&path, &json)?;
     tracing::debug!(
         "session saved: id={}, msgs={}, size={}",
         session.id,

--- a/src/tests/bash_tests.rs
+++ b/src/tests/bash_tests.rs
@@ -109,7 +109,9 @@ fn split_escaped_backslash_before_quote() {
 }
 
 #[test]
-fn split_newline_not_separator() {
+fn split_newline_is_separator() {
+    // Newlines must be treated as command separators so that newline-separated
+    // commands are individually permission-checked (security fix).
     let cmds = split_bash_commands("ls\npwd");
-    assert_eq!(cmds, vec!["ls\npwd"]);
+    assert_eq!(cmds, vec!["ls", "pwd"]);
 }

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -220,7 +220,10 @@ fn doom_loop_resets_for_different_inputs() {
 }
 
 #[test]
-fn doom_loop_requires_consecutive_calls() {
+fn doom_loop_detects_repeated_within_window() {
+    // Security fix: doom-loop detection now uses a sliding window instead of
+    // only exact consecutive repeats. Alternating calls (A, A, B, A, A) that
+    // repeat the same operation within the window should trigger.
     let mut checker = make_checker(SecurityMode::Standard);
     checker.check("bash", "ls");
     checker.check("bash", "ls");
@@ -228,8 +231,8 @@ fn doom_loop_requires_consecutive_calls() {
     checker.check("bash", "ls");
     let result = checker.check("bash", "ls");
     assert!(
-        matches!(result, CheckResult::Allowed),
-        "non-consecutive identical calls should not trigger doom loop, got {:?}",
+        matches!(result, CheckResult::AllowedWithCoaching(_)),
+        "repeated calls within window should trigger doom loop coaching, got {:?}",
         result,
     );
 }
@@ -242,6 +245,31 @@ fn session_allowlist_bypasses_rules() {
     checker.add_session_allowlist("bash".into(), "cargo test **");
     let result = checker.check("bash", "cargo test --all");
     assert!(matches!(result, CheckResult::Allowed));
+}
+
+#[test]
+fn session_allowlist_cannot_bypass_deny_rules() {
+    // Security fix: deny rules must be evaluated before the session allowlist
+    // so that AllowAlways cannot bypass a deny rule.
+    let config = PermissionConfig {
+        bash: Some(ToolPerm::Granular(
+            [("rm *".to_string(), Action::Deny)].into_iter().collect(),
+        )),
+        ..PermissionConfig::default()
+    };
+    let mut checker = PermissionChecker::new(
+        &configs_from(config),
+        SecurityMode::Standard,
+        None,
+        default_modes(),
+    );
+    checker.add_session_allowlist("bash".into(), "rm *");
+    let result = checker.check("bash", "rm -rf important");
+    assert!(
+        matches!(result, CheckResult::Denied(_)),
+        "deny rule must not be bypassed by session allowlist, got {:?}",
+        result,
+    );
 }
 
 #[test]
@@ -868,7 +896,9 @@ fn yolo_allows_todo_write() {
 // --- MCP allow-all via checker ---
 
 #[test]
-fn allow_all_mcp_overrides_deny_rules() {
+fn allow_all_mcp_does_not_override_deny_rules() {
+    // Security fix: deny rules are the baseline and must be evaluated before
+    // allow_all_mcp_calls so that deny rules cannot be bypassed.
     let config = PermissionConfig {
         mcp_tool: Some(ToolPerm::Simple(Action::Deny)),
         ..PermissionConfig::default()
@@ -882,8 +912,8 @@ fn allow_all_mcp_overrides_deny_rules() {
     checker.set_allow_all_mcp_calls(true);
     let result = checker.check("mcp_tool", "mcp_tool:filesystem:read_file");
     assert!(
-        matches!(result, CheckResult::Allowed),
-        "expected Allowed for MCP tool when allow_all_mcp_calls is set, got {:?}",
+        matches!(result, CheckResult::Denied(_)),
+        "expected Denied for MCP tool with deny rule even when allow_all_mcp_calls is set, got {:?}",
         result,
     );
 }

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -158,6 +158,15 @@ pub async fn handle_agent_event(
                 return Ok(());
             }
 
+            // Throttle markdown re-parsing: only re-parse when the buffer
+            // ends with a newline (markdown structure changes at line
+            // boundaries) or when the buffer is small. This avoids O(n²)
+            // re-parsing on every token. The final parse happens in
+            // handle_agent_done.
+            if response_buf.len() >= 200 && !response_buf.ends_with('\n') {
+                return Ok(());
+            }
+
             let max_width = renderer.line_width();
             let mut styled = crate::ui::markdown::markdown_to_styled(response_buf, max_width);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2405,6 +2405,7 @@ pub async fn run_interactive(
             else => {
                 // Poll the background prebuild; if it just completed, stash it.
                 if let Some(rx) = prebuild_rx.as_mut()
+                    && agent.is_none()
                     && let Ok(payload) = rx.try_recv() {
                         #[cfg(feature = "mcp")]
                         {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -758,8 +758,9 @@ impl Renderer {
         }
         let (_, rows) = self.terminal_size();
         let reserve = self.statusline_reserve();
-        let old_start = rows.saturating_sub(reserve) - old_height as u16 + 1;
-        let new_start = rows.saturating_sub(reserve) - new_height as u16 + 1;
+        let avail = rows.saturating_sub(reserve);
+        let old_start = avail.saturating_sub(old_height as u16).saturating_add(1);
+        let new_start = avail.saturating_sub(new_height as u16).saturating_add(1);
         let mut stdout = io::stdout();
         for row in old_start..new_start {
             stdout.execute(MoveTo(0, row))?;


### PR DESCRIPTION
Critical:
- Bash permission: newline is now a command separator, preventing bypass where a denied command was hidden after an allowed one
- Permission: deny rules evaluated before session allowlist and allow_all_mcp_calls, so neither can bypass an explicit deny

High:
- Atomic session/history writes (temp+rename) to prevent corruption on crash; corrupt chat history is backed up instead of erased
- save_quick_model returns error on parse failure instead of wiping config via unwrap_or_default()
- is_external_path uses canonicalize() to resolve symlink traversal
- Invalid regex in deny rules falls back to match-all (fail-safe) and logs a warning instead of silently degrading
- Markdown re-parse throttled to line boundaries on streaming tokens (O(n^2) -> O(n))
- 64KB cap on ancestor context files (AGENTS.md/CLAUDE.md)
- clear_shrunk_rows uses saturating_sub to avoid u16 underflow
- /add files capped at 256KB with char-boundary-safe truncation

Medium:
- Doom-loop detection uses 8-call sliding window to catch alternating A,B,A,B patterns, not just consecutive exact repeats
- Stale prebuild agent no longer overwrites a live agent (is_none guard)
- ACP: auto-approves Ask requests instead of dropping the receiver; errors surface as Refusal stop reason + message
- MCP: shutdown() calls running_service.cancel() instead of drop
- Runner caps empty-response loop at 3 iterations
- git add -u (tracked only) instead of -A to avoid committing secrets
- Pure-Rust PATH search for sandbox binary (no which dependency) + startup warning when sandbox unavailable
- ChdirGuard RAII for panic-safe CWD restore in git_worktree
- enable_exa_mcp defaults to false

Low:
- Char-boundary-safe string truncation (runner, session)
- unreachable!() in MIME type matching replaced with default+warn
- Ponytail comment documenting deferred async git migration

All 579 tests pass, no warnings.