### PR TITLE
fix(clippy): collapse nested if statements into let-chains

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -35,10 +35,10 @@ pub fn install_panic_hook() {
 
 fn write_crash_report(info: &std::panic::PanicHookInfo) -> Option<PathBuf> {
     let path = resolve_crash_log_path();
-    if let Some(parent) = path.parent() {
-        if fs::create_dir_all(parent).is_err() {
-            return None;
-        }
+    if let Some(parent) = path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return None;
     }
 
     let mut content = String::from("zerostack crash report\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,23 +391,21 @@ async fn main() -> anyhow::Result<()> {
         let need_pricing = session.input_token_cost == 0.0 && session.output_token_cost == 0.0;
         let need_ctx = cfg.context_window.is_none()
             && config::Config::catalog_context_window("openrouter", model.as_str()).is_none();
-        if need_pricing || need_ctx {
-            if let Ok(infos) = provider::fetch_openrouter_pricing(
+        if (need_pricing || need_ctx)
+            && let Ok(infos) = provider::fetch_openrouter_pricing(
                 cli.api_key.as_deref(),
                 &cfg.custom_providers_map(),
                 cfg.api_keys.as_ref(),
             )
             .await
-            {
-                if let Some(info) = infos.get(model.as_str()) {
-                    if need_pricing {
-                        session.input_token_cost = info.input_cost;
-                        session.output_token_cost = info.output_cost;
-                    }
-                    if need_ctx && let Some(cw) = info.context_length {
-                        session.update_context_window(cw);
-                    }
-                }
+            && let Some(info) = infos.get(model.as_str())
+        {
+            if need_pricing {
+                session.input_token_cost = info.input_cost;
+                session.output_token_cost = info.output_cost;
+            }
+            if need_ctx && let Some(cw) = info.context_length {
+                session.update_context_window(cw);
             }
         }
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -873,7 +873,7 @@ pub(crate) fn build_http_client(
 }
 
 fn is_localhost(url: Option<&str>) -> bool {
-    url.map_or(false, |u| {
+    url.is_some_and(|u| {
         u.starts_with("http://localhost")
             || u.starts_with("http://127.")
             || u.starts_with("http://[::1]")

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -130,10 +130,9 @@ pub fn find_sessions_by_prefix(prefix: &str) -> anyhow::Result<Vec<Session>> {
             && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
             && let Ok(json) = std::fs::read_to_string(&path)
             && let Ok(session) = serde_json::from_str::<Session>(&json)
+            && (stem.starts_with(prefix) || session.name.to_lowercase().contains(&lower))
         {
-            if stem.starts_with(prefix) || session.name.to_lowercase().contains(&lower) {
-                sessions.push(session);
-            }
+            sessions.push(session);
         }
     }
     sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
@@ -158,10 +157,9 @@ pub fn find_session_by_name(name: &str) -> anyhow::Result<Option<Session>> {
         if path.extension().is_some_and(|e| e == "json")
             && let Ok(json) = std::fs::read_to_string(&path)
             && let Ok(session) = serde_json::from_str::<Session>(&json)
+            && session.name.to_lowercase() == lower
         {
-            if session.name.to_lowercase() == lower {
-                return Ok(Some(session));
-            }
+            return Ok(Some(session));
         }
     }
     Ok(None)

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -178,25 +178,22 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
     if let Some((input, output)) = lookup_pricing_from_cache(&ctx.session.provider, model_id) {
         ctx.session.input_token_cost = input;
         ctx.session.output_token_cost = output;
-    } else if ctx.session.provider == "openrouter" {
-        if let Ok(prices) = crate::provider::fetch_openrouter_pricing(
+    } else if ctx.session.provider == "openrouter"
+        && let Ok(prices) = crate::provider::fetch_openrouter_pricing(
             ctx.cli.api_key.as_deref(),
             &ctx.cfg.custom_providers_map(),
             ctx.cfg.api_keys.as_ref(),
         )
         .await
+        && let Some(info) = prices.get(model_id)
+    {
+        ctx.session.input_token_cost = info.input_cost;
+        ctx.session.output_token_cost = info.output_cost;
+        if ctx.cfg.context_window.is_none()
+            && crate::config::Config::catalog_context_window("openrouter", model_id).is_none()
+            && let Some(cw) = info.context_length
         {
-            if let Some(info) = prices.get(model_id) {
-                ctx.session.input_token_cost = info.input_cost;
-                ctx.session.output_token_cost = info.output_cost;
-                if ctx.cfg.context_window.is_none()
-                    && crate::config::Config::catalog_context_window("openrouter", model_id)
-                        .is_none()
-                    && let Some(cw) = info.context_length
-                {
-                    ctx.session.update_context_window(cw);
-                }
-            }
+            ctx.session.update_context_window(cw);
         }
     }
     write_ok(ctx.renderer, format!("switched to model: {}", new_model));
@@ -290,25 +287,22 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
     if let Some((input, output)) = lookup_pricing_from_cache(&ctx.session.provider, &new_model) {
         ctx.session.input_token_cost = input;
         ctx.session.output_token_cost = output;
-    } else if ctx.session.provider == "openrouter" {
-        if let Ok(prices) = crate::provider::fetch_openrouter_pricing(
+    } else if ctx.session.provider == "openrouter"
+        && let Ok(prices) = crate::provider::fetch_openrouter_pricing(
             ctx.cli.api_key.as_deref(),
             &ctx.cfg.custom_providers_map(),
             ctx.cfg.api_keys.as_ref(),
         )
         .await
+        && let Some(info) = prices.get(&*new_model)
+    {
+        ctx.session.input_token_cost = info.input_cost;
+        ctx.session.output_token_cost = info.output_cost;
+        if ctx.cfg.context_window.is_none()
+            && crate::config::Config::catalog_context_window("openrouter", &new_model).is_none()
+            && let Some(cw) = info.context_length
         {
-            if let Some(info) = prices.get(&*new_model) {
-                ctx.session.input_token_cost = info.input_cost;
-                ctx.session.output_token_cost = info.output_cost;
-                if ctx.cfg.context_window.is_none()
-                    && crate::config::Config::catalog_context_window("openrouter", &new_model)
-                        .is_none()
-                    && let Some(cw) = info.context_length
-                {
-                    ctx.session.update_context_window(cw);
-                }
-            }
+            ctx.session.update_context_window(cw);
         }
     }
     write_ok(ctx.renderer, format!("switched to model: {}", new_model));


### PR DESCRIPTION
## Summary
`cargo clippy --all-targets --all-features -- -D warnings` was failing on the pinned 1.96.0 toolchain with 10 `collapsible_if` errors and one `map_or(false, ...)` simplification. This PR fixes exactly those clippy findings, with no other behavior change.

## Motivation
The project pins Rust 1.96.0 (`rust-toolchain.toml`), which stabilizes let-chains (`if let Some(x) = y && cond { }`). Clippy on that toolchain now flags nested `if`/`if let` blocks that can be flattened into a single let-chain condition, and a `map_or(false, ...)` that reads more clearly as `is_some_and(...)`. Without this fix, `just check` (the CI-equivalent quality gate) fails for anyone building against the pinned toolchain.

## Design decisions
- Every merge is a mechanical flattening of existing nested conditionals into let-chains; no control flow or short-circuit order was changed. Where an outer `if` guarded two independent sibling side effects (`src/main.rs`, the `need_pricing` / `need_ctx` block), those siblings were deliberately left as separate inner `if`s rather than merged, since they are independent conditions, not a single nested check.
- Parenthesized `(cond1 || cond2)` groupings appear only where an `||` needs to bind before joining the surrounding `&&` chain (operator precedence); they are correctly absent where the joined condition is already a single boolean.
- Platform support: this is a pure control-flow refactor touching no paths, process spawning, or platform-specific code; no platform implications.

## Testing
- `just check` (fmt --check + clippy --all-targets --all-features -D warnings): passes clean.
- `cargo test --all-features`: 760 passed, 0 failed.

## Reviewing
Read `src/logging.rs` and `src/provider.rs` first (trivial 1:1 merges), then `src/session/storage.rs` (two near-identical merges appending a trailing condition to an existing let-chain), then `src/main.rs` and `src/ui/slash/providers.rs` (the more involved merges, where an outer `Ok`/`Some` unwrap was flattened into the chain while an inner independent condition was left as its own `if`).

## Notes
- `src/ui/slash/providers.rs` has two near-identical openrouter-pricing-fetch blocks (`apply_model` / `handle_model`) that were already duplicated before this PR; the fix mirrors that duplication faithfully rather than deduplicating it, since this PR is scoped to clippy compliance only. Flagging as a possible follow-up cleanup, not addressed here.
