### PR TITLE
fix: mouse text selection broken by missing bottom-alignment padding

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -232,11 +232,13 @@ impl Renderer {
         }
 
         let auto_scroll = self.scroll_offset == 0;
-        if auto_scroll && total < visible {
-            let pad = visible - total;
-            if (row as usize) < pad {
-                return None;
-            }
+        let pad = if auto_scroll && total < visible {
+            visible - total
+        } else {
+            0
+        };
+        if (row as usize) < pad {
+            return None;
         }
 
         let start = if auto_scroll {
@@ -246,7 +248,7 @@ impl Renderer {
         };
         let start = start.min(total.saturating_sub(visible));
 
-        let mut visual_row: u16 = 0;
+        let mut visual_row: u16 = pad as u16;
         let mut buf_idx = start;
 
         while buf_idx < total {


### PR DESCRIPTION
## Problem
Click-and-drag text selection in the chat viewport was broken — clicks on the content area returned \`None\` from \`buffer_line_at_row()\`, so no selection was ever started.

## Root Cause
\`buffer_line_at_row()\` started \`visual_row\` at 0, but the viewport renders padding rows at the top before actual content when auto-scrolled and content is shorter than the viewport (bottom-alignment). This meant clicks in the content area were off by \`pad\` rows.

## Fix
Start \`visual_row\` at \`pad\` (instead of 0) to match the rendering offset. Also hoisted the \`pad\` computation so it's available for both the early-return guard and the \`visual_row\` initial value.