### PR TITLE
feat(headless): connect configured MCP servers in -p and --loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,25 @@ fn apply_startup_prompt_model(
     ));
 }
 
+/// Connect configured MCP servers for a headless (`-p`/`--loop`) run. Unlike
+/// the TUI (`ui::ensure_mcp_manager`), headless has no alt-screen to protect,
+/// so connection failures are printed to stderr instead of staying silent
+/// until surfaced by the renderer.
+#[cfg(feature = "mcp")]
+async fn connect_headless_mcp(
+    cfg: &config::Config,
+) -> Option<crate::extras::mcp::McpClientManager> {
+    let servers = cfg.mcp_servers.as_ref()?;
+    if servers.is_empty() {
+        return None;
+    }
+    let manager = crate::extras::mcp::McpClientManager::connect_all(servers).await;
+    for notice in &manager.notices {
+        eprintln!("{}", notice);
+    }
+    Some(manager)
+}
+
 #[cfg_attr(
     feature = "multithread",
     tokio::main(flavor = "multi_thread", worker_threads = 4)
@@ -723,6 +742,8 @@ async fn main() -> anyhow::Result<()> {
         } else {
             let temperature = config::resolve_temperature(&cli, &cfg, &model);
             let extra_body = config::resolve_extra_body(&cfg, &model);
+            #[cfg(feature = "mcp")]
+            let mcp_manager = connect_headless_mcp(&cfg).await;
             let agent = provider::build_agent(
                 completion_model,
                 &cli,
@@ -735,7 +756,7 @@ async fn main() -> anyhow::Result<()> {
                 temperature,
                 extra_body,
                 #[cfg(feature = "mcp")]
-                None,
+                mcp_manager.as_ref(),
             )
             .await;
             #[cfg(feature = "advisor")]
@@ -780,6 +801,8 @@ async fn main() -> anyhow::Result<()> {
             let model_completion = client.completion_model(model.to_string());
             let temperature = config::resolve_temperature(&cli, &cfg, &model);
             let extra_body = config::resolve_extra_body(&cfg, &model);
+            #[cfg(feature = "mcp")]
+            let mcp_manager = connect_headless_mcp(&cfg).await;
             let agent = provider::build_agent(
                 model_completion,
                 &cli,
@@ -792,7 +815,7 @@ async fn main() -> anyhow::Result<()> {
                 temperature,
                 extra_body,
                 #[cfg(feature = "mcp")]
-                None,
+                mcp_manager.as_ref(),
             )
             .await;
             return run_headless_loop(agent, &cli, &cfg, &context, status_signals).await;


### PR DESCRIPTION
## Summary
- Configured MCP servers were dead in headless mode: the client manager was only ever connected by the interactive TUI, so `-p`/`--loop` always built their agent with no MCP tools available, regardless of config. This blocked any scripted/CI use of MCP tools.
- Adds a headless connection helper, mirroring the TUI's lazy-connect behavior but printing connection notices to stderr instead of queuing them for the renderer (headless has no alt-screen to protect).
- Called in both the `-p` and `--loop` branches before the agent is built. The manager is a local binding scoped to cover the whole run, so it drops normally on exit and the underlying child processes get reaped.

## Test plan
- [x] `cargo test --release` — all passing
- [x] `cargo build --release` with the `mcp` feature disabled — compiles cleanly, confirming the feature gating
- [x] A local dependency-free mock stdio MCP server connects successfully in a `-p` run, its tool is called, and the tool's result reaches the model's final answer
- [x] A misconfigured server (an invalid command) prints a notice to stderr and the prompt still gets answered normally
- [x] No leaked child processes after the run exits