### PR TITLE
docs: sync ARCHITECTURE.md, README.md, and docs/ with current codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Single crate, no workspace. All source under `src/`.
 
 ## Key Types & Relationships
 
-- **`Config`** (`src/config/mod.rs:21`) — central deserialized config, drives all runtime behavior.
+- **`Config`** (`src/config/mod.rs:23`) — central deserialized config, drives all runtime behavior.
 - **`Cli`** (`src/cli.rs:9`) — `clap::Parser` args, overrides `Config` fields.
 - **`AnyClient`** (`src/provider.rs:153`) / **`AnyModel`** (`:545`) / **`AnyAgent`** (`:562`) — type-erased enums wrapping rig's provider-specific clients (OpenAI, Anthropic, Gemini, Ollama, OpenRouter). `AnyAgent` provides `run_print()` and `spawn_runner()`. No custom traits — enum dispatch replaces dynamic dispatch.
 - **`AgentRunner`** (`src/agent/runner.rs:17`) — holds `mpsc::Receiver<AgentEvent>`, spawned via `spawn_agent()`.
@@ -37,7 +37,7 @@ Single crate, no workspace. All source under `src/`.
 - **`Renderer`** (`src/ui/renderer.rs:52`) — line-buffered viewport, markdown rendering, scroll/selection.
 - **`InputEditor`** (`src/ui/input/mod.rs:21`) — text buffer, cursor, history, kill-ring, picker integration.
 - **`ContextFiles`** (`src/context/mod.rs:57`) — loaded agents, prompts, themes, architecture docs.
-- **`HookDispatcher`** (`src/extras/hooks/dispatcher.rs:68`, feature `hooks`) — merges `PreToolUse` verdicts (`Allow`/`Defer`/`Ask`/`Deny`, most severe wins) and applies `PostToolUse`/lifecycle `Decision`s (`Continue`/`Block`/`Rewrite`). Wraps every tool via `wrap_from_global()` (`src/agent/builder.rs:276`), outside each tool's own `PermissionChecker` check.
+- **`HookDispatcher`** (`src/extras/hooks/dispatcher.rs:60`, feature `hooks`) — merges `PreToolUse` verdicts (`Allow`/`Defer`/`Ask`/`Deny`, most severe wins) and applies `PostToolUse`/lifecycle `Decision`s (`Continue`/`Block`/`Rewrite`). Wraps every tool via `wrap_from_global()` (`src/agent/builder.rs:276`), outside each tool's own `PermissionChecker` check.
 
 ## Control Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Architecture — zerostack v1.4.0-rc2
+# Architecture — zerostack v1.6.2
 
 Minimal coding agent in Rust, optimized for memory footprint and performance.
 Single crate, no workspace. All source under `src/`.
@@ -12,36 +12,37 @@ Single crate, no workspace. All source under `src/`.
 | `src/provider.rs` | LLM provider abstraction (type-erased: `AnyClient`, `AnyModel`, `AnyAgent` enums) |
 | `src/auth.rs` | API key resolution (`AuthResolver`, `ProviderKind` enum) |
 | `src/event.rs` | `AgentEvent` (streaming LLM output) and `UserEvent` (TUI input) enums |
-| `src/agent/` | Agent lifecycle: `builder.rs` (rig Agent construction + tool injection), `runner.rs` (spawn, stream), `prompt.rs` (system prompts), `tools/` (11 tool impls) |
+| `src/agent/` | Agent lifecycle: `builder.rs` (rig Agent construction + tool injection), `runner.rs` (spawn, stream), `prompt.rs` (system prompts), `tools/` (8 core tool impls: read, write, edit, bash, grep, find_files, list_dir, todo; plus feature-gated `TaskTool` and `AdvisorTool`) |
 | `src/session/` | Session state: `mod.rs` (messages, compactions, costs), `storage.rs` (JSON file I/O), `chat_history.rs` |
 | `src/permission/` | Security: `checker.rs` (glob+regex rules, doom-loop detection), `ask.rs` (user prompt UI), `pattern.rs` |
 | `src/ui/` | Custom TUI on crossterm (no ratatui): `mod.rs` (event loop), `terminal.rs` (raw mode guard), `renderer.rs` (line buffer + viewport), `input/` (text editor + pickers), `status.rs`, `markdown.rs`, `event_handler.rs`, `cmd_picker.rs` |
 | `src/context/` | Context gathering: embedded prompt themes (`prompts.rs`, `themes.rs`), AGENTS.md/ARCHITECTURE.md loading |
 | `src/config/` | Configuration: `load.rs` (TOML/YAML/JSON from disk+env), `types.rs` (QuickModel, CustomProvider, Colors, EditSystem) |
-| `src/extras/` | Feature-gated extensions: `loop/` (headless), `mcp/` (MCP client), `acp/` (ACP server), `memory/` (persistent memory), `subagents/` (parallel task delegation), `git_worktree/`, `archmd/` |
+| `src/extras/` | Feature-gated extensions: `loop/` (headless), `mcp/` (MCP client), `acp/` (ACP server), `memory/` (persistent memory), `subagents/` (parallel task delegation), `git_worktree/`, `archmd/`, `advisor/` (external model consultation, `/advisor`), `multimodal/` (image/PDF ingestion, gated separately by `multimodal`/`pdf`), `hooks/` (lifecycle hook dispatch: `PreToolUse`/`PostToolUse`/`Stop`/`UserPromptSubmit`/session+subagent events, trust-hash confirmation). Two subsystems are always compiled (not feature-gated): `chain/` (brainstorm→plan→code prompt transitions) and `status_signals` (Unix-socket start/stop/git-conflict signals, itself gated by the `status-signals` feature at the call site) |
 | `src/sandbox.rs` | `bwrap`/`zerobox` command wrapping |
 | `src/fs.rs` | Filesystem utilities |
 | `src/pricing.rs` | Token pricing constants |
 
 ## Key Types & Relationships
 
-- **`Config`** (`src/config/mod.rs:22`) — central deserialized config, drives all runtime behavior.
+- **`Config`** (`src/config/mod.rs:21`) — central deserialized config, drives all runtime behavior.
 - **`Cli`** (`src/cli.rs:9`) — `clap::Parser` args, overrides `Config` fields.
-- **`AnyClient` / `AnyModel` / `AnyAgent`** (`src/provider.rs:83-259`) — type-erased enums wrapping rig's provider-specific clients (OpenAI, Anthropic, Gemini, Ollama, OpenRouter). `AnyAgent` provides `run_print()` and `spawn_runner()`. No custom traits — enum dispatch replaces dynamic dispatch.
-- **`AgentRunner`** (`src/agent/runner.rs:12`) — holds `mpsc::Receiver<AgentEvent>`, spawned via `spawn_agent()`.
+- **`AnyClient`** (`src/provider.rs:153`) / **`AnyModel`** (`:545`) / **`AnyAgent`** (`:562`) — type-erased enums wrapping rig's provider-specific clients (OpenAI, Anthropic, Gemini, Ollama, OpenRouter). `AnyAgent` provides `run_print()` and `spawn_runner()`. No custom traits — enum dispatch replaces dynamic dispatch.
+- **`AgentRunner`** (`src/agent/runner.rs:17`) — holds `mpsc::Receiver<AgentEvent>`, spawned via `spawn_agent()`.
 - **`AgentEvent`** (`src/event.rs:4`) — `Token`, `Reasoning`, `ToolCall`, `ToolResult`, `SubagentToolCall`, `Error`, `Done`.
-- **`UserEvent`** (`src/event.rs:27`) — `Key`, `ScrollUp/Down`, `Resize`, `Paste`, `MouseDown/Drag/Up`.
-- **`Session`** (`src/session/mod.rs:39`) — serializable state: messages, compactions, costs, permission allowlist, model/provider info.
+- **`UserEvent`** (`src/event.rs:64`) — `Key`, `ScrollUp/Down`, `Resize`, `Paste`, `MouseDown/Drag/Up`.
+- **`Session`** (`src/session/mod.rs:61`) — serializable state: messages, compactions, costs, permission allowlist, model/provider info.
 - **`PermissionChecker`** (`src/permission/checker.rs:29`) — dual-layer (glob + regex) rules, doom-loop detection, `SecurityMode` dispatch.
 - **`TerminalGuard`** (`src/ui/terminal.rs:10`) — RAII for raw mode, alt screen, mouse capture.
-- **`Renderer`** (`src/ui/renderer.rs:21`) — line-buffered viewport, markdown rendering, scroll/selection.
-- **`InputEditor`** (`src/ui/input/mod.rs:22`) — text buffer, cursor, history, kill-ring, picker integration.
-- **`ContextFiles`** (`src/context/mod.rs:56`) — loaded agents, prompts, themes, architecture docs.
+- **`Renderer`** (`src/ui/renderer.rs:52`) — line-buffered viewport, markdown rendering, scroll/selection.
+- **`InputEditor`** (`src/ui/input/mod.rs:21`) — text buffer, cursor, history, kill-ring, picker integration.
+- **`ContextFiles`** (`src/context/mod.rs:57`) — loaded agents, prompts, themes, architecture docs.
+- **`HookDispatcher`** (`src/extras/hooks/dispatcher.rs:68`, feature `hooks`) — merges `PreToolUse` verdicts (`Allow`/`Defer`/`Ask`/`Deny`, most severe wins) and applies `PostToolUse`/lifecycle `Decision`s (`Continue`/`Block`/`Rewrite`). Wraps every tool via `wrap_from_global()` (`src/agent/builder.rs:276`), outside each tool's own `PermissionChecker` check.
 
 ## Control Flow
 
 ```
-CLI parse (main.rs:88) → config load → context load → session load
+CLI parse (main.rs:150) → config load → context load → session load
   │
   ├── --print-config → print and exit
   ├── --acp → extras::acp::serve()
@@ -52,11 +53,14 @@ CLI parse (main.rs:88) → config load → context load → session load
 
 ### Interactive TUI Event Loop (`src/ui/mod.rs`)
 
-Single `tokio::select!` with 4 branches (line ~310):
+Single `tokio::select!` with 6 branches plus an `else` fallback (line 1119):
 1. **`UserEvent` from `user_rx`** — keyboard/mouse/resize/paste from background event thread (polls crossterm every 50ms)
-2. **`AgentEvent` from `agent_rx`** — streaming LLM tokens, tool calls, errors
-3. **Permission `AskRequest` from `ask_rx`** — user must approve/reject tool calls
-4. **Periodic refresh** (100ms) — spinner animation when agent is running
+2. **Background agent prebuild** from `prebuild_rx` — consumed once idle, so MCP connection notices land in the transcript instead of racing the alt-screen TUI
+3. **`AgentEvent` from `agent_rx`** — streaming LLM tokens, tool calls, errors
+4. **Permission `AskRequest` from `ask_rx`** — user must approve/reject tool calls
+5. **`BtwEvent` from `btw_rx`** — parallel `/btw` side-question results, rendered but never written to the session
+6. **Periodic refresh** (100ms, gated on `is_running`) — spinner animation
+7. **`else`** — polls the prebuild receiver and sleeps 50ms when nothing else is ready
 
 Key dispatch: `InputEditor::handle_key()` → `Some(text)` triggers `spawn_agent()` → stream events via `handle_agent_event()` which writes to `Renderer` and appends to `Session`.
 
@@ -72,9 +76,10 @@ Agent (rig) → CompletionModel (LLM API)
 AgentEvent stream (Token, ToolCall, ToolResult, ...)
   │
   ├── handle_agent_event() → Renderer (viewport buffer) → crossterm draw commands
-  ├── ToolCall → PermissionChecker.check() → {Allowed, Ask, Denied}
-  │     ├── Ask → permission_handler (user approves/rejects via UI)
-  │     └── Allowed → tool execution (bash/read/write/edit/grep/etc.)
+  ├── ToolCall → [feature `hooks`] HookDispatcher PreToolUse → {Allow, Ask, Deny, rewritten input}
+  │     └── tool.call() → PermissionChecker.check() → {Allowed, Ask, Denied}
+  │           ├── Ask → permission_handler (user approves/rejects via UI)
+  │           └── Allowed → tool execution (bash/read/write/edit/grep/etc.) → [feature `hooks`] PostToolUse rewrite
   └── Done → Session.append() → session::storage::save_session()
 ```
 
@@ -83,17 +88,18 @@ Session is serialized to JSON files in `$XDG_DATA_HOME/zerostack/sessions/`. Cha
 ## Design Decisions
 
 1. **Custom TUI over crossterm (no ratatui)** — keeps binary size minimal; project has its own line buffer, markdown renderer, scroll/selection. No widget tree overhead.
-2. **Type-erased enums, not trait objects** — `AnyAgent` enum wraps each provider variant. Avoids `dyn CompletionModel` lifetime issues; matching on enum is faster than vtable dispatch. (`src/provider.rs:83-259`)
+2. **Type-erased enums, not trait objects** — `AnyAgent` enum wraps each provider variant. Avoids `dyn CompletionModel` lifetime issues; matching on enum is faster than vtable dispatch. (`src/provider.rs:153`, `:545`, `:562`)
 3. **Permission: dual-layer (glob + regex) rules** — glob for fast path, regex for complex patterns. Doom-loop detection tracks repeated identical tool calls. (`src/permission/checker.rs:29`)
-4. **Session compaction** — when token count approaches context window, old messages are summarized and dropped, preserving a summary prefix. (`src/session/mod.rs:24`)
-5. **Feature-gated extras** — `loop`, `mcp`, `acp`, `memory`, `subagents`, `git-worktree`, `archmd` are all compile-time features. Extras don't bloat the core binary.
+4. **Session compaction** — when token count approaches context window, old messages are summarized and dropped, preserving a summary prefix. (`Compaction` struct at `src/session/mod.rs:46`, gate at `:528`)
+5. **Feature-gated extras** — `loop`, `git-worktree`, `mcp`, `subagents`, `archmd`, `status-signals`, `multithread` are the default features; `acp`, `memory`, `advisor`, `hooks`, `multimodal`, `pdf` are opt-in. Extras don't bloat the core binary.
 6. **Single-threaded tokio by default** — `#[tokio::main(flavor = "current_thread")]` unless `multithread` feature enabled. Keeps resource usage low for a CLI tool.
+7. **Hooks wrap tools, they don't replace permission checks** — `HookDispatcher` (feature `hooks`) decorates every tool at construction time (`wrap_from_global()`); it runs strictly outside each tool's own `PermissionChecker` call, so a `PreToolUse` rewrite can only narrow a request, never grant a permission the checker would otherwise deny. (`src/extras/hooks/dispatcher.rs`)
 
 ## Dependencies
 
 | Crate | Use |
 |---|---|
-| `rig 0.37` | Agent framework: prompt hooks, tool system, streaming, provider clients (OpenAI, Anthropic, Gemini, Ollama, OpenRouter) |
+| `rig 0.39` | Agent framework: prompt hooks, tool system, streaming, provider clients (OpenAI, Anthropic, Gemini, Ollama, OpenRouter) |
 | `clap 4` | Derive-based CLI argument parsing (`src/cli.rs:9`) |
 | `crossterm 0.29` | Terminal raw mode, color, cursor, mouse, paste events — TUI foundation |
 | `tokio 1` | Async runtime (current_thread default), channels (`mpsc`), process, fs |
@@ -107,13 +113,16 @@ Session is serialized to JSON files in `$XDG_DATA_HOME/zerostack/sessions/`. Cha
 | `mimalloc` | Global allocator (size + speed) |
 | `compact_str`, `smallvec` | Heap-efficient small-string/small-vector types |
 
-Optional (`mcp` feature): `rmcp 1.7` (MCP client with child-process + HTTP transport). Optional (`acp` feature): `agent-client-protocol 0.12`.
+Optional (`mcp` feature): `rmcp 2.0` (MCP client with child-process + HTTP transport). Optional (`acp` feature): `agent-client-protocol 1.0.1`, `blocking`. Optional (`multimodal` feature): `rig/image`; `pdf` feature adds `rig/pdf` (implies `multimodal`). `advisor` and `hooks` are pure-logic features, no extra dependencies.
 
 ## Entry Points
 
-- **`main()`** (`src/main.rs:83`) — all modes dispatch from here
-- **`--print`** / `-p` — `agent.run_print()` → single reply, then exit (`main.rs:243`)
-- **`--loop`** — `run_headless_loop()` → iterative prompt/validate loop (`main.rs:262`)
-- **`--acp`** — `extras::acp::serve()` → ACP server mode (`main.rs:210`)
-- **Default (no flags)** — `ui::run_interactive()` → full TUI (`main.rs:295`)
+- **`main()`** (`src/main.rs:149`) — all modes dispatch from here
+- **`--print`** / `-p` — `agent.run_print()` → single reply, then exit (`main.rs:774`)
+- **`--loop`** — `run_headless_loop()` → iterative prompt/validate loop (branch at `main.rs:891`, definition at `:1160`)
+- **`--acp`** — `extras::acp::serve()` → ACP server mode (`main.rs:417`)
+- **Default (no flags)** — `ui::run_interactive()` → full TUI (call at `main.rs:931`, definition at `src/ui/mod.rs:751`)
 - **`--resume`** / `--continue` / `--session <id>` — loads prior session before entering TUI/print
+- **`--advisor`** (feature `advisor`) — registers `AdvisorTool` so the agent can consult a second model for strategic guidance mid-session (`src/agent/builder.rs:269-273`)
+- **`--no-hooks`** / **`--hooks-test`** (feature `hooks`) — disables the hook dispatcher, or dry-runs a single hook invocation against stdin and exits (`src/main.rs:178`, `:191`)
+- **`--status-socket`** (feature `status-signals`) — emits `start`/`stop`/`git-conflict` events over a Unix socket for external status bars (`src/cli.rs:260`)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Built-in prompts:
 | **`review-security`** | Security review mode — finds exploitable vulnerabilities                 |
 | **`simplify`**        | Code simplification mode — refines for clarity without changing behavior |
 | **`write-prompt`**    | Prompt writing mode — creates and optimizes agent prompts                |
+| **`refactor`**        | Refactoring mode — restructures code for design and maintainability while preserving behavior |
+| **`autoconfig`**      | Configuration mode — reads docs and edits your config/prompts, writes no code |
+| **`orchestrator`**    | Orchestration mode — combines direct tool use with parallel `zerostack` subprocess invocations for heavier work |
+| **`write-text`**      | Prose-writing mode — drafts and reviews non-code writing (docs, posts, emails) |
 
 You can also create custom prompts by placing markdown files in
 `$XDG_CONFIG_HOME/zerostack/prompts/` and referencing them by name.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 - **Integrated Git Worktrees integration**: Use `/worktree` to move the agent from one worktree to another.
 - **ACP support** (gated): Agent Communication Protocol server — lets editors (Zed, etc.) connect to zerostack as an ACP agent
 - **Persistent memory** (gated): plain-Markdown memory across sessions: a global MEMORY.md plus per-project daily logs, scratchpad, and notes, injected into the system prompt each session
+- **Lifecycle hooks** (gated): observe or gate tool calls, prompts, and session lifecycle events via external commands, using a `settings.json` schema largely compatible with Claude Code hooks
+- **Advisor** (gated): a second model the agent can consult mid-session for strategic guidance, with an optional human-handoff mode
+- **Multimodal input** (gated): attach images and PDFs to messages
 - **Subagents**: Parallel and fast, used for exploring the codebase
 - **ARCHITECTURE.md**: Our own companion file for AGENTS.md, it allows to offer a shared core knowledge for all agents working on the same codebase
+- **Prompt chaining**: offers to advance brainstorm → plan → code → review as each phase finishes, config-gated per transition
+- **Status signals**: emits start/stop/git-conflict events over a Unix socket for external status bars or tooling
 
 **NOTE**: Windows support is not tested is any way, but feel free to try and open an issue if you encounter any bugs!
 
@@ -32,7 +37,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 
 _zerostack_ is one of the smallest and most performant coding agents on the market.
 
-- Lines of code: ~17k LoC
+- Lines of code: ~30k LoC (core, excluding tests)
 - Binary size: 26MB
 - RAM footprint: ~16MB on average, with peaks at ~24MB (vs ~300MB with peaks at ~700MB for opencode or other JS-based coding agents)
 - CPU usage: 0.0% on idle, ~1.5% when using tools (measured on an Intel i5 7th gen, vs ~2% on idle and ~20% when working for opencode)
@@ -64,14 +69,14 @@ Or pick a tarball manually from [GitHub Releases](https://github.com/gi-dellav/z
 ### Cargo
 
 ```bash
-# Default: loop, git-worktree, mcp, subagents, archmd
+# Default: loop, git-worktree, mcp, subagents, archmd, status-signals, multithread
 cargo install zerostack
 
 # With all features
 cargo install zerostack --all-features
 
 # With specific features
-cargo install zerostack --features acp,memory,multithread
+cargo install zerostack --features acp,memory,hooks,advisor
 ```
 
 ### Homebrew
@@ -196,6 +201,14 @@ system prompt. When enabled (feature `archmd`), `ARCHITECTURE.md` is also loaded
 the same way, providing high-level design context to speed up exploration.
 Use `-n` / `--no-context-files` to disable all context file loading.
 
+### Prompt chaining
+
+When `brainstorm`, `plan`, or `code` finishes, zerostack can offer to advance
+to the next phase (`brainstorm` → `plan` → `code` → `/review`), asking
+`Continue to plan? [Y/N/B]`-style at each step: `Y` advances, `N` stays put,
+and `B` ("but ...") advances with an extra instruction appended. Each
+transition is enabled independently in config.
+
 ## Permission system
 
 zerostack has five permission modes:
@@ -236,6 +249,9 @@ This is a list of the most important slash commands:
 - `/mode` — Set the permission system's mode
 - `/queue` — Manage input queued while the agent is busy
 - `/btw` — Ask a quick side question in parallel without interrupting the agent
+- `/review` — Run a one-shot code review in readonly mode, then restore the previous prompt
+- `/hooks` (gated) — Show whether a hook dispatcher is installed and what it's configured for
+- `/advisor` (gated) — Show or change advisor status (enabled, mode, model, max uses)
 
 To see all of the commands, use `/help`.
 
@@ -292,6 +308,58 @@ injects the relevant ones into the system prompt at the start of every session,
 so it remembers your preferences and recent context across runs.
 
 Global memory files are stored in `$XDG_DATA_HOME/zerostack/agent/memory/`.
+
+## Hooks
+
+**NOTE:** Hooks are gated behind the `hooks` feature and are not included in the
+default build. Install with `cargo install zerostack --features hooks`.
+
+With the `hooks` feature, external commands can observe or gate agent behavior
+at defined lifecycle events: a tool call (`PreToolUse`/`PostToolUse`), a user
+prompt (`UserPromptSubmit`), the agent finishing a turn (`Stop`), a session
+starting/ending, or a subagent starting/stopping. Hooks use the same
+`settings.json` shape, stdin envelope, and exit-code/stdout-JSON contract as
+Claude Code, so an existing CC hooks setup is largely compatible.
+
+Hook config lives in `settings.json` at up to three locations (global,
+project, and an admin-managed file), merged in that order. The project-level
+file is untrusted by default; zerostack asks for confirmation (tracked by
+hash) before running project hooks for the first time. Use `--no-hooks` to
+disable all non-managed hooks, or `--hooks-test <tool>` to dry-run
+`PreToolUse` hooks for a tool without starting a session. See
+[docs/CONFIG.md](docs/CONFIG.md#hooks) for the full configuration reference.
+
+## Advisor
+
+**NOTE:** Advisor is gated behind the `advisor` feature and is not included in
+the default build. Install with `cargo install zerostack --features advisor`.
+
+With the `advisor` feature, the agent can consult a second model mid-session
+for strategic guidance (architecture calls, edge cases, course correction)
+without derailing the main coding session. Enable it with `--advisor`, or
+toggle it at runtime with `/advisor on` / `/advisor off`. An optional
+human-handoff mode (`/advisor handoff on`) routes advisor calls to you
+instead of a model. See [docs/CONFIG.md](docs/CONFIG.md#advisor) for
+configuration.
+
+## Multimodal input
+
+**NOTE:** Multimodal input is gated behind the `multimodal` feature (images)
+and `pdf` feature (PDFs, implies `multimodal`), neither included in the
+default build.
+
+With these features enabled, you can attach images and PDFs to your messages
+(up to 20 MB per file) and the agent processes them via the underlying
+provider's multimodal support.
+
+## Status signals
+
+**NOTE:** Status signals require the `status-signals` feature, which is
+included in the default build.
+
+Pass `--status-socket <path>` to have zerostack emit `start`, `stop`, and
+`git-conflict` events over a Unix domain socket, for external status bars or
+tooling to watch.
 
 ## Parallel Agent
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -7,14 +7,23 @@ All slash commands are available from the TUI input prompt.
 | Command | Description |
 | ------- | ----------- |
 | `/clear` | Clear the current session (all messages, tokens, compactions). |
+| `/new` | Alias for `/clear`. |
 | `/undo` | Remove the last exchange (user message + assistant response). |
+| `/redo` | Restore the last exchange removed by `/rewind`. |
+| `/rewind` | Open a picker to jump the session back to an earlier point. |
 | `/retry` | Load the last user message into the input editor for editing. |
 | `/quit` | Exit zerostack. |
+| `/exit` | Alias for `/quit`. |
 | `/sessions` | List recent saved sessions (up to 20). |
 | `/sessions <id-or-name>` | Load a session by its ID prefix or name. |
 | `/sessions delete <id-or-name>` | Delete a session by its ID prefix or name. |
 | `/rename <name>` | Rename the current session. |
 | `/history` | Show global chat history (last 10 entries across sessions). |
+| `/queue` | List input queued while the agent is busy (same as `/queue ls`). |
+| `/queue clear` | Empty the queue. |
+| `/queue pop` | Remove the last queued input. |
+| `/welcome` | Show the welcome/onboarding screen. |
+| `/tutorial` | Alias for `/welcome`. |
 
 ## Provider & Model
 
@@ -172,6 +181,17 @@ older daily logs are accessible via `/memory read` and `memory_search`.
 | `/advisor model <name>` | Change the advisor model. |
 | `/advisor max-uses <n>` | Set max advisor calls per request (0 = unlimited). |
 | `/advisor context-limit <n>` | Set max kilobytes of conversation context sent to advisor. |
+
+## Subagents (feature-gated)
+
+Requires the `subagents` feature (default-on; see [SUBAGENTS.md](SUBAGENTS.md)).
+
+| Command | Description |
+| ------- | ----------- |
+| `/model-subagent` | Show the model currently used for subagents. |
+| `/model-subagent <name>` | Switch the subagent model. |
+| `/models-subagent` | List quick models available for subagents. |
+| `/models-subagent <name>` | Switch subagents to a named quick model. |
 
 ## Worktree (feature-gated)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,7 +9,7 @@ All slash commands are available from the TUI input prompt.
 | `/clear` | Clear the current session (all messages, tokens, compactions). |
 | `/new` | Alias for `/clear`. |
 | `/undo` | Remove the last exchange (user message + assistant response). |
-| `/redo` | Restore the last exchange removed by `/rewind`. |
+| `/redo` | Restore whatever the most recent `/undo` or `/rewind` removed. |
 | `/rewind` | Open a picker to jump the session back to an earlier point. |
 | `/retry` | Load the last user message into the input editor for editing. |
 | `/quit` | Exit zerostack. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -980,7 +980,7 @@ model only when needed.
 enabled = true
 model = "deepseek-v4-pro"
 # max_uses = 3                    # max advisor calls per request (nil = unlimited)
-# human_handoff = true            # route advisor calls to the user instead of a model (this is the default)
+# human_handoff = true            # struct default is true, but currently has no effect from config alone; see the note below
 # advisor_kilobytes_limit = 256   # max KB of conversation context (split half head / half tail)
 ```
 
@@ -1005,9 +1005,15 @@ advisor:
 | `--advisor-human-handoff[=<bool>]` | Route advisor calls to the user instead of a model. Bare flag or `=true` enables it; CLI default is `false` unless passed |
 | `--advisor-kilobytes-limit <n>` | Max KB of conversation context sent to advisor (default: 256) |
 
+**Known quirk:** the CLI flag always supplies a value (`Some(false)` when not
+passed), so `resolve_advisor_human_handoff()` never falls through to the
+config file's `human_handoff` key in practice. Use `--advisor-human-handoff`
+or the `/advisor handoff on` runtime command to actually enable it; setting
+`human_handoff` in the config file alone currently has no effect.
+
 ### Human handoff mode
 
-When `human_handoff = true`, the agent's advisor calls are redirected to the
+When enabled, the agent's advisor calls are redirected to the
 user instead of a second model. The agent pauses, shows its question, and the
 user types a response. This is useful for:
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -152,7 +152,7 @@ Accepted top-level keys:
 | `max_text_file_size`      | integer | Maximum allowed file size in bytes for read/write tool operations. Default: `1048576` (1 MB).                                                                               |
 | `deny_repeated_reads`     | boolean | Block repeated reads of the same file section within a session until the file is edited or written. Default: `true`. Set to `false` to allow re-reading.                     |
 | `show_cost_always`        | boolean | Show the session cost in the status bar even when it is `$0.0000` (for example when the model has no per-token pricing configured). Default: `false`, which hides the cost until it is above zero. |
-| `compact_enabled`         | boolean | Master switch for all automatic conversation compaction (both between-turn and mid-turn). Default: `true`. When `false`, nothing is ever compacted automatically.            |
+| `compact_enabled`         | boolean | Master switch for all automatic conversation compaction (both between-turn and mid-turn). Default: `false`. When `false`, nothing is ever compacted automatically.            |
 | `mid_turn_compact_threshold` | number | Opt-in mid-turn compaction. Fraction of the context window (`0.0`–`1.0`) of real provider prompt pressure at which to compact *during* a turn, not just between turns. Unset by default, meaning no mid-turn compaction. Honored only when `compact_enabled` is `true`. Recommended starting value: `0.80`. See Mid-turn compaction below.            |
 | `always_show_welcome`     | boolean | Always show the welcome banner on startup, bypassing the one-shot marker file. Default: `false`.                                                                               |
 | `auto-update-prompts`     | boolean | When `true`, always regenerate prompts on version change without asking. When `false`, never regenerate. When unset, asks interactively.                                         |
@@ -569,6 +569,14 @@ Available items:
 The `git_changes` and `git_status` items run `git status` once a second (only
 when one of them is used). All other items are read from the session.
 
+## Status signals
+
+Requires the `status-signals` feature (included in the default build). Pass
+`--status-socket <path>` to have zerostack emit `start`, `stop`, and
+`git-conflict` events over a Unix domain socket at `<path>`, for external
+status bars or tooling to watch. This is separate from the in-TUI status bar
+above.
+
 ## Colors
 
 The `colors` object accepts an optional `scheme_type` field and three optional
@@ -971,9 +979,8 @@ model only when needed.
 [advisor]
 enabled = true
 model = "deepseek-v4-pro"
-# provider = "openrouter"         # defaults to main provider
 # max_uses = 3                    # max advisor calls per request (nil = unlimited)
-# human_handoff = false           # route advisor calls to the user instead
+# human_handoff = true            # route advisor calls to the user instead of a model (this is the default)
 # advisor_kilobytes_limit = 256   # max KB of conversation context (split half head / half tail)
 ```
 
@@ -984,7 +991,7 @@ advisor:
   enabled: true
   model: deepseek-v4-pro
   max_uses: 3
-  human_handoff: false
+  human_handoff: true
   advisor_kilobytes_limit: 256
 ```
 
@@ -994,9 +1001,8 @@ advisor:
 |------|-------------|
 | `--advisor` | Enable the advisor tool |
 | `--advisor-model <name>` | Advisor model name |
-| `--advisor-provider <name>` | Provider for the advisor model |
 | `--advisor-max-uses <n>` | Max advisor calls per request |
-| `--advisor-human-handoff` | Route advisor calls to the user |
+| `--advisor-human-handoff[=<bool>]` | Route advisor calls to the user instead of a model. Bare flag or `=true` enables it; CLI default is `false` unless passed |
 | `--advisor-kilobytes-limit <n>` | Max KB of conversation context sent to advisor (default: 256) |
 
 ### Human handoff mode

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -52,7 +52,7 @@ You can just set the matching env var with :
 | Gemini     | `GEMINI_API_KEY`      |
 | Ollama     | (none — local)        |
 
-Then, you can change your configuration file (`~/.local/share/zerostack/config.toml` on Linux/WSL or `~/Library/Application Support/zerostack/` on macOS) by adding `provider = [provider_name]` in order to change your default provider.
+Then, you can change your configuration file (`~/.local/share/zerostack/config.toml` on Linux/WSL or `~/Library/Application Support/zerostack/` on macOS, unless overridden by `$ZS_CONFIG_DIR` or an existing `~/.config/zerostack/` file — see [CONFIG.md](CONFIG.md) for the full precedence) by adding `provider = [provider_name]` in order to change your default provider.
 
 If you are using a provider that's not your default one, use the `--provider` CLI flag:
 
@@ -123,6 +123,11 @@ Prompts change *how* the agent behaves. Type `.` at the start of a message to on
 | `debug` | Systematic debugging |
 | `refactor` | Restructuring existing code |
 
+This is the short list; run `/prompt` in the agent (or see the root
+[README](../README.md#prompts-system)) for the full set of built-in prompts,
+including `frontend-design`, `review-security`, `simplify`, `write-prompt`,
+`autoconfig`, `orchestrator`, and `write-text`.
+
 ## 3. Autoconfig
 
 There is one special prompt, called `autoconfig`, that has full access to your zerostack configuration and to the project's documentation: after reading this Get Started guide, you might decide to just never read any documentation or any configuration file for zerostack, you just need to load `autoconfig` and everything will be managed.
@@ -157,6 +162,15 @@ If you want to use zerostack from scripts, from other programs, or if you just w
 | `--worktree` | Run the agent inside a git worktree (Experimental) |
 | `--parallel` | Run the agent inside a self-managed git worktree (Experimental) |
 | `--load-prompt <prompt>` | Use a specific prompt |
+
+## 6. Opt-in features
+
+Everything above ships in the default build. A few extras are compiled in
+only when you ask for them: lifecycle hooks (`--features hooks`), a
+second-model advisor (`--features advisor`), image/PDF message attachments
+(`--features multimodal,pdf`), and ACP editor integration
+(`--features acp`). See the root [README](../README.md) for what each one
+does and how to enable it.
 
 # Conclusions
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,7 +91,7 @@ footer{padding:32px 0;text-align:center;font-size:.78rem;color:var(--text-dim)}
 <img class="logo" src="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/logo.png" alt="zerostack logo" width="56" height="56">
 <div class="header-text">
 <h1>zerostack</h1>
-<div class="tagline">~16k LoC · 26MB binary · ~16 MB RAM (avg) / ~24 MB (peak)</div>
+<div class="tagline">~30k LoC (core) · 26MB binary · ~16 MB RAM (avg) / ~24 MB (peak)</div>
 <div class="header-links">
 <a href="#overview">Overview</a>
 <a href="#docs">Docs</a>
@@ -115,11 +115,11 @@ footer{padding:32px 0;text-align:center;font-size:.78rem;color:var(--text-dim)}
 <a href="https://www.producthunt.com/products/zerostack-coding-agent/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-zerostack&#0045;coding&#0045;agent" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1236867&theme=light" alt="Zerostack&#0032;Coding&#0032;Agent - A&#0032;minimal&#0032;coding&#0032;agent&#0044;&#0032;with&#0032;a&#0032;bundle&#0032;of&#0032;innovative&#0032;features | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 <h2>Overview</h2>
 <p>
-Minimal coding agent written in Rust — ~16k LoC, 26MB binary, ~16 MB RAM (avg), ~24 MB (peak).
+Minimal coding agent written in Rust — ~30k LoC (core), 26MB binary, ~16 MB RAM (avg), ~24 MB (peak).
 Peak RAM ~24 MB vs ~700 MB for JS-based agents. CPU: 0.0% idle, ~1.5% under load.
 </p>
 <div class="perf-grid">
-<div class="perf-card"><div class="value">~16k</div><div class="label">Lines of Code</div></div>
+<div class="perf-card"><div class="value">~30k</div><div class="label">Lines of Code</div></div>
 <div class="perf-card"><div class="value">26MB</div><div class="label">Binary Size</div></div>
 <div class="perf-card"><div class="value">~16 MB</div><div class="label">RAM (avg)</div></div>
 <div class="perf-card"><div class="value">0.0%</div><div class="label">CPU (idle)</div></div>
@@ -129,17 +129,22 @@ Peak RAM ~24 MB vs ~700 MB for JS-based agents. CPU: 0.0% idle, ~1.5% under load
 <li><strong>Standard tools</strong> — all tools exposed to coding agents (as described by opencode)</li>
 <li><strong>Permission system</strong> — 5 modes, per-tool patterns, session allowlists</li>
 <li><strong>Terminal UI</strong> — crossterm, markdown rendering, mouse support, scrollback</li>
-<li><strong>Prompts system</strong> — 10 built-in prompts, switchable at runtime</li>
+<li><strong>Prompts system</strong> — 14 built-in prompts, switchable at runtime</li>
 <li><strong>Session management</strong> — save/load/resume, auto-compaction</li>
 <li><strong>MCP support</strong> — connect external tool servers</li>
 <li><strong>Ralph Wiggum loops</strong> — iterative coding for long-horizon tasks</li>
 <li><strong>Git Worktrees</strong> — branch-per-task workflow</li>
 <li><strong>ACP support</strong> (gated) — editor integration (Zed, etc.)</li>
 <li><strong>Persistent memory</strong> (gated) — plain-Markdown memory across sessions</li>
+<li><strong>Lifecycle hooks</strong> (gated) — observe/gate tool calls and session lifecycle via external commands</li>
+<li><strong>Advisor</strong> (gated) — consult a second model mid-session for strategic guidance</li>
+<li><strong>Multimodal input</strong> (gated) — attach images and PDFs to messages</li>
 <li><strong>Subagents</strong> — parallel, fast codebase exploration</li>
 <li><strong>ARCHITECTURE.md</strong> — shared core knowledge for all agents on the same codebase</li>
 <li><strong>Sandbox mode</strong> — bubblewrap / zerobox isolation</li>
 <li><strong>Exa search</strong> — WebFetch &amp; WebSearch tools</li>
+<li><strong>Prompt chaining</strong> — offers to advance brainstorm → plan → code → review</li>
+<li><strong>Status signals</strong> — start/stop/git-conflict events over a Unix socket</li>
 </ul>
 <div class="screenshot-wrap">
 <img src="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/tui_screenshot0.png" alt="zerostack TUI screenshot">
@@ -234,6 +239,21 @@ Peak RAM ~24 MB vs ~700 MB for JS-based agents. CPU: 0.0% idle, ~1.5% under load
 <div class="cmd-header"><strong>/wt-exit</strong> — Return to main repo without merging</div>
 </div>
 <div class="cmd">
+<div class="cmd-header"><strong>/queue</strong> — Manage input queued while the agent is busy</div>
+</div>
+<div class="cmd">
+<div class="cmd-header"><strong>/btw</strong> — Ask a quick side question in parallel</div>
+</div>
+<div class="cmd">
+<div class="cmd-header"><strong>/review</strong> — Run a one-shot code review</div>
+</div>
+<div class="cmd">
+<div class="cmd-header"><strong>/hooks</strong> (gated) — Show the installed hook dispatcher config</div>
+</div>
+<div class="cmd">
+<div class="cmd-header"><strong>/advisor</strong> (gated) — Show or change advisor status</div>
+</div>
+<div class="cmd">
 <div class="cmd-header"><strong>/help</strong> — Show all commands</div>
 </div>
 </section>
@@ -242,6 +262,7 @@ Peak RAM ~24 MB vs ~700 MB for JS-based agents. CPU: 0.0% idle, ~1.5% under load
 <section id="docs">
 <h2>Documentation</h2>
 <ul class="features">
+<li><a href="GET_STARTED.html">GET_STARTED.md</a> — Installation, first session, and essential commands</li>
 <li><a href="ARCHITECTURE.html">ARCHITECTURE.md</a> — Project architecture and design decisions</li>
 <li><a href="COMMANDS.html">COMMANDS.md</a> — Slash commands reference</li>
 <li><a href="CONFIG.html">CONFIG.md</a> — Full configuration guide (TOML/YAML)</li>
@@ -278,7 +299,7 @@ zerostack --provider openrouter --model deepseek/deepseek-v4-flash</code></pre>
 <section id="install">
 <h2>Installation</h2>
 <p>Requires <a href="https://rustup.rs/" target="_blank" rel="noopener">Cargo</a> and git:</p>
-<pre><code># Default — MCP, loop, git-worktree, and subagents
+<pre><code># Default — loop, git-worktree, mcp, subagents, archmd, status-signals, multithread
 cargo install zerostack
 
 # With ACP (Agent Communication Protocol) support for editor integration
@@ -287,8 +308,8 @@ cargo install zerostack --features acp
 # With Memory support
 cargo install zerostack --features memory
 
-# With experimental multi-threaded subagents
-cargo install zerostack --features multithread</code></pre>
+# With hooks and advisor
+cargo install zerostack --features hooks,advisor</code></pre>
 <p>Pre-built binaries are also available on <a href="https://github.com/gi-dellav/zerostack/releases" target="_blank" rel="noopener">GitHub Releases</a>.</p>
 <p>Once installed, run <code>/prompt autoconfig</code> inside zerostack to configure the tool interactively.</p>
 


### PR DESCRIPTION
## Summary

Syncs `ARCHITECTURE.md`, `README.md`, `docs/COMMANDS.md`, `docs/CONFIG.md`, `docs/GET_STARTED.md`, and `docs/index.html` with the current codebase: fixes stale facts (version, line numbers, dependency versions, config defaults, LoC count) and documents subsystems that had shipped with zero mention (`hooks`, `advisor`, `multimodal`/`pdf`, prompt chaining, `status-signals`).

## Motivation

`ARCHITECTURE.md` still said `v1.4.0-rc2` and cited line numbers from a much smaller `main.rs`; the "Lines of code: ~17k" figure undercounted the actual core by nearly half. More importantly, five subsystems that already ship (three of them behind their own CLI flags and slash commands) had no documentation anywhere a new user or contributor would look. A reader following the docs as written would miss `hooks`, `advisor`, `multimodal`/`pdf` input, prompt chaining, and `status-signals` entirely, and would hit wrong line numbers if they used `ARCHITECTURE.md` to navigate the source.

## Design decisions

- **Verification method**: every fact changed here (line numbers, default values, CLI flag names, feature lists) was checked directly against the current source tree, not inferred from the old docs or from memory. Several genuinely surprising corrections came out of this: `compact_enabled` defaults to `false` (docs said `true`), `AdvisorConfig::human_handoff` defaults to `true` (docs said `false`), and `--advisor-provider` / a `provider` key in `[advisor]` do not exist in code at all.
- **LoC figure**: reported as "~30k LoC (core, excluding tests)" rather than a raw total, since the prior figure was implicitly a core count and mixing in the ~10.7k lines of `src/tests/` would not be an apples-to-apples replacement.
- **HASHEDIT.md intentionally untouched**: this doc describes an anchor-word/FNV-1a/Myers-diff edit system that no longer matches the shipped implementation (`src/agent/tools/edit.rs` + `crc.rs` use a much simpler CRC-32 line-tag scheme; `/editsys hashedit` and `CONFIG.md`'s Edit System Modes section already describe the CRC-32 behavior correctly). Rewriting 693 lines describing a different system is a bigger call than a docs-sync PR should make unilaterally, so it's left out of scope here pending a decision from whoever owns that design.
- **`docs/CONFIG.md` advisor `human_handoff` quirk**: while verifying the advisor docs, found that `resolve_advisor_human_handoff()` (`src/cli.rs`) never actually reads the config value at runtime, because the CLI flag's own `default_value = "false"` always supplies `Some(false)` when the flag is absent, short-circuiting the `unwrap_or_else` fallback to config. Confirmed empirically (temporary debug print, `--print-config`). Documented as a known quirk rather than silently repeating a config example that would not do what it says; not fixed here since it is a behavior change to `src/cli.rs`, out of scope for a docs PR.
- **Platform support**: docs-only change, no platform-specific code touched.

## Testing

- `cargo test --all-features`: 760 passed, 0 failed.
- Every changed fact was cross-checked against its source location (file:line citations kept in the diff itself, e.g. struct/enum definitions, `Cargo.toml`, `src/cli.rs` arg definitions).
- An independent adversarial review pass (fresh-context reviewer, no access to this development conversation) spot-checked 25+ claims against the source tree; it found two wrong line numbers (now fixed: `Config` struct at `src/config/mod.rs:23` not `:21`, `HookDispatcher` struct at `src/extras/hooks/dispatcher.rs:60` not `:68`), one imprecise command description (`/redo` restores what `/undo` *or* `/rewind` removed, not just `/rewind`), and the `human_handoff` precedence quirk above.

## Reviewing

Start with `ARCHITECTURE.md` and `README.md` (largest, most structural changes), then `docs/CONFIG.md` (the advisor/compaction default fixes are the most behaviorally significant), then `docs/COMMANDS.md` and `docs/GET_STARTED.md` (additive, lower risk), and `docs/index.html` last (mirrors `README.md`, mostly mechanical).

## Notes

- `just check` (clippy, part of the quality gate) currently fails on `main` itself (`933e274`) with `collapsible_if` errors in `src/main.rs`, unrelated to this diff (this branch touches no `.rs` files; confirmed the same failure reproduces on a clean checkout of `main`). Flagging since it blocks a fully-green gate report for this PR through no fault of this diff; worth a separate look.
- `PROVIDERS.md` and `SUBAGENTS.md` were audited against the source and found accurate; not touched.
