### PR TITLE
fix(pricing): bake and use direct-API model pricing from models.dev

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -3,12 +3,16 @@
     {
       "id": "claude-haiku-4-5",
       "name": "Claude Haiku 4.5 (latest)",
-      "context": 200000
+      "context": 200000,
+      "input_price": 1,
+      "output_price": 5
     },
     {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
-      "context": 200000
+      "context": 200000,
+      "input_price": 1,
+      "output_price": 5
     },
     {
       "id": "claude-opus-4-0",
@@ -18,12 +22,16 @@
     {
       "id": "claude-opus-4-1",
       "name": "Claude Opus 4.1 (latest)",
-      "context": 200000
+      "context": 200000,
+      "input_price": 15,
+      "output_price": 75
     },
     {
       "id": "claude-opus-4-1-20250805",
       "name": "Claude Opus 4.1",
-      "context": 200000
+      "context": 200000,
+      "input_price": 15,
+      "output_price": 75
     },
     {
       "id": "claude-opus-4-20250514",
@@ -33,27 +41,37 @@
     {
       "id": "claude-opus-4-5",
       "name": "Claude Opus 4.5 (latest)",
-      "context": 200000
+      "context": 200000,
+      "input_price": 5,
+      "output_price": 25
     },
     {
       "id": "claude-opus-4-5-20251101",
       "name": "Claude Opus 4.5",
-      "context": 200000
+      "context": 200000,
+      "input_price": 5,
+      "output_price": 25
     },
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "context": 1000000
+      "context": 1000000,
+      "input_price": 5,
+      "output_price": 25
     },
     {
       "id": "claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "context": 1000000
+      "context": 1000000,
+      "input_price": 5,
+      "output_price": 25
     },
     {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "context": 1000000
+      "context": 1000000,
+      "input_price": 5,
+      "output_price": 25
     },
     {
       "id": "claude-sonnet-4-0",
@@ -68,199 +86,277 @@
     {
       "id": "claude-sonnet-4-5",
       "name": "Claude Sonnet 4.5 (latest)",
-      "context": 200000
+      "context": 200000,
+      "input_price": 3,
+      "output_price": 15
     },
     {
       "id": "claude-sonnet-4-5-20250929",
       "name": "Claude Sonnet 4.5",
-      "context": 200000
+      "context": 200000,
+      "input_price": 3,
+      "output_price": 15
     },
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "context": 1000000
+      "context": 1000000,
+      "input_price": 3,
+      "output_price": 15
     }
   ],
   "openai": [
     {
       "id": "gpt-3.5-turbo",
       "name": "GPT-3.5-turbo",
-      "context": 16385
+      "context": 16385,
+      "input_price": 0.5,
+      "output_price": 1.5
     },
     {
       "id": "gpt-4",
       "name": "GPT-4",
-      "context": 8192
+      "context": 8192,
+      "input_price": 30,
+      "output_price": 60
     },
     {
       "id": "gpt-4-turbo",
       "name": "GPT-4 Turbo",
-      "context": 128000
+      "context": 128000,
+      "input_price": 10,
+      "output_price": 30
     },
     {
       "id": "gpt-4.1",
       "name": "GPT-4.1",
-      "context": 1047576
+      "context": 1047576,
+      "input_price": 2,
+      "output_price": 8
     },
     {
       "id": "gpt-4.1-mini",
       "name": "GPT-4.1 mini",
-      "context": 1047576
+      "context": 1047576,
+      "input_price": 0.4,
+      "output_price": 1.6
     },
     {
       "id": "gpt-4.1-nano",
       "name": "GPT-4.1 nano",
-      "context": 1047576
+      "context": 1047576,
+      "input_price": 0.1,
+      "output_price": 0.4
     },
     {
       "id": "gpt-4o",
       "name": "GPT-4o",
-      "context": 128000
+      "context": 128000,
+      "input_price": 2.5,
+      "output_price": 10
     },
     {
       "id": "gpt-4o-2024-05-13",
       "name": "GPT-4o (2024-05-13)",
-      "context": 128000
+      "context": 128000,
+      "input_price": 5,
+      "output_price": 15
     },
     {
       "id": "gpt-4o-2024-08-06",
       "name": "GPT-4o (2024-08-06)",
-      "context": 128000
+      "context": 128000,
+      "input_price": 2.5,
+      "output_price": 10
     },
     {
       "id": "gpt-4o-2024-11-20",
       "name": "GPT-4o (2024-11-20)",
-      "context": 128000
+      "context": 128000,
+      "input_price": 2.5,
+      "output_price": 10
     },
     {
       "id": "gpt-4o-mini",
       "name": "GPT-4o mini",
-      "context": 128000
+      "context": 128000,
+      "input_price": 0.15,
+      "output_price": 0.6
     },
     {
       "id": "gpt-5",
       "name": "GPT-5",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5-chat-latest",
       "name": "GPT-5 Chat (latest)",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5-codex",
       "name": "GPT-5-Codex",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5-mini",
       "name": "GPT-5 Mini",
-      "context": 400000
+      "context": 400000,
+      "input_price": 0.25,
+      "output_price": 2
     },
     {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
-      "context": 400000
+      "context": 400000,
+      "input_price": 0.05,
+      "output_price": 0.4
     },
     {
       "id": "gpt-5-pro",
       "name": "GPT-5 Pro",
-      "context": 400000
+      "context": 400000,
+      "input_price": 15,
+      "output_price": 120
     },
     {
       "id": "gpt-5.1",
       "name": "GPT-5.1",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5.1-chat-latest",
       "name": "GPT-5.1 Chat",
-      "context": 128000
+      "context": 128000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5.1-codex",
       "name": "GPT-5.1 Codex",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5.1-codex-max",
       "name": "GPT-5.1 Codex Max",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gpt-5.1-codex-mini",
       "name": "GPT-5.1 Codex mini",
-      "context": 400000
+      "context": 400000,
+      "input_price": 0.25,
+      "output_price": 2
     },
     {
       "id": "gpt-5.2",
       "name": "GPT-5.2",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.2-chat-latest",
       "name": "GPT-5.2 Chat",
-      "context": 128000
+      "context": 128000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.2-codex",
       "name": "GPT-5.2 Codex",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.2-pro",
       "name": "GPT-5.2 Pro",
-      "context": 400000
+      "context": 400000,
+      "input_price": 21,
+      "output_price": 168
     },
     {
       "id": "gpt-5.3-chat-latest",
       "name": "GPT-5.3 Chat (latest)",
-      "context": 128000
+      "context": 128000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.3-codex",
       "name": "GPT-5.3 Codex",
-      "context": 400000
+      "context": 400000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.3-codex-spark",
       "name": "GPT-5.3 Codex Spark",
-      "context": 128000
+      "context": 128000,
+      "input_price": 1.75,
+      "output_price": 14
     },
     {
       "id": "gpt-5.4",
       "name": "GPT-5.4",
-      "context": 1050000
+      "context": 1050000,
+      "input_price": 2.5,
+      "output_price": 15
     },
     {
       "id": "gpt-5.4-mini",
       "name": "GPT-5.4 mini",
-      "context": 400000
+      "context": 400000,
+      "input_price": 0.75,
+      "output_price": 4.5
     },
     {
       "id": "gpt-5.4-nano",
       "name": "GPT-5.4 nano",
-      "context": 400000
+      "context": 400000,
+      "input_price": 0.2,
+      "output_price": 1.25
     },
     {
       "id": "gpt-5.4-pro",
       "name": "GPT-5.4 Pro",
-      "context": 1050000
+      "context": 1050000,
+      "input_price": 30,
+      "output_price": 180
     },
     {
       "id": "gpt-5.5",
       "name": "GPT-5.5",
-      "context": 1050000
+      "context": 1050000,
+      "input_price": 5,
+      "output_price": 30
     },
     {
       "id": "gpt-5.5-pro",
       "name": "GPT-5.5 Pro",
-      "context": 1050000
+      "context": 1050000,
+      "input_price": 30,
+      "output_price": 180
     },
     {
       "id": "o1",
       "name": "o1",
-      "context": 200000
+      "context": 200000,
+      "input_price": 15,
+      "output_price": 60
     },
     {
       "id": "o1-mini",
@@ -275,119 +371,165 @@
     {
       "id": "o1-pro",
       "name": "o1-pro",
-      "context": 200000
+      "context": 200000,
+      "input_price": 150,
+      "output_price": 600
     },
     {
       "id": "o3",
       "name": "o3",
-      "context": 200000
+      "context": 200000,
+      "input_price": 2,
+      "output_price": 8
     },
     {
       "id": "o3-deep-research",
       "name": "o3-deep-research",
-      "context": 200000
+      "context": 200000,
+      "input_price": 10,
+      "output_price": 40
     },
     {
       "id": "o3-mini",
       "name": "o3-mini",
-      "context": 200000
+      "context": 200000,
+      "input_price": 1.1,
+      "output_price": 4.4
     },
     {
       "id": "o3-pro",
       "name": "o3-pro",
-      "context": 200000
+      "context": 200000,
+      "input_price": 20,
+      "output_price": 80
     },
     {
       "id": "o4-mini",
       "name": "o4-mini",
-      "context": 200000
+      "context": 200000,
+      "input_price": 1.1,
+      "output_price": 4.4
     },
     {
       "id": "o4-mini-deep-research",
       "name": "o4-mini-deep-research",
-      "context": 200000
+      "context": 200000,
+      "input_price": 2,
+      "output_price": 8
     }
   ],
   "gemini": [
     {
       "id": "gemini-2.0-flash",
       "name": "Gemini 2.0 Flash",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.1,
+      "output_price": 0.4
     },
     {
       "id": "gemini-2.0-flash-lite",
       "name": "Gemini 2.0 Flash-Lite",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.075,
+      "output_price": 0.3
     },
     {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.3,
+      "output_price": 2.5
     },
     {
       "id": "gemini-2.5-flash-image",
       "name": "Nano Banana",
-      "context": 32768
+      "context": 32768,
+      "input_price": 0.3,
+      "output_price": 30
     },
     {
       "id": "gemini-2.5-flash-lite",
       "name": "Gemini 2.5 Flash-Lite",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.1,
+      "output_price": 0.4
     },
     {
       "id": "gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 1.25,
+      "output_price": 10
     },
     {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash Preview",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.5,
+      "output_price": 3
     },
     {
       "id": "gemini-3-pro-preview",
       "name": "Gemini 3 Pro Preview",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 2,
+      "output_price": 12
     },
     {
       "id": "gemini-3.1-flash-image-preview",
       "name": "Nano Banana 2",
-      "context": 65536
+      "context": 65536,
+      "input_price": 0.5,
+      "output_price": 60
     },
     {
       "id": "gemini-3.1-flash-lite",
       "name": "Gemini 3.1 Flash Lite",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.25,
+      "output_price": 1.5
     },
     {
       "id": "gemini-3.1-flash-lite-preview",
       "name": "Gemini 3.1 Flash Lite Preview",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.25,
+      "output_price": 1.5
     },
     {
       "id": "gemini-3.1-pro-preview",
       "name": "Gemini 3.1 Pro Preview",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 2,
+      "output_price": 12
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
       "name": "Gemini 3.1 Pro Preview Custom Tools",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 2,
+      "output_price": 12
     },
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 1.5,
+      "output_price": 9
     },
     {
       "id": "gemini-flash-latest",
       "name": "Gemini Flash Latest",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.3,
+      "output_price": 2.5
     },
     {
       "id": "gemini-flash-lite-latest",
       "name": "Gemini Flash-Lite Latest",
-      "context": 1048576
+      "context": 1048576,
+      "input_price": 0.1,
+      "output_price": 0.4
     },
     {
       "id": "gemma-4-26b-a4b-it",

--- a/scripts/gen-models-catalog.sh
+++ b/scripts/gen-models-catalog.sh
@@ -42,6 +42,13 @@ api="$(curl -fsSL --max-time 120 "$SRC")"
 
 # jq program:
 #  - `entry`  : project a models.dev model into our compact {id,name,context}.
+#  - `priced_entry` : `entry` plus input_price/output_price (USD per million
+#               tokens) straight from models.dev's `cost.input`/`cost.output`,
+#               when present. Used for the direct-API providers (anthropic,
+#               openai, gemini), which have no other source of pricing at
+#               runtime. OpenRouter keeps plain `entry`: it has its own live
+#               pricing fetch (`fetch_openrouter_pricing`), and models.dev's
+#               marketplace-wide OpenRouter cost data is less reliable.
 #  - `denied` : drop non-chat models (embeddings/audio/image/etc.) by id substring,
 #               mirroring crate::provider::is_agent_model's denylist, and keep only
 #               models that can output text.
@@ -60,11 +67,15 @@ echo "$api" | jq --argjson orv "$OPENROUTER_VENDORS" --argjson cut "$CUTOFFS" '
     | select((.key | ascii_downcase) as $id | (deny | any(. as $d | $id | contains($d))) | not)
     | recent($c);
   def entry: {id: .value.id, name: .value.name, context: (.value.limit.context // null)};
-  def models_of($p; $c): ($p.models // {}) | to_entries | map(chat($c) | entry) | sort_by(.id);
+  def priced_entry: entry + {
+    input_price: (.value.cost.input // null),
+    output_price: (.value.cost.output // null)
+  };
+  def models_of($p; $c; e): ($p.models // {}) | to_entries | map(chat($c) | e) | sort_by(.id);
   {
-    anthropic:  models_of(.anthropic; ($cut.anthropic  // "0000-00-00")),
-    openai:     models_of(.openai;    ($cut.openai     // "0000-00-00")),
-    gemini:     models_of(.google;    ($cut.gemini     // "0000-00-00")),
+    anthropic:  models_of(.anthropic; ($cut.anthropic  // "0000-00-00"); priced_entry),
+    openai:     models_of(.openai;    ($cut.openai     // "0000-00-00"); priced_entry),
+    gemini:     models_of(.google;    ($cut.gemini     // "0000-00-00"); priced_entry),
     openrouter: (
       (.openrouter.models // {})
       | to_entries

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -272,6 +272,18 @@ impl Config {
             .map(|cl| cl as u64)
     }
 
+    /// The model's input/output cost (USD per million tokens) straight from
+    /// the static catalog, or `None` when the provider/model isn't listed or
+    /// carries no baked-in pricing (e.g. OpenRouter, which prices live via
+    /// `fetch_openrouter_pricing` instead).
+    pub fn catalog_input_output_cost(provider: &str, model_id: &str) -> Option<(f64, f64)> {
+        let entries = crate::models_catalog::catalog_entries(provider)?;
+        entries
+            .iter()
+            .find(|e| e.id == model_id)
+            .and_then(|e| e.input_price.zip(e.output_price))
+    }
+
     pub fn resolve_reserve_tokens(
         &self,
         model_id: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,11 @@ async fn main() -> anyhow::Result<()> {
     {
         session.input_token_cost = qm.input_token_cost;
         session.output_token_cost = qm.output_token_cost;
+    } else if let Some((input_cost, output_cost)) =
+        config::Config::catalog_input_output_cost(&provider, &model)
+    {
+        session.input_token_cost = input_cost;
+        session.output_token_cost = output_cost;
     }
 
     if cli.continue_session


### PR DESCRIPTION
## Summary
- Anthropic/OpenAI/Gemini models never got `input_token_cost`/`output_token_cost` seeded at startup unless the user had a matching `quick_model` entry, so `total_cost` stayed $0.0 for a plain `--provider`/`--model` invocation (in both TUI and headless mode). 
- models.dev's api.json already carries `cost.input`/`cost.output` for these providers, in the same USD-per-million-tokens unit `pricing::estimate_cost` expects, `gen-models-catalog.sh` just wasn't capturing it.
- Adds `input_price`/`output_price` to existing `data/models.json` entries onlyc(no model list churn), and a new `Config::catalog_input_output_cost` read at startup, mirroring the existing `catalog_context_window` fallback.

## Test plan
- [x] `cargo test --release` — 579 passed