### PR TITLE
fix(pricing): price Anthropic cache tokens so cost isn't undercounted

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -103,6 +103,8 @@ where
                             response,
                             input_tokens: usage.input_tokens,
                             output_tokens: usage.output_tokens,
+                            cached_input_tokens: usage.cached_input_tokens,
+                            cache_creation_input_tokens: usage.cache_creation_input_tokens,
                         })
                         .await;
                     return;

--- a/src/event.rs
+++ b/src/event.rs
@@ -51,6 +51,8 @@ pub enum BtwEvent {
         response: CompactString,
         input_tokens: u64,
         output_tokens: u64,
+        cached_input_tokens: u64,
+        cache_creation_input_tokens: u64,
     },
     Error {
         id: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -818,7 +818,12 @@ async fn main() -> anyhow::Result<()> {
                     .total_cache_creation_input_tokens
                     .saturating_add(usage.cache_creation_input_tokens);
                 session.total_cost += crate::pricing::estimate_cost(
-                    usage.input_tokens,
+                    crate::pricing::billable_input_tokens(
+                        cfg.is_anthropic_native(&session.provider),
+                        usage.input_tokens,
+                        usage.cached_input_tokens,
+                        usage.cache_creation_input_tokens,
+                    ),
                     usage.output_tokens,
                     session.input_token_cost,
                     session.output_token_cost,

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -1,5 +1,53 @@
+/// Anthropic prompt-cache billing multipliers, relative to the base input rate.
+/// Anthropic bills cache *writes* (`cache_creation_input_tokens`) at 1.25× and
+/// cache *reads* (`cached_input_tokens`) at 0.10× the base input token price.
+/// These ratios are fixed across Anthropic models, so we keep them as constants
+/// rather than carrying per-model cache rates in the catalog (`data/models.json`
+/// only has base input/output prices). WRITE assumes the default 5-minute cache
+/// TTL; the 1-hour TTL bills writes at 2.0× — revisit if that is ever enabled
+/// (see `provider.rs`'s `.with_prompt_caching()`).
+const ANTHROPIC_CACHE_WRITE_MULT: f64 = 1.25;
+const ANTHROPIC_CACHE_READ_MULT: f64 = 0.10;
+
+/// Effective (billable) input-token count, folding Anthropic's cache tiers into
+/// a single number priced at the base input rate. The cost-side sibling of
+/// [`Session::real_input_tokens`](crate::session::Session::real_input_tokens):
+/// where that one answers "how big is the context" (for compaction), this
+/// answers "how much input do we pay for".
+///
+/// Anthropic's reported `input_tokens` *excludes* both cached and cache-creation
+/// tokens, but both are billed — reads at 0.10× and writes at 1.25× — so pricing
+/// on raw `input_tokens` alone undercounts massively whenever caching is active
+/// (the fixed request prefix — tool defs + system prompt — is re-sent every turn
+/// and lands almost entirely in the cache tiers). Every other provider folds the
+/// cached subset into `input_tokens` and reports no separate cache-creation, so
+/// this is a no-op for them.
+///
+/// `anthropic_native` must be the resolved protocol route — compute it with
+/// [`Config::is_anthropic_native`](crate::config::Config::is_anthropic_native),
+/// exactly as `real_input_tokens` callers do.
+pub fn billable_input_tokens(
+    anthropic_native: bool,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+) -> u64 {
+    if anthropic_native {
+        (input_tokens as f64
+            + cache_creation_input_tokens as f64 * ANTHROPIC_CACHE_WRITE_MULT
+            + cached_input_tokens as f64 * ANTHROPIC_CACHE_READ_MULT)
+            .round() as u64
+    } else {
+        input_tokens
+    }
+}
+
 /// Estimate cost for given token counts and per-million-token prices.
 /// Returns 0.0 if either price is 0.0.
+///
+/// `input_tokens` is the *billable* input count — for Anthropic routes, pass the
+/// output of [`billable_input_tokens`] so cache reads/writes are priced, not the
+/// raw provider-reported `input_tokens` (which excludes both cache tiers).
 pub fn estimate_cost(
     input_tokens: u64,
     output_tokens: u64,

--- a/src/tests/session_tests.rs
+++ b/src/tests/session_tests.rs
@@ -101,6 +101,27 @@ fn real_input_tokens_non_native_uses_input_only() {
     assert_eq!(Session::real_input_tokens(false, 7000, 5600, 0), 7000);
 }
 
+#[test]
+fn billable_input_tokens_native_prices_cache_tiers() {
+    use crate::pricing::billable_input_tokens;
+    // Cost sibling of real_input_tokens: Anthropic bills cache writes at 1.25×
+    // and cache reads at 0.10× the base input rate, on top of raw input_tokens.
+    // write only: 100 + 6000*1.25 = 7600
+    assert_eq!(billable_input_tokens(true, 100, 0, 6000), 7600);
+    // read only: 100 + 7000*0.10 = 800
+    assert_eq!(billable_input_tokens(true, 100, 7000, 0), 800);
+    // both, with rounding: 4 + 6003*0.10 + 6089*1.25 = 4 + 600.3 + 7611.25 = 8215.55 -> 8216
+    assert_eq!(billable_input_tokens(true, 4, 6003, 6089), 8216);
+}
+
+#[test]
+fn billable_input_tokens_non_native_uses_input_only() {
+    use crate::pricing::billable_input_tokens;
+    // Non-Anthropic providers have no separate cache tiers to price — input_tokens
+    // is already the full billable amount, so the cache fields are ignored.
+    assert_eq!(billable_input_tokens(false, 7000, 5600, 4000), 7000);
+}
+
 // Helper: a session with `n` ASCII messages of `len` chars each, so every
 // message has a predictable estimated_tokens == len/4.
 fn session_with_messages(n: usize, len: usize) -> Session {

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -352,7 +352,12 @@ pub async fn handle_agent_event(
             session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
             session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
             session.total_cost += crate::pricing::estimate_cost(
-                input_tokens,
+                crate::pricing::billable_input_tokens(
+                    cfg.is_anthropic_native(&session.provider),
+                    input_tokens,
+                    cached_input_tokens,
+                    cache_creation_input_tokens,
+                ),
                 output_tokens,
                 session.input_token_cost,
                 session.output_token_cost,
@@ -447,12 +452,19 @@ async fn handle_agent_done(
     renderer.write_line("", Color::White)?;
     renderer.write_line("", Color::White)?;
     session.add_message(MessageRole::Assistant, &response);
-    // Cost tracking uses the raw reported `input_tokens` (for Anthropic this is
-    // the billed uncached portion; cache reads are billed separately/cheaper).
+    // `total_input_tokens`/`total_output_tokens` keep the raw provider-reported
+    // counts (that's what those fields mean), but cost prices the *billable*
+    // input — for Anthropic that folds in cache reads/writes, which the raw
+    // `input_tokens` excludes yet are still billed (see `billable_input_tokens`).
     session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
     session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
     session.total_cost += crate::pricing::estimate_cost(
-        input_tokens,
+        crate::pricing::billable_input_tokens(
+            cfg.is_anthropic_native(&session.provider),
+            input_tokens,
+            cached_input_tokens,
+            cache_creation_input_tokens,
+        ),
         output_tokens,
         session.input_token_cost,
         session.output_token_cost,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2387,9 +2387,13 @@ pub async fn run_interactive(
                 // Parallel side-question result. Rendered as a single block; it is
                 // NEVER written to the session (cost is tracked separately).
                 match bev {
-                    crate::event::BtwEvent::Done { id, response, input_tokens, output_tokens } => {
+                    crate::event::BtwEvent::Done { id, response, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens } => {
                         btw_total_cost += crate::pricing::estimate_cost(
-                            input_tokens, output_tokens,
+                            crate::pricing::billable_input_tokens(
+                                cfg.is_anthropic_native(&session.provider),
+                                input_tokens, cached_input_tokens, cache_creation_input_tokens,
+                            ),
+                            output_tokens,
                             session.input_token_cost, session.output_token_cost,
                         );
                         btw_total_in = btw_total_in.saturating_add(input_tokens);


### PR DESCRIPTION
## TL;DR
With prompt caching enabled, Anthropic reports `input_tokens` **excluding** both cache tiers (`cached_input_tokens`, `cache_creation_input_tokens`), but both are billed (reads at 0.10×, writes at 1.25× the base input rate).
Cost was priced on raw `input_tokens` only, so `session.total_cost` undercounted spend by ~15–20×.
Dashboard-confirmed: a run reported **$0.0052** while actually costing **$0.10**. 
This is the cost-side sibling of #122 same cache quirk, other half of the fix.

## Root cause
1. We enable prompt caching for the Anthropic-native route (`provider.rs`: `with_prompt_caching()`), and the fixed request prefix (tool defs + system prompt) is re-sent every turn, landing almost entirely in the cache tiers.
2. `pricing::estimate_cost` takes only `input_tokens` + `output_tokens` and two rates ,it has no notion of cache tiers, and the catalog (`data/models.json`, models.dev) carries only base input/output prices, no cache rates.
3. #122 already hit this quirk and split accounting into **context** (cache-inclusive, via `real_input_tokens`) vs **cost** (left on raw `input_tokens`, reasoning "cache reads are billed separately"). That comment was mis-read as "not ours to price": #122 fixed the context half, cost kept undercounting.

## The fix
- **`pricing::billable_input_tokens(anthropic_native, input, cached, cache_creation)`** (`pricing.rs`) — the cost sibling of `Session::real_input_tokens`. Folds the cache tiers into an effective input-token count at fixed Anthropic multipliers (write 1.25×, read 0.10×), gated by the same `is_anthropic_native` route check; returns `input_tokens` unchanged for other providers. `estimate_cost` stays provider-agnostic, call sites just wrap their input. Multipliers are constants, so no per-model cache rates are needed.
- Applied at all three `session.total_cost` accumulators: headless `-p` (`main.rs`), TUI intermediate `CompletionCall` and final `handle_agent_done` (`event_handler.rs`).
- **`/btw` cost counter** was doubly wrong (raw formula, and `BtwEvent::Done` dropped the cache fields at the source though `res.usage()` carries them). Threaded the two fields through `BtwEvent::Done` + `spawn_btw` and applied the same helper. Display-only status-line value, never persisted.
- **Caveat:** the 1.25× write multiplier assumes the default 5-minute cache TTL (what zerostack uses); the 1-hour TTL bills writes at 2.0× (noted in `pricing.rs`).

## Test report
### 1. Automated tests
- `cargo build --release`: clean.
- `cargo test billable_input_tokens`: 2 new unit tests pass, sitting beside #122's `real_input_tokens` tests in `session_tests.rs` (native route prices both tiers incl. the exact reconciliation case; non-native ignores cache fields).

### 2. Live verification
- A headless `-p` run's persisted `total_cost` now matches an independent cache-inclusive recompute **to the cent** ($0.020256), 15.7× the old buggy value, and the earlier $0.10 reconciliation matches the Anthropic dashboard exactly.