### PR TITLE
feat: named sessions — --name flag, /rename command, resume by name

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,8 +11,9 @@ All slash commands are available from the TUI input prompt.
 | `/retry` | Load the last user message into the input editor for editing. |
 | `/quit` | Exit zerostack. |
 | `/sessions` | List recent saved sessions (up to 20). |
-| `/sessions <id-prefix>` | Load a session by its ID prefix. |
-| `/sessions delete <id-prefix>` | Delete a session by its ID prefix. |
+| `/sessions <id-or-name>` | Load a session by its ID prefix or name. |
+| `/sessions delete <id-or-name>` | Delete a session by its ID prefix or name. |
+| `/rename <name>` | Rename the current session. |
 | `/history` | Show global chat history (last 10 entries across sessions). |
 
 ## Provider & Model

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -106,6 +106,7 @@ By pressing `/` on an empty message, you can select any command to send the agen
 | `/btw` | Ask a question to the agent without changing the context |
 | `/review` | Ask the agent to review the last changes made |
 | `/sessions` | List older sessions |
+| `/rename <name>` | Rename the current session |
 | `/quit` | Exit |
 
 ## 2. Prompts
@@ -148,6 +149,8 @@ If you want to use zerostack from scripts, from other programs, or if you just w
 | ---- | ------ |
 | `-p <msg>` | Sends a message |
 | `-c` | Continues from last open session |
+| `--name <name>` | Set a name for the new session |
+| `--session <id-or-name>` | Load session by ID prefix or name |
 | `--read-only` | Only reads files |
 | `--yolo` | No limitations given to the agent |
 | `--sandbox` | Run the agent inside a sandbox (Experimental) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -338,7 +338,7 @@ zerostack --acp --acp-host 0.0.0.0 --acp-port 7243</code></pre>
 <!-- session mgmt -->
 <section id="sessions">
 <h2>Sessions</h2>
-<p>Sessions are saved to <code>$XDG_DATA_HOME/zerostack/sessions/</code>. Use <code>-c</code> to resume the most recent session, <code>-r</code> to browse and select one, or <code>--session &lt;id&gt;</code> to load a specific session.</p>
+<p>Sessions are saved to <code>$XDG_DATA_HOME/zerostack/sessions/</code>. Use <code>-c</code> to resume the most recent session, <code>-r</code> to browse and select one, <code>--session &lt;id-or-name&gt;</code> to load a specific session, or <code>--name &lt;name&gt;</code> to assign a name at creation.</p>
 </section>
 
 <!-- license -->

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,9 @@ pub struct Cli {
     #[arg(long = "session", help = "Load session by ID prefix")]
     pub session: Option<String>,
 
+    #[arg(long = "name", help = "Name for the session")]
+    pub name: Option<String>,
+
     #[arg(long = "no-session", help = "Ephemeral mode, do not save")]
     pub no_session: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,11 +163,13 @@ async fn main() -> anyhow::Result<()> {
         model = qm.model.clone();
     }
 
+    let name = cli.name.as_deref().unwrap_or("");
     let qm_map = config::quick_models_map(&cfg);
-    let mut session = session::Session::new(
+    let mut session = session::Session::with_name(
         &provider,
         &model,
         cfg.resolve_context_window(&provider, &model, &qm_map),
+        name,
     );
 
     // Resolve input/output token costs from quick models or defaults
@@ -194,7 +196,12 @@ async fn main() -> anyhow::Result<()> {
     if let Some(session_id) = &cli.session {
         let sessions = session::storage::find_sessions_by_prefix(session_id)?;
         if sessions.is_empty() {
-            anyhow::bail!("no session matching '{}'", session_id);
+            // try exact name match as fallback
+            if let Some(s) = session::storage::find_session_by_name(session_id)? {
+                session = s;
+            } else {
+                anyhow::bail!("no session matching '{}'", session_id);
+            }
         } else if sessions.len() == 1 {
             session = sessions.into_iter().next().unwrap();
         } else {
@@ -209,13 +216,19 @@ async fn main() -> anyhow::Result<()> {
                     })
                     .unwrap_or_default();
                 let time = crate::ui::events::format_time(&s.updated_at);
+                let name_part = if s.name.is_empty() {
+                    String::new()
+                } else {
+                    format!("  [{}]", s.name)
+                };
                 eprintln!(
-                    "  {}  {}  {}msgs  {}  {}",
+                    "  {}  {}  {}msgs  {}  {}{}",
                     &s.id[..8],
                     time,
                     s.messages.len(),
                     s.model,
-                    preview
+                    preview,
+                    name_part
                 );
             }
             anyhow::bail!("be more specific with the session ID prefix");
@@ -864,17 +877,23 @@ fn print_sessions() {
                 })
                 .unwrap_or_default();
             let time = crate::ui::events::format_time(&s.updated_at);
+            let name_col = if s.name.is_empty() {
+                String::new()
+            } else {
+                format!("  [{}]", s.name)
+            };
             println!(
-                "  {}  {}  {}msgs  {}  {}",
+                "  {}  {}  {}msgs  {}  {}{}",
                 &s.id[..8],
                 time,
                 s.messages.len(),
                 s.model,
-                last
+                last,
+                name_col
             );
         }
         println!();
-        println!("Use --session <id> to load a session by its ID prefix.");
+        println!("Use --session <id-or-name> to load a session by its ID prefix or name.");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> anyhow::Result<()> {
 
     let name = cli.name.as_deref().unwrap_or("");
     let qm_map = config::quick_models_map(&cfg);
-    let mut session = session::Session::with_name(
+    let mut session = session::Session::new(
         &provider,
         &model,
         cfg.resolve_context_window(&provider, &model, &qm_map),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -164,10 +164,14 @@ impl Session {
     }
 
     pub fn new(provider: &str, model: &str, context_window: u64) -> Self {
+        Self::with_name(provider, model, context_window, "")
+    }
+
+    pub fn with_name(provider: &str, model: &str, context_window: u64, name: &str) -> Self {
         let now = CompactString::new(chrono::Utc::now().to_rfc3339());
         Session {
             id: CompactString::new(Uuid::new_v4().to_string()),
-            name: CompactString::new(""),
+            name: CompactString::new(name),
             messages: Vec::new(),
             compactions: Vec::new(),
             created_at: now.clone(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -163,11 +163,7 @@ impl Session {
         )
     }
 
-    pub fn new(provider: &str, model: &str, context_window: u64) -> Self {
-        Self::with_name(provider, model, context_window, "")
-    }
-
-    pub fn with_name(provider: &str, model: &str, context_window: u64, name: &str) -> Self {
+    pub fn new(provider: &str, model: &str, context_window: u64, name: &str) -> Self {
         let now = CompactString::new(chrono::Utc::now().to_rfc3339());
         Session {
             id: CompactString::new(Uuid::new_v4().to_string()),

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -121,26 +121,50 @@ pub fn find_sessions_by_prefix(prefix: &str) -> anyhow::Result<Vec<Session>> {
     if !dir.exists() {
         return Ok(Vec::new());
     }
+    let lower = prefix.to_lowercase();
     let mut sessions: Vec<Session> = Vec::new();
     for entry in std::fs::read_dir(&dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_some_and(|e| e == "json")
             && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
-            && stem.starts_with(prefix)
             && let Ok(json) = std::fs::read_to_string(&path)
             && let Ok(session) = serde_json::from_str::<Session>(&json)
         {
-            sessions.push(session);
+            if stem.starts_with(prefix) || session.name.to_lowercase().contains(&lower) {
+                sessions.push(session);
+            }
         }
     }
     sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    sessions.dedup_by(|a, b| a.id == b.id);
     tracing::debug!(
         "find_sessions_by_prefix('{}'): {} results",
         prefix,
         sessions.len(),
     );
     Ok(sessions)
+}
+
+pub fn find_session_by_name(name: &str) -> anyhow::Result<Option<Session>> {
+    let dir = session_dir();
+    if !dir.exists() {
+        return Ok(None);
+    }
+    let lower = name.to_lowercase();
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "json")
+            && let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(session) = serde_json::from_str::<Session>(&json)
+        {
+            if session.name.to_lowercase() == lower {
+                return Ok(Some(session));
+            }
+        }
+    }
+    Ok(None)
 }
 
 pub fn find_recent_sessions(limit: usize) -> anyhow::Result<Vec<Session>> {

--- a/src/tests/btw_tests.rs
+++ b/src/tests/btw_tests.rs
@@ -11,7 +11,7 @@ use crate::agent::runner::build_btw_snapshot;
 use crate::session::{MessageRole, Session};
 
 fn sample_session() -> Session {
-    let mut s = Session::new("anthropic", "claude-test", 200_000);
+    let mut s = Session::new("anthropic", "claude-test", 200_000, "");
     s.add_message(MessageRole::User, "hello");
     s.add_message(MessageRole::Assistant, "hi there");
     s

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -40,7 +40,7 @@ fn setup_test_env() -> TestEnv {
 #[test]
 fn save_and_find_session_by_prefix() {
     let env = setup_test_env();
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "hello");
     save_session(&s).unwrap();
 
@@ -62,7 +62,7 @@ fn find_sessions_by_prefix_no_match() {
 #[test]
 fn delete_session_removes_file() {
     let env = setup_test_env();
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     save_session(&s).unwrap();
 
     delete_session(&s.id).unwrap();
@@ -74,7 +74,7 @@ fn delete_session_removes_file() {
 #[test]
 fn save_session_preserves_messages() {
     let env = setup_test_env();
-    let mut s = Session::new("anthropic", "claude", 200000);
+    let mut s = Session::new("anthropic", "claude", 200000, "");
     s.add_message(MessageRole::User, "question");
     s.add_message(MessageRole::Assistant, "answer");
     save_session(&s).unwrap();
@@ -90,7 +90,7 @@ fn save_session_preserves_messages() {
 #[test]
 fn save_session_preserves_tool_messages() {
     let env = setup_test_env();
-    let mut s = Session::new("anthropic", "claude", 200000);
+    let mut s = Session::new("anthropic", "claude", 200000, "");
     s.add_message(MessageRole::User, "question");
     s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
     s.add_tool_result("read", "file contents");
@@ -112,7 +112,7 @@ fn save_session_preserves_tool_messages() {
 #[test]
 fn long_tool_result_is_saved_and_truncated_in_session() {
     let env = setup_test_env();
-    let mut s = Session::new("anthropic", "claude", 200000);
+    let mut s = Session::new("anthropic", "claude", 200000, "");
     let head = "H".repeat(TOOL_RESULT_HEAD_CHARS);
     let omitted = "M"
         .repeat(TOOL_RESULT_SAVE_THRESHOLD - TOOL_RESULT_HEAD_CHARS - TOOL_RESULT_TAIL_CHARS + 1);
@@ -151,7 +151,7 @@ fn long_tool_result_save_failure_keeps_full_output() {
     std::fs::write(&path, b"not a directory").unwrap();
     unsafe { env::set_var("ZS_DATA_DIR", path.to_str().unwrap()) };
 
-    let mut s = Session::new("anthropic", "claude", 200000);
+    let mut s = Session::new("anthropic", "claude", 200000, "");
     let output = "x".repeat(TOOL_RESULT_SAVE_THRESHOLD + 1);
     s.add_tool_result("bash", &output);
 
@@ -165,13 +165,13 @@ fn long_tool_result_save_failure_keeps_full_output() {
 #[test]
 fn find_all_sessions_returns_saved_sessions_newest_first() {
     let env = setup_test_env();
-    let mut older = Session::new("openai", "gpt-4", 128000);
+    let mut older = Session::new("openai", "gpt-4", 128000, "");
     older.updated_at = "2026-01-01T00:00:00Z".into();
     older.add_message(MessageRole::User, "older");
     older.updated_at = "2026-01-01T00:00:00Z".into();
     save_session(&older).unwrap();
 
-    let mut newer = Session::new("anthropic", "claude", 200000);
+    let mut newer = Session::new("anthropic", "claude", 200000, "");
     newer.updated_at = "2026-01-02T00:00:00Z".into();
     newer.add_message(MessageRole::User, "newer");
     newer.updated_at = "2026-01-02T00:00:00Z".into();
@@ -187,7 +187,7 @@ fn find_all_sessions_returns_saved_sessions_newest_first() {
 #[test]
 fn save_session_preserves_cost_fields() {
     let env = setup_test_env();
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.total_input_tokens = 100;
     s.total_output_tokens = 50;
     s.total_cost = 0.003;
@@ -228,7 +228,7 @@ fn save_session_creates_parent_dirs() {
     // Delete sessions dir to verify save_session recreates it
     let sessions_dir = std::path::PathBuf::from(&env.data_dir).join("sessions");
     std::fs::remove_dir_all(&sessions_dir).unwrap();
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     save_session(&s).unwrap();
     let found = find_sessions_by_prefix(&s.id[..8]).unwrap();
     assert_eq!(found.len(), 1);

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -57,14 +57,14 @@ fn estimate_tokens_pure_ascii_matches_old_formula() {
 
 #[test]
 fn effective_context_falls_back_without_calibration() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "hello world this is a test message");
     assert_eq!(s.effective_context_tokens(), s.total_estimated_tokens);
 }
 
 #[test]
 fn effective_context_uses_calibration_anchor_plus_delta() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "first user message");
     s.add_message(MessageRole::Assistant, "assistant reply");
     s.set_calibration(5000, 200); // anchor = 5200, covers 2 messages
@@ -77,7 +77,7 @@ fn effective_context_uses_calibration_anchor_plus_delta() {
 
 #[test]
 fn calibration_ignores_zero_usage() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "msg");
     s.set_calibration(0, 0);
     assert_eq!(s.calibrated_tokens, 0);
@@ -104,7 +104,7 @@ fn real_input_tokens_non_native_uses_input_only() {
 // Helper: a session with `n` ASCII messages of `len` chars each, so every
 // message has a predictable estimated_tokens == len/4.
 fn session_with_messages(n: usize, len: usize) -> Session {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     for _ in 0..n {
         s.add_message(MessageRole::User, &"x".repeat(len));
     }
@@ -143,39 +143,39 @@ fn compaction_cut_single_message_is_kept() {
 
 #[test]
 fn new_session_has_id() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     assert!(!s.id.is_empty());
 }
 
 #[test]
 fn new_session_sets_provider_and_model() {
-    let s = Session::new("anthropic", "claude-sonnet", 200000);
+    let s = Session::new("anthropic", "claude-sonnet", 200000, "");
     assert_eq!(s.provider.as_str(), "anthropic");
     assert_eq!(s.model.as_str(), "claude-sonnet");
 }
 
 #[test]
 fn new_session_sets_context_window() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     assert_eq!(s.context_window, 128000);
 }
 
 #[test]
 fn new_session_sets_working_dir() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     assert!(!s.working_dir.is_empty());
 }
 
 #[test]
 fn new_session_has_timestamps() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     assert!(!s.created_at.is_empty());
     assert!(!s.updated_at.is_empty());
 }
 
 #[test]
 fn new_session_starts_empty() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     assert!(s.messages.is_empty());
     assert!(s.compactions.is_empty());
     assert_eq!(s.total_estimated_tokens, 0);
@@ -186,7 +186,7 @@ fn new_session_starts_empty() {
 
 #[test]
 fn add_message_appends() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "hello");
     assert_eq!(s.messages.len(), 1);
     assert_eq!(s.messages[0].role, MessageRole::User);
@@ -195,7 +195,7 @@ fn add_message_appends() {
 
 #[test]
 fn add_message_increments_estimated_tokens() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     let before = s.total_estimated_tokens;
     s.add_message(MessageRole::Assistant, "hello world, this is a test");
     assert!(s.total_estimated_tokens > before);
@@ -203,7 +203,7 @@ fn add_message_increments_estimated_tokens() {
 
 #[test]
 fn add_message_updates_updated_at() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     let before = s.updated_at.clone();
     // Brief sleep to ensure timestamp changes
     std::thread::sleep(std::time::Duration::from_millis(1));
@@ -213,7 +213,7 @@ fn add_message_updates_updated_at() {
 
 #[test]
 fn needs_compaction_when_over_threshold() {
-    let mut s = Session::new("openai", "gpt-4", 1000);
+    let mut s = Session::new("openai", "gpt-4", 1000, "");
     s.add_message(MessageRole::User, &"x".repeat(900 * 4)); // ~900 tokens
     // With context_window=1000, reserve=200, threshold is 800
     // We have ~900 tokens, so should need compaction
@@ -222,7 +222,7 @@ fn needs_compaction_when_over_threshold() {
 
 #[test]
 fn needs_compaction_when_under_threshold() {
-    let mut s = Session::new("openai", "gpt-4", 1000);
+    let mut s = Session::new("openai", "gpt-4", 1000, "");
     s.add_message(MessageRole::User, "short");
     // Very few tokens, should not need compaction
     assert!(!s.needs_compaction(200));
@@ -230,20 +230,20 @@ fn needs_compaction_when_under_threshold() {
 
 #[test]
 fn needs_compaction_zero_context_window() {
-    let s = Session::new("openai", "gpt-4", 0);
+    let s = Session::new("openai", "gpt-4", 0, "");
     assert!(!s.needs_compaction(200));
 }
 
 #[test]
 fn update_context_window_changes_value() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.update_context_window(256000);
     assert_eq!(s.context_window, 256000);
 }
 
 #[test]
 fn compacted_context_returns_none_without_compactions() {
-    let s = Session::new("openai", "gpt-4", 128000);
+    let s = Session::new("openai", "gpt-4", 128000, "");
     let (summary, index) = s.compacted_context();
     assert!(summary.is_none());
     assert_eq!(index, 0);
@@ -251,7 +251,7 @@ fn compacted_context_returns_none_without_compactions() {
 
 #[test]
 fn compress_adds_compaction_entry() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "msg1");
     s.add_message(MessageRole::Assistant, "msg2");
     s.add_message(MessageRole::User, "msg3");
@@ -265,7 +265,7 @@ fn compress_adds_compaction_entry() {
 
 #[test]
 fn compress_inserts_summary_as_system_message() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "msg1");
     s.add_message(MessageRole::Assistant, "msg2");
     s.add_message(MessageRole::User, "msg3");
@@ -278,7 +278,7 @@ fn compress_inserts_summary_as_system_message() {
 
 #[test]
 fn compress_drains_messages_before_first_kept_index() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "msg1");
     s.add_message(MessageRole::Assistant, "msg2");
     s.add_message(MessageRole::User, "msg3");
@@ -295,7 +295,7 @@ fn compress_drains_messages_before_first_kept_index() {
 
 #[test]
 fn compacted_context_returns_summary_after_compress() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "msg1");
     s.add_message(MessageRole::Assistant, "msg2");
     s.compress("the summary".to_string(), 1, 20);
@@ -342,7 +342,7 @@ fn parse_porcelain_counts_changes_and_sync() {
 
 #[test]
 fn rewind_to_truncates_and_records_restore_point() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "first");
     s.add_message(MessageRole::Assistant, "reply");
     s.add_message(MessageRole::User, "second");
@@ -363,7 +363,7 @@ fn rewind_to_truncates_and_records_restore_point() {
 
 #[test]
 fn rewind_to_at_or_past_end_is_a_noop() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "only");
 
     assert_eq!(s.rewind_to(1), 0);
@@ -374,7 +374,7 @@ fn rewind_to_at_or_past_end_is_a_noop() {
 
 #[test]
 fn redo_restores_the_messages_a_rewind_removed() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "first");
     s.add_message(MessageRole::Assistant, "reply");
     s.add_message(MessageRole::User, "second");
@@ -394,7 +394,7 @@ fn redo_restores_the_messages_a_rewind_removed() {
 
 #[test]
 fn adding_a_message_invalidates_the_redo_point() {
-    let mut s = Session::new("openai", "gpt-4", 128000);
+    let mut s = Session::new("openai", "gpt-4", 128000, "");
     s.add_message(MessageRole::User, "first");
     s.add_message(MessageRole::Assistant, "reply");
     s.add_message(MessageRole::User, "second");

--- a/src/tests/statusline_tests.rs
+++ b/src/tests/statusline_tests.rs
@@ -33,7 +33,7 @@ fn line_text(spans: &[StatusSpan]) -> String {
 
 #[test]
 fn default_statusline_shows_core_items() {
-    let session = Session::new("openrouter", "deepseek/deepseek-v4-pro", 1_048_576);
+    let session = Session::new("openrouter", "deepseek/deepseek-v4-pro", 1_048_576, "");
     let lines = statusline::build_lines(&statusline::default_spec(), &session, &ctx());
     assert_eq!(lines.len(), 1);
     let text = line_text(&lines[0]);
@@ -48,7 +48,7 @@ fn flex_separator_is_preserved() {
             segments: vec![seg("model"), seg("flex_separator"), seg("context_max")],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000);
+    let session = Session::new("openrouter", "m", 1000, "");
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert!(matches!(lines[0][1], StatusSpan::Flex));
 }
@@ -70,7 +70,7 @@ fn skipped_optional_item_drops_adjacent_separator() {
             ],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.total_cost = 0.0;
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert_eq!(
@@ -87,7 +87,7 @@ fn cost_shown_when_always_flag_set() {
             segments: vec![seg("cost")],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.show_cost_always = true;
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert_eq!(line_text(&lines[0]), "$0.0000");
@@ -149,7 +149,7 @@ fn left_right_caps_wrap_the_item() {
             }],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000);
+    let session = Session::new("openrouter", "m", 1000, "");
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert_eq!(lines[0].len(), 3); // left cap, model, right cap
     assert_eq!(line_text(&lines[0]), "\u{e0b6}m\u{e0b4}");
@@ -168,7 +168,7 @@ fn caps_skipped_when_item_is_hidden() {
             }],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000);
+    let session = Session::new("openrouter", "m", 1000, "");
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert!(lines[0].is_empty());
 }
@@ -197,7 +197,7 @@ fn auto_icon_prepends_item_glyph() {
             }],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.git_branch = Some("main".into());
     let lines = statusline::build_lines(&spec, &session, &ctx());
     assert_eq!(line_text(&lines[0]), "\u{e0a0} main");
@@ -214,7 +214,7 @@ fn custom_icon_name_resolves() {
             }],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000);
+    let session = Session::new("openrouter", "m", 1000, "");
     let text = line_text(&statusline::build_lines(&spec, &session, &ctx())[0]);
     assert!(text.starts_with("\u{f07b} "), "{text}");
 }
@@ -232,7 +232,7 @@ fn cwd_full_vs_cwd_folder() {
             segments: vec![seg("cwd"), seg("separator"), seg("cwd_full")],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.working_dir = "/var/lib/zerostack-demo/project".into();
     let lines = statusline::build_lines(&spec, &session, &ctx());
     // cwd = folder name, cwd_full = full path (no $HOME prefix here, unchanged)
@@ -258,7 +258,7 @@ fn always_shows_zero_tokens() {
             }],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000); // total_input_tokens == 0
+    let session = Session::new("openrouter", "m", 1000, ""); // total_input_tokens == 0
     assert!(line_text(&statusline::build_lines(&hidden, &session, &ctx())[0]).is_empty());
     assert_eq!(
         line_text(&statusline::build_lines(&forced, &session, &ctx())[0]),
@@ -279,7 +279,7 @@ fn provider_model_short_message_count() {
             ],
         }],
     };
-    let mut session = Session::new("openrouter", "deepseek/deepseek-v4-pro", 1000);
+    let mut session = Session::new("openrouter", "deepseek/deepseek-v4-pro", 1000, "");
     session.add_message(crate::session::MessageRole::User, "hi");
     let text = line_text(&statusline::build_lines(&spec, &session, &ctx())[0]);
     assert_eq!(text, "openrouter deepseek-v4-pro 1");
@@ -292,7 +292,7 @@ fn reasoning_shows_only_when_enabled() {
             segments: vec![seg("reasoning")],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     assert!(line_text(&statusline::build_lines(&spec, &session, &ctx())[0]).is_empty());
     session.reasoning_enabled = true;
     assert_eq!(
@@ -317,7 +317,7 @@ fn context_percentage_is_not_clamped() {
             segments: vec![seg("context_percentage")],
         }],
     };
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.set_calibration(1100, 0); // 110% of the window
     assert_eq!(
         line_text(&statusline::build_lines(&spec, &session, &ctx())[0]),
@@ -334,7 +334,7 @@ fn context_percentage_color_warns_as_it_fills() {
         }],
     };
     // Green tier keeps the configured (here: default/none) color.
-    let mut session = Session::new("openrouter", "m", 1000);
+    let mut session = Session::new("openrouter", "m", 1000, "");
     session.set_calibration(500, 0); // 50%
     assert_eq!(
         first_fg(&statusline::build_lines(&spec, &session, &ctx())[0]),
@@ -363,7 +363,7 @@ fn session_age_is_short_duration() {
             segments: vec![seg("session_age")],
         }],
     };
-    let session = Session::new("openrouter", "m", 1000); // created_at = now
+    let session = Session::new("openrouter", "m", 1000, ""); // created_at = now
     let text = line_text(&statusline::build_lines(&spec, &session, &ctx())[0]);
     assert!(text.ends_with('s') || text.ends_with('m'), "got {text:?}");
 }

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -29,6 +29,7 @@ const BASE_COMMANDS: &[&str] = &[
     "/quit",
     "/reasoning",
     "/redo",
+    "/rename",
     "/regen-prompts",
     "/regen-themes",
     "/retry",

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -520,8 +520,8 @@ pub async fn handle_slash(
         "/reasoning" | "/thinking" | "/mode" | "/toggle" | "/mcp" | "/editsys" | "/advisor" => {
             settings::handle(&parts, &mut ctx).await
         }
-        "/sessions" | "/clear" | "/new" | "/undo" | "/redo" | "/rewind" | "/retry" | "/quit"
-        | "/exit" | "/history" => session::handle(&parts, &mut ctx).await,
+        "/sessions" | "/rename" | "/clear" | "/new" | "/undo" | "/redo" | "/rewind" | "/retry"
+        | "/quit" | "/exit" | "/history" => session::handle(&parts, &mut ctx).await,
         "/help" => {
             help::handle(&parts, &mut ctx);
             Ok(())

--- a/src/ui/slash/session.rs
+++ b/src/ui/slash/session.rs
@@ -1,11 +1,37 @@
 use std::io::Read;
 
+use compact_str::CompactString;
+
 use crate::ui::events::render_session;
 use crate::ui::slash::{SlashCtx, undo_last, write_error, write_ok, write_result};
+
+fn format_session_line(s: &crate::session::Session) -> String {
+    let last = s
+        .messages
+        .last()
+        .map(|m| format!("...{}", &m.content.chars().take(30).collect::<String>()))
+        .unwrap_or_default();
+    let time = crate::ui::events::format_time(&s.updated_at);
+    let name_part = if s.name.is_empty() {
+        String::new()
+    } else {
+        format!("  [{}]", s.name)
+    };
+    format!(
+        "  {}  {}  {}msgs  {}  {}{}",
+        &s.id[..8],
+        time,
+        s.messages.len(),
+        s.model,
+        last,
+        name_part
+    )
+}
 
 pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     match parts[0] {
         "/sessions" => handle_sessions(parts, ctx).await,
+        "/rename" => handle_rename(parts, ctx).await,
         "/clear" | "/new" => handle_clear(ctx).await,
         "/undo" => handle_undo(ctx).await,
         "/redo" => handle_redo(ctx).await,
@@ -15,6 +41,31 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         "/history" => handle_history(ctx).await,
         _ => Ok(()),
     }
+}
+
+async fn handle_rename(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
+    if parts.len() < 2 || parts[1].is_empty() {
+        if ctx.session.name.is_empty() {
+            write_ok(
+                ctx.renderer,
+                "current session has no name. Usage: /rename <name>",
+            );
+        } else {
+            write_ok(
+                ctx.renderer,
+                format!(
+                    "current session name: \"{}\". Usage: /rename <new-name>",
+                    ctx.session.name
+                ),
+            );
+        }
+        return Ok(());
+    }
+    let new_name = parts[1..].join(" ").trim().to_string();
+    ctx.session.name = CompactString::new(&new_name);
+    crate::session::storage::save_session(ctx.session)?;
+    write_ok(ctx.renderer, format!("session renamed to \"{}\"", new_name));
+    Ok(())
 }
 
 async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
@@ -28,23 +79,7 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
                 format!("recent sessions ({}):", sessions.len()),
             );
             for s in &sessions {
-                let last = s
-                    .messages
-                    .last()
-                    .map(|m| format!("...{}", &m.content.chars().take(30).collect::<String>()))
-                    .unwrap_or_default();
-                let time = crate::ui::events::format_time(&s.updated_at);
-                write_result(
-                    ctx.renderer,
-                    format!(
-                        "  {}  {}  {}msgs  {}  {}",
-                        &s.id[..8],
-                        time,
-                        s.messages.len(),
-                        s.model,
-                        last
-                    ),
-                );
+                write_result(ctx.renderer, format_session_line(s));
             }
         }
     } else if parts[1] == "delete" && parts.len() >= 3 {
@@ -75,23 +110,7 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
                 format!("multiple sessions match '{}', be more specific", prefix),
             );
             for s in &sessions {
-                let last = s
-                    .messages
-                    .last()
-                    .map(|m| format!("...{}", &m.content.chars().take(30).collect::<String>()))
-                    .unwrap_or_default();
-                let time = crate::ui::events::format_time(&s.updated_at);
-                write_result(
-                    ctx.renderer,
-                    format!(
-                        "  {}  {}  {}msgs  {}  {}",
-                        &s.id[..8],
-                        time,
-                        s.messages.len(),
-                        s.model,
-                        last
-                    ),
-                );
+                write_result(ctx.renderer, format_session_line(s));
             }
         }
     } else {
@@ -112,23 +131,7 @@ async fn handle_sessions(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Resu
                 format!("multiple sessions match '{}':", prefix),
             );
             for s in &sessions {
-                let last = s
-                    .messages
-                    .last()
-                    .map(|m| format!("...{}", &m.content.chars().take(30).collect::<String>()))
-                    .unwrap_or_default();
-                let time = crate::ui::events::format_time(&s.updated_at);
-                write_result(
-                    ctx.renderer,
-                    format!(
-                        "  {}  {}  {}msgs  {}  {}",
-                        &s.id[..8],
-                        time,
-                        s.messages.len(),
-                        s.model,
-                        last
-                    ),
-                );
+                write_result(ctx.renderer, format_session_line(s));
             }
         }
     }
@@ -195,8 +198,6 @@ async fn handle_rewind(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
         write_ok(ctx.renderer, "nothing to rewind to");
         return Ok(());
     }
-    // Opens the two-level rewind picker; the event loop performs the rewind once
-    // the user confirms a turn.
     ctx.input.start_rewind_picker(targets);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds named sessions to zerostack.

## Changes

- **`--name <name>`** CLI flag — set a session name at creation
- **`/rename <name>`** slash command — rename the current session in-TUI
- **`--session`** now matches by name (prefix/substring) when ID is ambiguous, plus a separate exact-name recovery path
- Session listings (CLI `--resume` and TUI `/sessions`) show `[name]` for named sessions
- Updated docs: COMMANDS.md, GET_STARTED.md, index.html
- Added `/rename` to the slash command picker

## Usage

```bash
zerostack --name "my-bugfix"          # create named session
zerostack --session my-bugfix          # resume by name
```

```
/rename refactor-auth                  # rename in-TUI
/sessions                              # now shows [name]
```