### PR TITLE
fix(help): list all dispatched commands in /help output

### DIFF
--- a/src/ui/slash/help.rs
+++ b/src/ui/slash/help.rs
@@ -62,6 +62,14 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
         ctx.renderer,
         "  /mode <mode>           set mode (standard|restrictive|readonly|guarded|yolo)",
     );
+    write_result(
+        ctx.renderer,
+        "  /toggle                show toggleable features",
+    );
+    write_result(
+        ctx.renderer,
+        "  /toggle todo [on|off]  toggle todo-list tools",
+    );
     #[cfg(feature = "mcp")]
     {
         write_result(
@@ -94,6 +102,23 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
     write_result(ctx.renderer, "  /retry                 retry last prompt");
     write_result(
         ctx.renderer,
+        "  /queue                 list input queued while agent is busy",
+    );
+    write_result(ctx.renderer, "  /queue clear           clear the queue");
+    write_result(
+        ctx.renderer,
+        "  /queue pop             remove the last queued input",
+    );
+    write_result(
+        ctx.renderer,
+        "  /btw <message>         ask a side question in parallel (no session trace)",
+    );
+    write_result(
+        ctx.renderer,
+        "  /review [msg]          review code (auto message if omitted)",
+    );
+    write_result(
+        ctx.renderer,
         "  /compress [/compact]   compress conversation history",
     );
     write_result(
@@ -104,6 +129,27 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
         ctx.renderer,
         "  /editsys [mode]        edit system (similarity | hashedit)",
     );
+    #[cfg(feature = "advisor")]
+    {
+        write_result(ctx.renderer, "  /advisor               show advisor status");
+        write_result(
+            ctx.renderer,
+            "  /advisor on|off        enable or disable advisor",
+        );
+        write_result(
+            ctx.renderer,
+            "  /advisor handoff [on|off]  toggle human handoff mode",
+        );
+        write_result(ctx.renderer, "  /advisor model <name>  set advisor model");
+        write_result(
+            ctx.renderer,
+            "  /advisor max-uses <n>  set max advisor calls per request",
+        );
+        write_result(
+            ctx.renderer,
+            "  /advisor context-limit <n>  set max KB sent to advisor",
+        );
+    }
     #[cfg(feature = "loop")]
     {
         write_result(
@@ -125,6 +171,10 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
     );
     write_result(ctx.renderer, "  /prompt <name>         activate a prompt");
     write_result(ctx.renderer, "  /prompt default        clear active prompt");
+    write_result(
+        ctx.renderer,
+        "  /rename <name>         rename current session",
+    );
     write_result(
         ctx.renderer,
         "  /theme                 list available themes",


### PR DESCRIPTION
## Summary
`/help` was missing six commands that are already fully implemented, dispatched, and documented in `docs/COMMANDS.md`: `/toggle`, `/queue`, `/btw`, `/review`, `/advisor`, and `/rename`. This adds them to `src/ui/slash/help.rs`'s output so the help text matches what the dispatcher and docs already say is available.

Fixes #180.

## Motivation
Users who only ever check `/help` have no way to discover these commands. `/rename` specifically is reported missing in #180, which asked for it to appear "between `/prompt default` and `/theme`", exactly where this PR places it. While auditing the same gap, five more commands turned up with the identical problem (dispatched and documented, but absent from `/help`), so this fixes all of them together instead of shipping a one-line patch for #180 alone. This is a pure documentation/UX fix: no dispatch logic, behavior, or the command picker changed, since the picker (`src/ui/pickers/list.rs`) and `docs/COMMANDS.md` were already correct and already listed all six commands.

## Design decisions
Placement follows the existing grouping in `help.rs` rather than alphabetical or dispatch order: `/toggle` sits next to `/mode` since both are settings toggles; `/advisor` is grouped with `/editsys` before the `/loop` block, matching how `/mcp` and `/loop` are already each their own `#[cfg(feature = ...)]` block; `/queue`, `/btw`, and `/review` are grouped right after `/retry` since all three are "usable while the agent is busy" or analysis-style commands; `/rename` is placed exactly between `/prompt default` and `/theme`, matching what #180 explicitly asked for. `/advisor` is wrapped in `#[cfg(feature = "advisor")]` since it is a non-default feature, consistent with the existing `/mcp` and `/loop` blocks.

Platform support: unaffected. This diff only adds string literals to a function that prints static text; nothing here touches process spawning, paths, or settings loading, so no Windows-specific check was needed.

## Testing
- `cargo test --all-features`: 760 passed, 0 failed.
- `just check` (`cargo fmt --check` + `cargo clippy --all-targets --all-features -D warnings`): clean.
- Live verification: built the debug binary, drove the real TUI under `tmux` with a pre-seeded session (no LLM calls), and visually confirmed `/help` now prints all six new entries correctly, with `/advisor` correctly absent from a build compiled without the `advisor` feature.

## Reviewing
Single file, single commit, purely additive string literals inside `help.rs`'s `handle()` function. No control flow changed. Read top to bottom; every hunk is a straightforward insertion between two existing, unmodified lines.

## Notes
- Two of the six new `/advisor` lines (`/advisor handoff [on|off]` and `/advisor context-limit <n>`) run past the file's informal ~25-character description column because of their longer subcommand names. This mirrors existing precedent (the pre-existing `/memory` line already overflows to column 51), so it was left as-is rather than force-truncated.
- The `/advisor handoff` help text says "toggle human handoff mode," but the underlying handler treats a bare `/advisor handoff` (no arg) as always-enable, not a literal flip. The `[on|off]` form disambiguates, and the wording mirrors `docs/COMMANDS.md`'s own phrasing for this command, so it was kept for consistency with the existing docs rather than reworded.
- `/rename` only gets a `/rename <name>` line, not a bare no-arg line, even though `/toggle`/`/advisor`/`/queue` each get one. This matches `docs/COMMANDS.md`, which also only documents the `<name>` form, so it's an intentional asymmetry rather than a missed case.
- Out of scope: `src/ui/slash/docs.rs` implements a `/docs` command that is never wired into `handle_slash()`'s dispatch table, so it is currently unreachable dead code. That's a dispatch/logic bug, not a `/help` text gap, and fixing it would mean changing dispatch logic, which this PR intentionally does not touch. Flagging for a separate PR/issue.
