### PR TITLE
fix(headless): honor --pure-stdout in --loop mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1155,7 +1155,7 @@ async fn run_headless_loop(
             .run_print(
                 &iteration_prompt,
                 cli.resolve_max_agent_turns(cfg),
-                false,
+                cli.pure_stdout,
                 &cfg.retry,
             )
             .await


### PR DESCRIPTION
## Summary
- `run_headless_loop` called `agent.run_print(..., false, ...)`, hardcoding `pure_stdout` regardless of the `--pure-stdout` flag, so tool-call markers (`◈ <tool> ...`) — the only channel that carries tool calls in headless mode — were never emitted in `--loop` runs.
- Pass `cli.pure_stdout` through instead, matching the existing `-p` branch behavior.

## Test plan
- [x] `cargo build --release`
- [x] `zerostack --loop --pure-stdout ...` and confirm `◈ <tool>` markers appear in stdout for tool calls made during loop iterations