### PR TITLE
feat: clickable hyperlinks in chat output

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1124,10 +1124,14 @@ pub async fn run_interactive(
                             refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
                         } else if row < renderer.visible_lines() as u16
                             && let Some(idx) = renderer.buffer_line_at_row(row) {
-                                renderer.selection_active = true;
-                                renderer.selection_start = Some(idx);
-                                renderer.selection_end = Some(idx);
-                                refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                                if let Some(url) = renderer.link_url_at(idx, col) {
+                                    renderer::open_url(url);
+                                } else {
+                                    renderer.selection_active = true;
+                                    renderer.selection_start = Some(idx);
+                                    renderer.selection_end = Some(idx);
+                                    refresh_display(&mut renderer, &mut input, session, is_running, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), chain_label_msg.as_deref(), btw_total_cost, btw_total_in, btw_total_out)?;
+                                }
                             }
                         continue;
                     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::sync::LazyLock;
 
 use compact_str::CompactString;
 use crossterm::ExecutableCommand;
@@ -7,11 +8,31 @@ use crossterm::style::{
     Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
 };
 use crossterm::terminal::{Clear, ClearType, ScrollUp};
+use regex::Regex;
 use smallvec::{SmallVec, smallvec};
 
 use super::markdown::word_wrap;
 use super::statusline::StatusSpan;
 use super::utils::{char_display_width, display_width, resolve_color};
+
+static URL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"https?://[^\x00-\x1f\x7f\s<>]+").expect("compile URL regex"));
+
+fn wrap_urls_osc8(text: &str) -> String {
+    let mut result = String::with_capacity(text.len() + 64);
+    let mut last = 0;
+    for m in URL_RE.find_iter(text) {
+        result.push_str(&text[last..m.start()]);
+        result.push_str("\x1b]8;;");
+        result.push_str(m.as_str());
+        result.push_str("\x1b\\");
+        result.push_str(m.as_str());
+        result.push_str("\x1b]8;;\x1b\\");
+        last = m.end();
+    }
+    result.push_str(&text[last..]);
+    result
+}
 
 #[derive(Clone)]
 pub struct LineEntry {
@@ -276,6 +297,21 @@ impl Renderer {
         self.selection_end = None;
     }
 
+    pub fn link_url_at(&self, buf_idx: usize, col: u16) -> Option<&str> {
+        let entry = self.buffer.get(buf_idx)?;
+        let text: &str = &entry.text;
+        let click_col = col.saturating_sub(self.chat_margin) as usize;
+        for m in URL_RE.find_iter(text) {
+            let prefix = &text[..m.start()];
+            let url_start = display_width(prefix);
+            let url_end = url_start + display_width(m.as_str());
+            if click_col >= url_start && click_col < url_end {
+                return Some(m.as_str());
+            }
+        }
+        None
+    }
+
     pub fn selected_text(&self) -> Option<String> {
         let (start, end) = match (self.selection_start, self.selection_end) {
             (Some(s), Some(e)) if s <= e => (s, e),
@@ -499,7 +535,7 @@ impl Renderer {
                     write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
                 }
                 write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
-                write!(stdout, "{}", chunk)?;
+                write!(stdout, "{}", wrap_urls_osc8(chunk))?;
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
                 }
@@ -712,7 +748,7 @@ impl Renderer {
                             write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
                         }
                         write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
-                        write!(stdout, "{}", chunk)?;
+                        write!(stdout, "{}", wrap_urls_osc8(&chunk))?;
                         write!(stdout, "{}", ResetColor)?;
 
                         self.col = self.col.saturating_add(w as u16);
@@ -1180,6 +1216,25 @@ impl Renderer {
         write!(stdout, "{}", Show)?;
         stdout.flush()?;
         Ok(())
+    }
+}
+
+pub fn open_url(url: &str) {
+    let openers: &[(&str, &[&str])] = &[
+        ("xdg-open", &[url]),
+        ("open", &[url]),               // macOS
+        ("cmd", &["/c", "start", url]), // Windows
+    ];
+    for &(cmd, args) in openers {
+        if std::process::Command::new(cmd)
+            .args(args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .is_ok()
+        {
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
## What
URLs in chat output are now clickable hyperlinks.

## How
- **OSC 8 escape sequences** — URLs are wrapped with terminal hyperlink escapes (\`\x1b]8;;<url>\x1b\\<text>\x1b]8;;\x1b\\\`), making them clickable in Kitty, Alacritty, WezTerm, foot, iTerm2, Windows Terminal, and most other modern terminals.
- **Click-to-open** — clicking a URL in the chat area opens it via \`xdg-open\` (Linux), \`open\` (macOS), or \`cmd /c start\` (Windows).
- **URL detection** — uses a \`LazyLock<Regex>\` matching \`https?://\` URLs. The regex is compiled once at first use.
- **Selection priority** — link clicks take priority over text selection. If you click on a URL, it opens; if you click elsewhere, text selection starts as before.

## Changes
- \`src/ui/renderer.rs\`: added \`URL_RE\` regex, \`wrap_urls_osc8()\`, \`link_url_at()\`, and \`open_url()\`
- \`src/ui/mod.rs\`: \`MouseDown\` handler checks for link before starting selection