### PR TITLE
feat(memory): add memory_edit, backups, and long-term append dedup

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -120,7 +120,7 @@ Rules:
 
 ## Rig Tools
 
-Three tools are registered when the `memory` feature is enabled:
+Four tools are registered when the `memory` feature is enabled:
 
 ### `memory_write`
 
@@ -139,6 +139,19 @@ Three tools are registered when the `memory` feature is enabled:
 | `name` | string (opt) | Note stem or YYYY-MM-DD for daily |
 
 `source=list` enumerates all `.md` files in the store (global MEMORY.md + current project's notes + daily logs).
+
+### `memory_edit`
+
+| Parameter | Type | Description |
+|---|---|---|
+| `target` | string | `long_term`, `scratchpad`, `daily`, or `note` |
+| `name` | string (opt) | Note stem, required for `note` |
+| `old_str` | string (opt) | Substring to replace; must occur exactly once. Omit to delete a whole note |
+| `new_str` | string | Replacement text; empty string deletes the matched substring |
+
+Replaces a unique substring in a memory file in place. `old_str` is matched literally (no fuzzy matching) and must occur exactly once in the target file; zero or multiple matches fail without writing. `new_str` replaces the match verbatim with no newline cleanup, so an empty `new_str` deletes exactly the matched text, and including the trailing newline in `old_str` deletes a whole line.
+
+Omitting `old_str` deletes an entire note file (`notes/<name>.md`) from disk; this requires `target=note` with a `name`. Omitting `old_str` for `long_term`, `scratchpad`, or `daily` is rejected and changes nothing. Deleting a note that does not exist is an error.
 
 ### `memory_search`
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -145,7 +145,7 @@ Four tools are registered when the `memory` feature is enabled:
 | Parameter | Type | Description |
 |---|---|---|
 | `target` | string | `long_term`, `scratchpad`, `daily`, or `note` |
-| `name` | string (opt) | Note stem, required for `note` |
+| `name` | string (opt) | Note stem (required for `note`); or a `YYYY-MM-DD` date for `daily` to edit an earlier day (defaults to today) |
 | `old_str` | string (opt) | Substring to replace; must occur exactly once. Omit to delete a whole note |
 | `new_str` | string | Replacement text; empty string deletes the matched substring |
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -170,6 +170,8 @@ A backup is taken only before these operations (and only when the target file al
 
 Appends are non-destructive by construction, so they never back up. `daily` and `note` content edits are targeted unique-match replacements (low-risk and already reversible via a re-edit), so they are deliberately left un-backed-up to avoid churn.
 
+If the backup copy itself fails (for example the `.bak` path is not writable), the mutation still proceeds (the primary operation is what was asked for), but the tool response is suffixed with a `warning: backup failed, no .bak written` note so the caller knows there is no undo for that change. The failure is also logged.
+
 ### `memory_search`
 
 | Parameter | Type | Description |

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -51,7 +51,7 @@ Enum selecting which file to write to:
 
 ### `WriteMode`
 
-- `Append` — append content, inserting a `\n` separator if the file does not end with one
+- `Append` — append content, inserting a `\n` separator if the file does not end with one. For `long_term` only, appended lines are deduplicated (see [Long-term append deduplication](#long-term-append-deduplication))
 - `Overwrite` — replace the entire file
 
 ### `Mem`
@@ -175,6 +175,26 @@ Appends are non-destructive by construction, so they never back up. `daily` and 
 | Parameter | Type | Description |
 |---|---|---|
 | `query` | string | Space-separated keywords, searched case-insensitively |
+
+---
+
+## Long-term append deduplication
+
+`MEMORY.md` is curated one fact per line, so `memory_write target=long_term mode=append` deduplicates its lines. This applies to `long_term` appends **only**: `scratchpad`, `daily`, and `note` appends are never deduplicated (repeats are preserved), and no target dedups on `overwrite`.
+
+Comparison is whitespace-insensitive: each line is normalized by trimming and collapsing every run of Unicode whitespace (ASCII spaces/tabs and the full-width `U+3000` space) to a single ASCII space, preserving case. Two lines that differ only in whitespace width are duplicates.
+
+For a `long_term` append batch (the incoming content split on `\n`):
+
+1. Batch-internal duplicates are dropped, keeping the first occurrence.
+2. Lines whose normalized form already exists anywhere in `MEMORY.md` are dropped.
+3. Blank / whitespace-only lines normalize to empty; they are never a dedup key (they carry no fact) and are kept verbatim.
+4. If nothing meaningful survives, the write is skipped entirely and the file is left byte-for-byte unchanged.
+
+The response message reflects the outcome:
+- No duplicates: `Wrote N bytes to <path>` (unchanged).
+- Partial dedup: `Wrote N bytes to <path> (skipped M duplicate line(s))`.
+- Whole batch dropped: `Nothing written to <path>: all M line(s) were duplicates`.
 
 ---
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -153,6 +153,23 @@ Replaces a unique substring in a memory file in place. `old_str` is matched lite
 
 Omitting `old_str` deletes an entire note file (`notes/<name>.md`) from disk; this requires `target=note` with a `name`. Omitting `old_str` for `long_term`, `scratchpad`, or `daily` is rejected and changes nothing. Deleting a note that does not exist is an error.
 
+---
+
+## Backups
+
+Content-destroying mutations first copy the current file to a sibling `.bak` (single version, `MEMORY.md` becomes `MEMORY.bak`), so the pre-mutation content stays recoverable. There is exactly one `.bak` per file: each qualifying mutation overwrites the previous `.bak` rather than keeping a history. The `.bak` extension keeps these files out of `memory_read source=list` and `memory_search`, which both filter to `.md` only, so backups never leak into the model's context.
+
+A backup is taken only before these operations (and only when the target file already exists: a first-ever overwrite of a not-yet-created file has nothing to back up and skips silently):
+
+| Operation | `long_term` | `scratchpad` | `daily` | `note` |
+|---|---|---|---|---|
+| `memory_write` overwrite | Backs up | Backs up | No | No |
+| `memory_edit` content-replace (`old_str` given) | Backs up | Backs up | No | No |
+| `memory_edit` whole-note deletion (`old_str` omitted) | n/a | n/a | n/a | Backs up |
+| any append | No | No | No | No |
+
+Appends are non-destructive by construction, so they never back up. `daily` and `note` content edits are targeted unique-match replacements (low-risk and already reversible via a re-edit), so they are deliberately left un-backed-up to avoid churn.
+
 ### `memory_search`
 
 | Parameter | Type | Description |

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -235,8 +235,12 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
 
         #[cfg(feature = "memory")]
         {
-            use crate::extras::memory::{MemoryRead, MemorySearch, MemoryWrite};
+            use crate::extras::memory::{MemoryEdit, MemoryRead, MemorySearch, MemoryWrite};
             all_tools.push(Box::new(MemoryWrite::new(
+                permission.clone(),
+                ask_tx.clone(),
+            )));
+            all_tools.push(Box::new(MemoryEdit::new(
                 permission.clone(),
                 ask_tx.clone(),
             )));

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -79,6 +79,13 @@ are injected automatically; mark `- [x]` or rewrite with mode=overwrite when don
 - memory_write target=note name=<stem>: longer reference material kept on disk \
 and NOT auto-injected. Find it later with memory_search, then read it in full \
 with memory_read source=note name=<stem>.
+- memory_edit: replace a unique substring in a memory file in place (target=\
+long_term, scratchpad, daily, or note). old_str must occur EXACTLY once, matched \
+literally, so include enough surrounding text to make it unique; a zero- or \
+multiple-match old_str fails without writing. Set new_str to an empty string to \
+delete the matched text, and include the trailing newline in old_str to delete a \
+whole line. Use this to fix or remove existing memory; use memory_write to append \
+or overwrite.
 - memory_search: keyword search over all memory (including older daily logs not \
 injected above). Space-separated words are separate terms. It locates relevant \
 files with a little context — to use a file's full content, follow up with \

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -71,7 +71,9 @@ is already injected above; use the tools to read more or to persist new memory.
 
 - memory_write target=long_term: durable facts, preferences, and decisions that \
 should ALWAYS be remembered (written to MEMORY.md, injected every session). Keep \
-it curated and concise.
+it curated and concise: write ONE fact per line. Appends are deduplicated \
+(whitespace-insensitive), so re-appending a line already present is skipped and \
+leaves the file unchanged.
 - memory_write target=daily: a running log of what happened today. Use for \
 progress, findings, and context worth recalling soon but not forever.
 - memory_write target=scratchpad: a checklist; write `- [ ]` items. Open items \

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -307,8 +307,9 @@ impl Mem {
     /// bytes and nothing more. Unlike the source-code `EditTool`, there is no
     /// fuzzy fallback.
     ///
-    /// The `old_str: None` branch (whole-note deletion) is not yet supported and
-    /// is implemented in a later change.
+    /// The `old_str: None` branch deletes an entire note file (`target=note`,
+    /// `name=<stem>`) from disk. Omitting `old_str` for any non-note target
+    /// (`long_term`/`scratchpad`/`daily`) is a hard error that touches nothing.
     pub fn edit(
         &self,
         target: WriteTarget,
@@ -356,10 +357,21 @@ impl Mem {
                 atomic_write(&path, &updated)?;
                 Ok(format!("Edited {}", path.display()))
             }
-            None => Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "memory_edit without old_str (whole-note deletion) is not yet supported",
-            )),
+            None => {
+                if !matches!(target, WriteTarget::Note) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "memory_edit without old_str deletes a whole note; \
+it is only allowed for target=note, not long_term/scratchpad/daily",
+                    ));
+                }
+                // `path` is already the sanitized note path (Note branch above
+                // rejects invalid names via `note_path`). Removing a missing note
+                // surfaces the io NotFound error, so deleting a stale note the
+                // model no longer sees is a clear failure rather than a silent Ok.
+                fs::remove_file(&path)?;
+                Ok(format!("Deleted {}", path.display()))
+            }
         }
     }
 
@@ -914,18 +926,19 @@ occur EXACTLY once in the target file, matched literally (no fuzzy matching); if
 multiple times the edit fails and nothing is written, so include enough surrounding text to make it \
 unique. The match is replaced with new_str verbatim, with no newline cleanup: set new_str to an \
 empty string to delete the matched text, and include the trailing newline in old_str to delete a \
-whole line. Use memory_write to append or overwrite; use this to surgically fix or remove existing \
-content."
+whole line. Omit old_str entirely to delete a whole note file (requires target=note and name=<stem>); \
+omitting old_str for long_term/scratchpad/daily is rejected and changes nothing. Use memory_write to \
+append or overwrite; use this to surgically fix or remove existing content."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "target":  { "type": "string", "description": "long_term, scratchpad, daily, or note" },
                     "name":    { "type": "string", "description": "note stem, required for note" },
-                    "old_str": { "type": "string", "description": "substring to replace; must occur exactly once" },
+                    "old_str": { "type": "string", "description": "substring to replace; must occur exactly once. Omit to delete the whole note (target=note only)" },
                     "new_str": { "type": "string", "description": "replacement text; empty string deletes the matched substring" }
                 },
-                "required": ["target", "old_str", "new_str"]
+                "required": ["target", "new_str"]
             }),
         }
     }

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -298,6 +298,71 @@ impl Mem {
         Ok(msg)
     }
 
+    /// Strict, unique-substring content replacement in a memory file.
+    ///
+    /// `old_str` must occur EXACTLY once in the target file (0 or >1 matches is a
+    /// hard error naming the count, with no write performed). The single match is
+    /// replaced with `new_str` via `replace_range` — a plain substring swap with
+    /// no implicit newline cleanup, so `new_str=""` removes exactly the matched
+    /// bytes and nothing more. Unlike the source-code `EditTool`, there is no
+    /// fuzzy fallback.
+    ///
+    /// The `old_str: None` branch (whole-note deletion) is not yet supported and
+    /// is implemented in a later change.
+    pub fn edit(
+        &self,
+        target: WriteTarget,
+        name: Option<&str>,
+        old_str: Option<&str>,
+        new_str: &str,
+    ) -> std::io::Result<String> {
+        tracing::debug!(
+            "memory edit: target={:?}, has_old={}",
+            target,
+            old_str.is_some(),
+        );
+        let path = match target {
+            WriteTarget::LongTerm => self.memory_md(),
+            WriteTarget::Scratchpad => self.scratchpad(),
+            WriteTarget::Daily => self.daily_file(&self.today),
+            WriteTarget::Note => match name.and_then(|n| self.note_path(n)) {
+                Some(p) => p,
+                None => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "invalid note name (no slashes or dots)",
+                    ));
+                }
+            },
+        };
+        match old_str {
+            Some(old) => {
+                let current = fs::read_to_string(&path)?;
+                let count = current.match_indices(old).count();
+                if count != 1 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "old_str matched {count} time(s) in {}; it must match exactly once",
+                            path.display()
+                        ),
+                    ));
+                }
+                let pos = current
+                    .find(old)
+                    .expect("match_indices count == 1 guarantees a match");
+                let mut updated = current;
+                updated.replace_range(pos..pos + old.len(), new_str);
+                atomic_write(&path, &updated)?;
+                Ok(format!("Edited {}", path.display()))
+            }
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "memory_edit without old_str (whole-note deletion) is not yet supported",
+            )),
+        }
+    }
+
     /// Append a timestamped entry to today's daily log. Used by the
     /// pre-compaction flush so the rolling summary survives compaction
     /// deterministically, rather than at the model's discretion.
@@ -808,6 +873,84 @@ Prefer long_term for things that should always be remembered."
         };
         Mem::open()
             .write(target, &args.content, mode, args.name.as_deref())
+            .map_err(|e| ToolError::Msg(e.to_string()))
+    }
+}
+
+#[derive(Deserialize)]
+pub struct MemoryEditArgs {
+    /// "long_term" | "scratchpad" | "daily" | "note"
+    pub target: String,
+    /// required when target == "note"
+    pub name: Option<String>,
+    /// substring to replace; must occur exactly once in the target file
+    pub old_str: Option<String>,
+    /// replacement text (empty string deletes the matched substring)
+    #[serde(default)]
+    pub new_str: String,
+}
+
+pub struct MemoryEdit {
+    pub permission: Option<PermCheck>,
+    pub ask_tx: Option<AskSender>,
+}
+impl MemoryEdit {
+    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
+        Self { permission, ask_tx }
+    }
+}
+impl Tool for MemoryEdit {
+    const NAME: &'static str = "memory_edit";
+    type Error = ToolError;
+    type Args = MemoryEditArgs;
+    type Output = String;
+
+    async fn definition(&self, _p: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Replace a unique substring in a memory file in place. \
+target=long_term (MEMORY.md), scratchpad, daily (today's log), or note (name=<stem>). old_str must \
+occur EXACTLY once in the target file, matched literally (no fuzzy matching); if it matches zero or \
+multiple times the edit fails and nothing is written, so include enough surrounding text to make it \
+unique. The match is replaced with new_str verbatim, with no newline cleanup: set new_str to an \
+empty string to delete the matched text, and include the trailing newline in old_str to delete a \
+whole line. Use memory_write to append or overwrite; use this to surgically fix or remove existing \
+content."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "target":  { "type": "string", "description": "long_term, scratchpad, daily, or note" },
+                    "name":    { "type": "string", "description": "note stem, required for note" },
+                    "old_str": { "type": "string", "description": "substring to replace; must occur exactly once" },
+                    "new_str": { "type": "string", "description": "replacement text; empty string deletes the matched substring" }
+                },
+                "required": ["target", "old_str", "new_str"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: MemoryEditArgs) -> Result<String, ToolError> {
+        tracing::debug!(
+            "tool memory_edit: target={}, has_old={}",
+            args.target,
+            args.old_str.is_some(),
+        );
+        check_perm(&self.permission, &self.ask_tx, Self::NAME, &args.target).await?;
+        let target = match args.target.as_str() {
+            "long_term" => WriteTarget::LongTerm,
+            "scratchpad" => WriteTarget::Scratchpad,
+            "daily" => WriteTarget::Daily,
+            "note" => WriteTarget::Note,
+            other => return Err(ToolError::Msg(format!("unknown target: {other}"))),
+        };
+        Mem::open()
+            .edit(
+                target,
+                args.name.as_deref(),
+                args.old_str.as_deref(),
+                &args.new_str,
+            )
             .map_err(|e| ToolError::Msg(e.to_string()))
     }
 }

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -31,6 +31,18 @@ fn atomic_write(path: &Path, content: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Take a single-version backup of `path` before a content-destroying mutation,
+/// so it stays recoverable. Copies the current file to a sibling `.bak` path
+/// (`MEMORY.md` -> `MEMORY.bak`), OVERWRITING any prior `.bak` (one version, not
+/// a history). The `.bak` extension keeps it out of the `.md`-filtered list and
+/// search. If `path` doesn't exist yet (e.g. a first-ever overwrite), there's
+/// nothing to back up, so this is a no-op rather than an error.
+fn backup_file(path: &Path) {
+    if path.exists() {
+        let _ = fs::copy(path, path.with_extension("bak"));
+    }
+}
+
 /// Append the injected memory block to a system-prompt preamble.
 /// None/empty is a no-op, so an empty store leaves zero trace.
 pub fn append_memory_block(preamble: &mut String, memory: Option<&str>) {
@@ -145,6 +157,26 @@ impl Mem {
     }
     fn notes_dir(&self) -> PathBuf {
         self.project_dir().join("notes")
+    }
+    /// Enumerate every `.md` memory file visible to `source=list`: the global
+    /// MEMORY.md (the store root, whose only `.md` is MEMORY.md) plus the current
+    /// project's notes and daily logs, sorted. Any non-`.md` file (notably a
+    /// `.bak` backup) is excluded, matching `Mem::search`, so backups never
+    /// surface here. This is the exact enumeration the `memory_read source=list`
+    /// tool returns.
+    pub(crate) fn list(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        for dir in [self.root.clone(), self.notes_dir(), self.daily_dir()] {
+            if let Ok(rd) = fs::read_dir(&dir) {
+                for e in rd.flatten() {
+                    if e.path().extension().is_some_and(|x| x == "md") {
+                        names.push(e.path().display().to_string());
+                    }
+                }
+            }
+        }
+        names.sort();
+        names
     }
     pub(crate) fn daily_file(&self, date: &str) -> PathBuf {
         self.daily_dir().join(format!("{date}.md"))
@@ -273,7 +305,15 @@ impl Mem {
             fs::create_dir_all(parent)?;
         }
         match mode {
-            WriteMode::Overwrite => atomic_write(&path, content)?,
+            WriteMode::Overwrite => {
+                // Overwriting a curated file replaces its whole content; back it
+                // up first so the prior version is recoverable. Daily/note
+                // overwrites are out of scope (low-risk / not curated).
+                if matches!(target, WriteTarget::LongTerm | WriteTarget::Scratchpad) {
+                    backup_file(&path);
+                }
+                atomic_write(&path, content)?;
+            }
             WriteMode::Append => {
                 // Memory files are small; read-modify-write is simpler and clearer
                 // than seeking to the end to inspect the last byte.
@@ -354,6 +394,12 @@ impl Mem {
                     .expect("match_indices count == 1 guarantees a match");
                 let mut updated = current;
                 updated.replace_range(pos..pos + old.len(), new_str);
+                // A content-replace on a curated file mutates it in place; back
+                // up the pre-edit version. Daily/note edits are low-risk and out
+                // of scope.
+                if matches!(target, WriteTarget::LongTerm | WriteTarget::Scratchpad) {
+                    backup_file(&path);
+                }
                 atomic_write(&path, &updated)?;
                 Ok(format!("Edited {}", path.display()))
             }
@@ -369,6 +415,9 @@ it is only allowed for target=note, not long_term/scratchpad/daily",
                 // rejects invalid names via `note_path`). Removing a missing note
                 // surfaces the io NotFound error, so deleting a stale note the
                 // model no longer sees is a clear failure rather than a silent Ok.
+                // Back up the note's bytes before removing it (this branch is
+                // note-only by construction) so the deletion is recoverable.
+                backup_file(&path);
                 fs::remove_file(&path)?;
                 Ok(format!("Deleted {}", path.display()))
             }
@@ -1030,23 +1079,10 @@ daily (name=YYYY-MM-DD, omit for today), note (name=<stem>), or list (enumerate 
                     .ok_or_else(|| ToolError::Msg("invalid note name".into()))?;
                 Mem::read_capped(&p)
             }
-            "list" => {
-                // Global root yields MEMORY.md only (projects/ is a dir, skipped);
-                // notes_dir()/daily_dir() are the current project's, so listing is
-                // automatically scoped to global + current project.
-                let mut names = Vec::new();
-                for dir in [m.root.clone(), m.notes_dir(), m.daily_dir()] {
-                    if let Ok(rd) = fs::read_dir(&dir) {
-                        for e in rd.flatten() {
-                            if e.path().extension().is_some_and(|x| x == "md") {
-                                names.push(e.path().display().to_string());
-                            }
-                        }
-                    }
-                }
-                names.sort();
-                names.join("\n")
-            }
+            // Global root yields MEMORY.md only (projects/ is a dir, skipped);
+            // notes/daily are the current project's, so listing is automatically
+            // scoped to global + current project. See `Mem::list`.
+            "list" => m.list().join("\n"),
             other => return Err(ToolError::Msg(format!("unknown source: {other}"))),
         };
         Ok(body)

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -53,6 +53,15 @@ fn normalize_line(line: &str) -> String {
     line.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// A daily-log date name is caller-supplied (models pass `name=YYYY-MM-DD`), so
+/// it must be validated before being spliced into a path: `daily_file` does no
+/// sanitization, so an unchecked name like `../../secret` would traverse out of
+/// the memory store. Allow ASCII digits and hyphens only (enough for a
+/// `YYYY-MM-DD` date), which forbids `.`, `/`, and `\`.
+fn is_safe_daily_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_ascii_digit() || c == '-')
+}
+
 /// Append the injected memory block to a system-prompt preamble.
 /// None/empty is a no-op, so an empty store leaves zero trace.
 pub fn append_memory_block(preamble: &mut String, memory: Option<&str>) {
@@ -437,7 +446,19 @@ impl Mem {
         let path = match target {
             WriteTarget::LongTerm => self.memory_md(),
             WriteTarget::Scratchpad => self.scratchpad(),
-            WriteTarget::Daily => self.daily_file(&self.today),
+            WriteTarget::Daily => {
+                // Honor a caller-supplied date (`name`) the way memory_read does,
+                // defaulting to today; validate it first since `daily_file` does
+                // no sanitization of its own.
+                let date = name.unwrap_or(&self.today);
+                if !is_safe_daily_name(date) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "invalid daily date name (expected YYYY-MM-DD: digits and hyphens only)",
+                    ));
+                }
+                self.daily_file(date)
+            }
             WriteTarget::Note => match name.and_then(|n| self.note_path(n)) {
                 Some(p) => p,
                 None => {
@@ -1044,7 +1065,8 @@ impl Tool for MemoryEdit {
         ToolDefinition {
             name: Self::NAME.to_string(),
             description: "Replace a unique substring in a memory file in place. \
-target=long_term (MEMORY.md), scratchpad, daily (today's log), or note (name=<stem>). old_str must \
+target=long_term (MEMORY.md), scratchpad, daily (a day's log; pass name=YYYY-MM-DD to edit an \
+earlier day, defaults to today), or note (name=<stem>). old_str must \
 occur EXACTLY once in the target file, matched literally (no fuzzy matching); if it matches zero or \
 multiple times the edit fails and nothing is written, so include enough surrounding text to make it \
 unique. The match is replaced with new_str verbatim, with no newline cleanup: set new_str to an \

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -38,9 +38,25 @@ fn atomic_write(path: &Path, content: &str) -> std::io::Result<()> {
 /// a history). The `.bak` extension keeps it out of the `.md`-filtered list and
 /// search. If `path` doesn't exist yet (e.g. a first-ever overwrite), there's
 /// nothing to back up, so this is a no-op rather than an error.
-fn backup_file(path: &Path) {
+fn backup_file(path: &Path) -> std::io::Result<()> {
     if path.exists() {
-        let _ = fs::copy(path, path.with_extension("bak"));
+        fs::copy(path, path.with_extension("bak"))?;
+    }
+    Ok(())
+}
+
+/// Back up `path` and return a warning suffix for the tool response if the
+/// backup could not be written (empty string on success). The mutation still
+/// proceeds (fail-open): the primary operation is what the caller asked for, but
+/// a failed backup means there is no `.bak` to undo it, so the response must say
+/// so. The failure is also logged.
+fn backup_warning(path: &Path) -> String {
+    match backup_file(path) {
+        Ok(()) => String::new(),
+        Err(e) => {
+            tracing::warn!("memory backup of {} failed: {e}", path.display());
+            format!(" (warning: backup failed, no .bak written: {e})")
+        }
     }
 }
 
@@ -330,13 +346,14 @@ impl Mem {
         let mut appended_len = content.len();
         let mut dedup_note = String::new();
         let mut nothing_written: Option<usize> = None;
+        let mut backup_note = String::new();
         match mode {
             WriteMode::Overwrite => {
                 // Overwriting a curated file replaces its whole content; back it
                 // up first so the prior version is recoverable. Daily/note
                 // overwrites are out of scope (low-risk / not curated).
                 if matches!(target, WriteTarget::LongTerm | WriteTarget::Scratchpad) {
-                    backup_file(&path);
+                    backup_note = backup_warning(&path);
                 }
                 atomic_write(&path, content)?;
             }
@@ -407,7 +424,7 @@ impl Mem {
             ));
         }
         let mut msg = format!(
-            "Wrote {appended_len} bytes to {}{dedup_note}",
+            "Wrote {appended_len} bytes to {}{dedup_note}{backup_note}",
             path.display()
         );
         if original_len > content.len() {
@@ -490,11 +507,12 @@ impl Mem {
                 // A content-replace on a curated file mutates it in place; back
                 // up the pre-edit version. Daily/note edits are low-risk and out
                 // of scope.
+                let mut warn = String::new();
                 if matches!(target, WriteTarget::LongTerm | WriteTarget::Scratchpad) {
-                    backup_file(&path);
+                    warn = backup_warning(&path);
                 }
                 atomic_write(&path, &updated)?;
-                Ok(format!("Edited {}", path.display()))
+                Ok(format!("Edited {}{warn}", path.display()))
             }
             None => {
                 if !matches!(target, WriteTarget::Note) {
@@ -510,9 +528,9 @@ it is only allowed for target=note, not long_term/scratchpad/daily",
                 // model no longer sees is a clear failure rather than a silent Ok.
                 // Back up the note's bytes before removing it (this branch is
                 // note-only by construction) so the deletion is recoverable.
-                backup_file(&path);
+                let warn = backup_warning(&path);
                 fs::remove_file(&path)?;
-                Ok(format!("Deleted {}", path.display()))
+                Ok(format!("Deleted {}{warn}", path.display()))
             }
         }
     }

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -1182,7 +1182,18 @@ daily (name=YYYY-MM-DD, omit for today), note (name=<stem>), or list (enumerate 
         let body = match args.source.as_str() {
             "long_term" => Mem::read_capped(&m.memory_md()),
             "scratchpad" => Mem::read_capped(&m.scratchpad()),
-            "daily" => Mem::read_capped(&m.daily_file(args.name.as_deref().unwrap_or(&m.today))),
+            "daily" => {
+                // `name` is caller-supplied; validate before splicing it into a
+                // path, since `daily_file` does no sanitization (an unchecked
+                // name would traverse out of the memory store).
+                let date = args.name.as_deref().unwrap_or(&m.today);
+                if !is_safe_daily_name(date) {
+                    return Err(ToolError::Msg(
+                        "invalid daily date name (expected YYYY-MM-DD)".into(),
+                    ));
+                }
+                Mem::read_capped(&m.daily_file(date))
+            }
             "note" => {
                 let name = args
                     .name

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -41,6 +42,15 @@ fn backup_file(path: &Path) {
     if path.exists() {
         let _ = fs::copy(path, path.with_extension("bak"));
     }
+}
+
+/// Normalize a line for long-term append dedup comparison: trim, and collapse
+/// every run of Unicode whitespace (ASCII spaces/tabs and full-width U+3000) to
+/// a single ASCII space, preserving case. `split_whitespace` uses the Unicode
+/// White_Space property, so U+3000 folds like an ASCII space, and a whitespace-
+/// only line normalizes to the empty string.
+fn normalize_line(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Append the injected memory block to a system-prompt preamble.
@@ -304,6 +314,13 @@ impl Mem {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
+        // Message state: `appended_len` is the byte count reported as written
+        // (content bytes for overwrite, surviving bytes for a deduped append);
+        // `dedup_note` is an optional suffix; `nothing_written` short-circuits to
+        // the whole-batch-dropped message. Only long_term append ever sets these.
+        let mut appended_len = content.len();
+        let mut dedup_note = String::new();
+        let mut nothing_written: Option<usize> = None;
         match mode {
             WriteMode::Overwrite => {
                 // Overwriting a curated file replaces its whole content; back it
@@ -315,20 +332,75 @@ impl Mem {
                 atomic_write(&path, content)?;
             }
             WriteMode::Append => {
-                // Memory files are small; read-modify-write is simpler and clearer
-                // than seeking to the end to inspect the last byte.
-                let mut prev = fs::read_to_string(&path).unwrap_or_default();
-                if !prev.is_empty() && !prev.ends_with('\n') {
-                    prev.push('\n');
+                // Long-term memory is curated one-fact-per-line, so drop lines
+                // whose normalized form repeats within this batch or already
+                // exists in MEMORY.md. Blank/whitespace-only lines normalize to
+                // empty and are never treated as a dedup key (they carry no fact,
+                // so they must not swallow real content); they are kept verbatim.
+                // Dedup is scoped to long_term ONLY: scratchpad/daily/note appends
+                // stay byte-identical to the pre-dedup behavior.
+                let mut append_content = content.to_string();
+                if matches!(target, WriteTarget::LongTerm) {
+                    let existing = fs::read_to_string(&path).unwrap_or_default();
+                    let mut seen: HashSet<String> = existing
+                        .lines()
+                        .map(normalize_line)
+                        .filter(|n| !n.is_empty())
+                        .collect();
+                    let mut kept: Vec<&str> = Vec::new();
+                    let mut skipped = 0usize;
+                    for line in content.split('\n') {
+                        let norm = normalize_line(line);
+                        if norm.is_empty() {
+                            kept.push(line);
+                            continue;
+                        }
+                        // insert returns false when the key was already present,
+                        // covering both prior file content and earlier batch lines.
+                        if seen.insert(norm) {
+                            kept.push(line);
+                        } else {
+                            skipped += 1;
+                        }
+                    }
+                    if skipped > 0 {
+                        let survived = kept.iter().any(|l| !normalize_line(l).is_empty());
+                        if survived {
+                            append_content = kept.join("\n");
+                            dedup_note = format!(" (skipped {skipped} duplicate line(s))");
+                        } else {
+                            // Nothing meaningful survived: leave the file untouched
+                            // (no atomic_write) and report that nothing was written.
+                            nothing_written = Some(skipped);
+                        }
+                    }
                 }
-                prev.push_str(content);
-                if !prev.ends_with('\n') {
-                    prev.push('\n');
+                if nothing_written.is_none() {
+                    // Memory files are small; read-modify-write is simpler and clearer
+                    // than seeking to the end to inspect the last byte.
+                    let mut prev = fs::read_to_string(&path).unwrap_or_default();
+                    if !prev.is_empty() && !prev.ends_with('\n') {
+                        prev.push('\n');
+                    }
+                    prev.push_str(&append_content);
+                    if !prev.ends_with('\n') {
+                        prev.push('\n');
+                    }
+                    atomic_write(&path, &prev)?;
+                    appended_len = append_content.len();
                 }
-                atomic_write(&path, &prev)?;
             }
         }
-        let mut msg = format!("Wrote {} bytes to {}", content.len(), path.display());
+        if let Some(n) = nothing_written {
+            return Ok(format!(
+                "Nothing written to {}: all {n} line(s) were duplicates",
+                path.display()
+            ));
+        }
+        let mut msg = format!(
+            "Wrote {appended_len} bytes to {}{dedup_note}",
+            path.display()
+        );
         if original_len > content.len() {
             msg.push_str(&format!(
                 " (truncated from {original_len} bytes to {} byte cap)",
@@ -895,7 +967,9 @@ impl Tool for MemoryWrite {
         ToolDefinition {
             name: Self::NAME.to_string(),
             description: "Persist durable memory to disk. target=long_term writes curated facts/\
-preferences/decisions to MEMORY.md (always loaded next session). target=scratchpad maintains a \
+preferences/decisions to MEMORY.md (always loaded next session), one fact per line; long_term \
+appends are deduplicated (whitespace-insensitive) so a line already present is skipped. \
+target=scratchpad maintains a \
 per-project checklist (use `- [ ]` items; open ones are auto-injected, mode=overwrite to rewrite the list). \
 target=daily appends to today's running log. target=note saves reference material to \
 notes/<name>.md (find it later with memory_search, then read it in full with memory_read). \

--- a/src/extras/subagents/builder.rs
+++ b/src/extras/subagents/builder.rs
@@ -4,6 +4,20 @@ use crate::provider::{AnyAgent, AnyModel, OpenAiAgent, OpenAiModel};
 use rig::agent::{Agent, AgentBuilder};
 use rig::completion::CompletionModel;
 
+/// The memory tools a subagent is granted: read-only access ONLY
+/// (`memory_read`, `memory_search`). `memory_write` and `memory_edit` are
+/// deliberately absent, so a subagent can never mutate the user's memory. This
+/// is the single place the subagent memory tool set is assembled, so the
+/// `subagent_memory_tool_set_excludes_memory_edit` test can guard it directly
+/// instead of re-listing the tools it expects.
+#[cfg(feature = "memory")]
+pub(crate) fn subagent_memory_tools() -> Vec<Box<dyn rig::tool::ToolDyn>> {
+    vec![
+        Box::new(crate::extras::memory::MemoryRead::new(None, None)),
+        Box::new(crate::extras::memory::MemorySearch::new(None, None)),
+    ]
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_explore_agent_inner<M: CompletionModel + 'static>(
     model: M,
@@ -42,11 +56,13 @@ fn build_explore_agent_inner<M: CompletionModel + 'static>(
         Box::new(tools::GrepTool::new(None, None, max_grep_results)),
         Box::new(tools::FindFilesTool::new(None, None, max_find_results)),
         Box::new(tools::ListDirTool::new(None, None, max_list_dir_entries)),
-        #[cfg(feature = "memory")]
-        Box::new(crate::extras::memory::MemoryRead::new(None, None)),
-        #[cfg(feature = "memory")]
-        Box::new(crate::extras::memory::MemorySearch::new(None, None)),
     ];
+    #[cfg(feature = "memory")]
+    let tools = {
+        let mut tools = tools;
+        tools.extend(subagent_memory_tools());
+        tools
+    };
 
     #[cfg(feature = "hooks")]
     let tools = crate::extras::hooks::wrap_from_global(tools, None);

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -441,6 +441,62 @@ fn edit_empty_new_str_removes_exactly_the_matched_substring() {
 }
 
 #[test]
+fn edit_omitted_old_str_deletes_note_file() {
+    let m = fresh("edit-del-note");
+    m.write(
+        WriteTarget::Note,
+        "body",
+        WriteMode::Overwrite,
+        Some("somestem"),
+    )
+    .unwrap();
+    let note = m.note_path("somestem").unwrap();
+    assert!(note.exists(), "note file should exist after write");
+    let msg = m
+        .edit(WriteTarget::Note, Some("somestem"), None, "")
+        .unwrap();
+    assert!(
+        msg.contains("Deleted"),
+        "message should confirm deletion: {msg}"
+    );
+    assert!(!note.exists(), "note file should be gone after delete");
+    cleanup(&m);
+}
+
+#[test]
+fn edit_omitted_old_str_rejects_non_note_targets_and_leaves_files() {
+    let m = fresh("edit-del-reject");
+    for (target, path, content) in [
+        (WriteTarget::LongTerm, memory_md(&m), "lt content\n"),
+        (WriteTarget::Scratchpad, scratchpad(&m), "sp content\n"),
+        (WriteTarget::Daily, daily(&m, &m.today), "daily content\n"),
+    ] {
+        fs::write(&path, content).unwrap();
+        assert!(
+            m.edit(target, None, None, "").is_err(),
+            "omitting old_str for non-note target must error"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            content,
+            "non-note file must be unchanged"
+        );
+    }
+    cleanup(&m);
+}
+
+#[test]
+fn edit_omitted_old_str_missing_note_errors() {
+    let m = fresh("edit-del-missing");
+    // No note written; deleting a non-existent note is a clear error.
+    assert!(
+        m.edit(WriteTarget::Note, Some("ghost"), None, "").is_err(),
+        "deleting an absent note should error"
+    );
+    cleanup(&m);
+}
+
+#[test]
 fn subagent_memory_tool_set_excludes_memory_edit() {
     use crate::extras::memory::MemoryEdit;
     use crate::extras::subagents::builder::subagent_memory_tools;

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -383,6 +383,83 @@ fn context_block_truncates_cjk_without_panic() {
     cleanup(&m);
 }
 
+// ---- edit --------------------------------------------------------------------
+
+#[test]
+fn edit_unique_match_replaces_only_that_occurrence() {
+    let m = fresh("edit-uniq");
+    fs::write(memory_md(&m), "alpha\nbeta\ngamma\n").unwrap();
+    m.edit(WriteTarget::LongTerm, None, Some("beta"), "BETA")
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(memory_md(&m)).unwrap(),
+        "alpha\nBETA\ngamma\n"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn edit_zero_matches_errors_and_leaves_file_unchanged() {
+    let m = fresh("edit-zero");
+    let before = "alpha\nbeta\n";
+    fs::write(memory_md(&m), before).unwrap();
+    assert!(
+        m.edit(WriteTarget::LongTerm, None, Some("nope"), "x")
+            .is_err()
+    );
+    assert_eq!(fs::read_to_string(memory_md(&m)).unwrap(), before);
+    cleanup(&m);
+}
+
+#[test]
+fn edit_multiple_matches_errors_with_count_and_leaves_file_unchanged() {
+    let m = fresh("edit-multi");
+    let before = "dup\ndup\ndup\n";
+    fs::write(memory_md(&m), before).unwrap();
+    let err = m
+        .edit(WriteTarget::LongTerm, None, Some("dup"), "x")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains('3'),
+        "error should name the match count: {err}"
+    );
+    assert_eq!(fs::read_to_string(memory_md(&m)).unwrap(), before);
+    cleanup(&m);
+}
+
+#[test]
+fn edit_empty_new_str_removes_exactly_the_matched_substring() {
+    let m = fresh("edit-del");
+    fs::write(memory_md(&m), "keep this LINE and more\n").unwrap();
+    m.edit(WriteTarget::LongTerm, None, Some("LINE "), "")
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(memory_md(&m)).unwrap(),
+        "keep this and more\n"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn subagent_memory_tool_set_excludes_memory_edit() {
+    use crate::extras::memory::MemoryEdit;
+    use crate::extras::subagents::builder::subagent_memory_tools;
+    use rig::tool::Tool;
+    // Exercise the real production assembly of a subagent's memory tools, not a
+    // hand-copied list: build_explore_agent_inner grants exactly what this
+    // function returns, so if memory_edit (or any mutating tool) ever leaks into
+    // it, this fails.
+    let names: Vec<String> = subagent_memory_tools().iter().map(|t| t.name()).collect();
+    assert!(
+        !names.iter().any(|n| n == MemoryEdit::NAME),
+        "subagents must not receive memory_edit; got {names:?}"
+    );
+    // Sanity: the granted set is the read-only pair, and memory_edit is a real,
+    // distinct tool that is simply never added.
+    assert_eq!(names, vec!["memory_read", "memory_search"]);
+    assert_eq!(MemoryEdit::NAME, "memory_edit");
+}
+
 // ---- search -----------------------------------------------------------------
 
 #[test]

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -496,6 +496,221 @@ fn edit_omitted_old_str_missing_note_errors() {
     cleanup(&m);
 }
 
+// ---- backup before destructive mutation --------------------------------------
+
+#[test]
+fn overwrite_long_term_backs_up_pre_overwrite_content() {
+    let m = fresh("bak-lt-ov");
+    m.write(
+        WriteTarget::LongTerm,
+        "original v1",
+        WriteMode::Overwrite,
+        None,
+    )
+    .unwrap();
+    m.write(
+        WriteTarget::LongTerm,
+        "replaced v2",
+        WriteMode::Overwrite,
+        None,
+    )
+    .unwrap();
+    let bak = memory_md(&m).with_extension("bak");
+    assert!(bak.exists(), "overwrite should have created a .bak");
+    assert_eq!(fs::read_to_string(&bak).unwrap(), "original v1");
+    assert_eq!(fs::read_to_string(memory_md(&m)).unwrap(), "replaced v2");
+    cleanup(&m);
+}
+
+#[test]
+fn overwrite_scratchpad_backs_up_pre_overwrite_content() {
+    let m = fresh("bak-sp-ov");
+    m.write(
+        WriteTarget::Scratchpad,
+        "- [ ] first",
+        WriteMode::Overwrite,
+        None,
+    )
+    .unwrap();
+    m.write(
+        WriteTarget::Scratchpad,
+        "- [ ] second",
+        WriteMode::Overwrite,
+        None,
+    )
+    .unwrap();
+    let bak = scratchpad(&m).with_extension("bak");
+    assert!(
+        bak.exists(),
+        "scratchpad overwrite should have created a .bak"
+    );
+    assert_eq!(fs::read_to_string(&bak).unwrap(), "- [ ] first");
+    cleanup(&m);
+}
+
+#[test]
+fn first_ever_overwrite_creates_no_backup() {
+    let m = fresh("bak-first");
+    // Nothing on disk yet: overwriting a not-yet-created file must not error and
+    // must not fabricate a .bak (there is nothing to back up).
+    m.write(
+        WriteTarget::LongTerm,
+        "brand new",
+        WriteMode::Overwrite,
+        None,
+    )
+    .unwrap();
+    assert!(!memory_md(&m).with_extension("bak").exists());
+    cleanup(&m);
+}
+
+#[test]
+fn overwrite_bak_is_single_version_overwriting_prior() {
+    let m = fresh("bak-single");
+    m.write(WriteTarget::LongTerm, "gen1", WriteMode::Overwrite, None)
+        .unwrap();
+    m.write(WriteTarget::LongTerm, "gen2", WriteMode::Overwrite, None)
+        .unwrap();
+    m.write(WriteTarget::LongTerm, "gen3", WriteMode::Overwrite, None)
+        .unwrap();
+    // Single .bak, overwritten each time: it holds the content just before the
+    // latest overwrite (gen2), not the original (gen1).
+    let bak = memory_md(&m).with_extension("bak");
+    assert_eq!(fs::read_to_string(&bak).unwrap(), "gen2");
+    cleanup(&m);
+}
+
+#[test]
+fn append_never_backs_up() {
+    let m = fresh("bak-append");
+    m.write(WriteTarget::LongTerm, "a", WriteMode::Append, None)
+        .unwrap();
+    m.write(WriteTarget::LongTerm, "b", WriteMode::Append, None)
+        .unwrap();
+    assert!(
+        !memory_md(&m).with_extension("bak").exists(),
+        "append is non-destructive and must not back up"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn edit_replace_long_term_backs_up_pre_edit_content() {
+    let m = fresh("bak-lt-edit");
+    fs::write(memory_md(&m), "alpha\nbeta\ngamma\n").unwrap();
+    m.edit(WriteTarget::LongTerm, None, Some("beta"), "BETA")
+        .unwrap();
+    let bak = memory_md(&m).with_extension("bak");
+    assert!(
+        bak.exists(),
+        "content-replace edit should have created a .bak"
+    );
+    assert_eq!(fs::read_to_string(&bak).unwrap(), "alpha\nbeta\ngamma\n");
+    cleanup(&m);
+}
+
+#[test]
+fn edit_replace_scratchpad_backs_up_pre_edit_content() {
+    let m = fresh("bak-sp-edit");
+    fs::write(scratchpad(&m), "- [ ] keep\n- [ ] change me\n").unwrap();
+    m.edit(WriteTarget::Scratchpad, None, Some("change me"), "changed")
+        .unwrap();
+    let bak = scratchpad(&m).with_extension("bak");
+    assert!(bak.exists(), "scratchpad edit should have created a .bak");
+    assert_eq!(
+        fs::read_to_string(&bak).unwrap(),
+        "- [ ] keep\n- [ ] change me\n"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn note_deletion_backs_up_deleted_bytes() {
+    let m = fresh("bak-note-del");
+    m.write(
+        WriteTarget::Note,
+        "note body to preserve",
+        WriteMode::Overwrite,
+        Some("somestem"),
+    )
+    .unwrap();
+    let note = m.note_path("somestem").unwrap();
+    m.edit(WriteTarget::Note, Some("somestem"), None, "")
+        .unwrap();
+    assert!(!note.exists(), "note file should be gone after delete");
+    let bak = note.with_extension("bak");
+    assert!(bak.exists(), "note deletion should have created a .bak");
+    assert_eq!(fs::read_to_string(&bak).unwrap(), "note body to preserve");
+    cleanup(&m);
+}
+
+#[test]
+fn daily_content_edit_creates_no_backup() {
+    let m = fresh("bak-daily-edit");
+    fs::write(daily(&m, &m.today), "morning\nafternoon\n").unwrap();
+    m.edit(WriteTarget::Daily, None, Some("afternoon"), "evening")
+        .unwrap();
+    assert!(
+        !daily(&m, &m.today).with_extension("bak").exists(),
+        "daily content edit is low-risk and must not back up"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn note_content_edit_creates_no_backup() {
+    let m = fresh("bak-note-edit");
+    m.write(
+        WriteTarget::Note,
+        "first\nsecond\n",
+        WriteMode::Overwrite,
+        Some("mynote"),
+    )
+    .unwrap();
+    // Clear the .bak that the initial overwrite of a fresh (nonexistent) note
+    // would NOT have made anyway, then do a content edit.
+    m.edit(WriteTarget::Note, Some("mynote"), Some("second"), "SECOND")
+        .unwrap();
+    let bak = m.note_path("mynote").unwrap().with_extension("bak");
+    assert!(
+        !bak.exists(),
+        "note content edit is low-risk and must not back up"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn bak_files_never_surface_in_list_or_search() {
+    let m = fresh("bak-hidden");
+    // Real content plus a sibling .bak on disk, in each searched location.
+    fs::write(memory_md(&m), "SECRETMARK in memory\n").unwrap();
+    fs::write(memory_md(&m).with_extension("bak"), "SECRETMARK backup\n").unwrap();
+    fs::write(m.note_path("mynote").unwrap(), "SECRETMARK in note\n").unwrap();
+    fs::write(
+        m.note_path("mynote").unwrap().with_extension("bak"),
+        "SECRETMARK note backup\n",
+    )
+    .unwrap();
+    // search must never return a .bak path.
+    for h in m.search("SECRETMARK").hits {
+        assert!(
+            h.path.extension().and_then(|e| e.to_str()) != Some("bak"),
+            "search surfaced a .bak file: {}",
+            h.path.display()
+        );
+    }
+    // Mem::list is the exact enumeration behind `memory_read source=list`; drive
+    // it directly on this test's store so a regression in its `.md` filter would
+    // surface a .bak here.
+    let listed = m.list();
+    assert!(
+        !listed.iter().any(|n| n.ends_with(".bak")),
+        "list surfaced a .bak file: {listed:?}"
+    );
+    assert!(listed.iter().any(|n| n.ends_with("MEMORY.md")));
+    cleanup(&m);
+}
+
 #[test]
 fn subagent_memory_tool_set_excludes_memory_edit() {
     use crate::extras::memory::MemoryEdit;

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -619,6 +619,28 @@ fn overwrite_bak_is_single_version_overwriting_prior() {
 }
 
 #[test]
+fn backup_failure_warns_but_completes_the_mutation() {
+    let m = fresh("bak-fail");
+    fs::write(memory_md(&m), "v1").unwrap();
+    // Make the .bak path a directory so `fs::copy` into it fails on every
+    // platform, without depending on permission bits.
+    fs::create_dir(memory_md(&m).with_extension("bak")).unwrap();
+    let msg = m
+        .write(WriteTarget::LongTerm, "v2", WriteMode::Overwrite, None)
+        .unwrap();
+    assert!(
+        msg.contains("backup failed"),
+        "a failed backup must be surfaced in the response: {msg}"
+    );
+    assert_eq!(
+        fs::read_to_string(memory_md(&m)).unwrap(),
+        "v2",
+        "the mutation must still complete despite the backup failure (fail-open)"
+    );
+    cleanup(&m);
+}
+
+#[test]
 fn append_never_backs_up() {
     let m = fresh("bak-append");
     m.write(WriteTarget::LongTerm, "a", WriteMode::Append, None)

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -594,6 +594,127 @@ fn append_never_backs_up() {
     cleanup(&m);
 }
 
+// ---- long-term append deduplication -----------------------------------------
+
+#[test]
+fn append_long_term_skips_existing_duplicate_line() {
+    let m = fresh("dedup-existing");
+    fs::write(memory_md(&m), "alpha\nbeta\n").unwrap();
+    let before = fs::read(memory_md(&m)).unwrap();
+    let msg = m
+        .write(WriteTarget::LongTerm, "beta", WriteMode::Append, None)
+        .unwrap();
+    assert_eq!(
+        before,
+        fs::read(memory_md(&m)).unwrap(),
+        "duplicate append must leave the file byte-for-byte unchanged"
+    );
+    assert!(
+        msg.contains("Nothing written") && msg.contains("1 line"),
+        "message should report nothing written: {msg}"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn append_long_term_dedups_whitespace_and_fullwidth_variants() {
+    let m = fresh("dedup-ws");
+    fs::write(memory_md(&m), "the quick brown fox\n").unwrap();
+    let before = fs::read(memory_md(&m)).unwrap();
+    // Leading/trailing padding, widened internal runs, and a full-width U+3000
+    // space all normalize to the same line as the existing one.
+    let msg = m
+        .write(
+            WriteTarget::LongTerm,
+            "  the   quick\u{3000}brown  fox  ",
+            WriteMode::Append,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        before,
+        fs::read(memory_md(&m)).unwrap(),
+        "whitespace-only variation must be treated as a duplicate"
+    );
+    assert!(msg.contains("Nothing written"), "{msg}");
+    cleanup(&m);
+}
+
+#[test]
+fn append_long_term_dedups_within_a_single_batch() {
+    let m = fresh("dedup-batch");
+    let msg = m
+        .write(
+            WriteTarget::LongTerm,
+            "fact one\nfact one\nfact two",
+            WriteMode::Append,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(memory_md(&m)).unwrap(),
+        "fact one\nfact two\n",
+        "a repeated line within one batch must keep only the first occurrence"
+    );
+    assert!(msg.contains("skipped 1 duplicate"), "{msg}");
+    cleanup(&m);
+}
+
+#[test]
+fn append_long_term_whole_batch_duplicate_leaves_file_and_reports_nothing() {
+    let m = fresh("dedup-whole");
+    fs::write(memory_md(&m), "one\ntwo\n").unwrap();
+    let before = fs::read(memory_md(&m)).unwrap();
+    let msg = m
+        .write(WriteTarget::LongTerm, "two\none", WriteMode::Append, None)
+        .unwrap();
+    assert_eq!(
+        before,
+        fs::read(memory_md(&m)).unwrap(),
+        "an all-duplicate batch must leave the file untouched"
+    );
+    assert!(
+        msg.contains("Nothing written") && msg.contains("2 line"),
+        "{msg}"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn append_non_long_term_never_dedups() {
+    let m = fresh("dedup-others");
+    m.write(WriteTarget::Scratchpad, "repeat", WriteMode::Append, None)
+        .unwrap();
+    m.write(WriteTarget::Scratchpad, "repeat", WriteMode::Append, None)
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(scratchpad(&m)).unwrap(),
+        "repeat\nrepeat\n",
+        "scratchpad appends must never be deduplicated"
+    );
+
+    m.write(WriteTarget::Daily, "dup line", WriteMode::Append, None)
+        .unwrap();
+    m.write(WriteTarget::Daily, "dup line", WriteMode::Append, None)
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(daily(&m, &m.today)).unwrap(),
+        "dup line\ndup line\n",
+        "daily appends must never be deduplicated"
+    );
+
+    m.write(WriteTarget::Note, "same", WriteMode::Append, Some("n"))
+        .unwrap();
+    m.write(WriteTarget::Note, "same", WriteMode::Append, Some("n"))
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(m.note_path("n").unwrap()).unwrap(),
+        "same\nsame\n",
+        "note appends must never be deduplicated"
+    );
+    cleanup(&m);
+}
+
 #[test]
 fn edit_replace_long_term_backs_up_pre_edit_content() {
     let m = fresh("bak-lt-edit");

--- a/src/tests/memory_tests.rs
+++ b/src/tests/memory_tests.rs
@@ -486,6 +486,44 @@ fn edit_omitted_old_str_rejects_non_note_targets_and_leaves_files() {
 }
 
 #[test]
+fn edit_daily_honors_name_for_an_earlier_day() {
+    let m = fresh("edit-daily-name");
+    let past = "2026-01-02";
+    fs::write(daily(&m, past), "old line\n").unwrap();
+    fs::write(daily(&m, &m.today), "today line\n").unwrap();
+    m.edit(WriteTarget::Daily, Some(past), Some("old line"), "new line")
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(daily(&m, past)).unwrap(),
+        "new line\n",
+        "the named day's log should be edited"
+    );
+    assert_eq!(
+        fs::read_to_string(daily(&m, &m.today)).unwrap(),
+        "today line\n",
+        "today's log must be untouched when name selects another day"
+    );
+    cleanup(&m);
+}
+
+#[test]
+fn edit_daily_rejects_unsafe_name_without_touching_files() {
+    let m = fresh("edit-daily-unsafe");
+    // A traversal-style name must be rejected before any path is built.
+    assert!(
+        m.edit(
+            WriteTarget::Daily,
+            Some("../../../etc/passwd"),
+            Some("x"),
+            "y"
+        )
+        .is_err(),
+        "a non-date daily name must be rejected"
+    );
+    cleanup(&m);
+}
+
+#[test]
 fn edit_omitted_old_str_missing_note_errors() {
     let m = fresh("edit-del-missing");
     // No note written; deleting a non-existent note is a clear error.


### PR DESCRIPTION
## Summary

Adds `memory_edit`, a precise in-place edit and delete tool for the `memory` feature, makes destructive memory mutations recoverable via an automatic single-slot `.bak` backup, and stops long-term memory from accumulating duplicate lines on repeated append. This is PR-B of the memory v2 plan (PR-A, section-priority injection, already merged as `memory-context-injection`).

## Motivation

The memory write path previously supported only append and whole-file overwrite. Correcting or removing a single stale fact meant reading the entire long-term store, rewriting it in full, and overwriting: a high-risk operation where one hallucination during the rewrite can corrupt or erase unrelated memories, so in practice it never happened. Memory only grew, and stale or duplicate facts accumulated. This PR gives the model a surgical way to fix one line, a safe way to delete a stale note, a recoverable undo for destructive writes, and automatic suppression of duplicate long-term lines.

## Design decisions

Strict unique-substring matching, no fuzzy fallback. `memory_edit` requires `old_str` to match the target file exactly once (`match_indices` count == 1); zero or multiple matches is a hard error naming the count, with no write. Unlike the source-code `EditTool` (exact, then normalized, then Levenshtein), memory files are the model's own curated durable state, not code under review: a silent fuzzy match landing on the wrong line corrupts memory in a way that is easy to miss and costly to recover. The files are small plain Markdown the model can re-read verbatim, so exact matching is cheap and gives the simplest 0/1/N test matrix.

Note deletion lives in `memory_edit` (omit `old_str`), not a `memory_write mode=delete`. Adding a delete mode to `memory_write` would leave `content` a required-but-ignored field for that call. `memory_edit` is already the "remove or change memory" tool and already carries `name`, so no `memory_write` schema change is needed. Deletion is rejected for any non-note target, so long-term and scratchpad can never be fully deleted via this path.

Backup scope is deliberately narrow. A single-version `.bak` (overwriting any prior `.bak`, sibling to the original) is written before content-destroying operations only: long-term/scratchpad overwrite, long-term/scratchpad edit, and note deletion. Append is non-destructive by construction and never backs up; daily/note content edits are low-risk targeted replacements and are left un-backed-up to avoid churn. The `.bak` extension keeps backups out of `memory_read source=list` and `memory_search`, which both filter to `.md`. If the backup copy itself fails, the mutation still proceeds (the primary operation is what was asked for) but the tool response is suffixed with a warning so the caller knows there is no undo for that change.

Daily edits address a day by `name`. `memory_edit target=daily` honors a `name=YYYY-MM-DD` to edit an earlier day (defaulting to today), matching how `memory_read` already selects daily logs. The date is validated (ASCII digits and hyphens only) before it is spliced into a path, since `daily_file` does no sanitization of its own.

Platform support: this change is pure filesystem and string work (`std::fs`, `atomic_write`'s temp-file-then-rename, `Path::with_extension`), no process spawning or shell-outs, so it carries the same cross-platform support as the rest of the crate, including Windows. Paths are built with `Path`/`PathBuf` throughout; note names are sanitized by the existing `note_path` (rejects slashes and dots) and daily date names by the new digits-and-hyphens check before any file operation.

## Testing

- `cargo test --all-features`: 787 passing, 0 failing.
- New coverage in `src/tests/memory_tests.rs`: unique-match replace, 0/N-match rejection leaving the file byte-for-byte unchanged, empty-`new_str` substring deletion, note deletion by name, deletion rejected for non-note targets, missing-note error, daily edit targeting a named earlier day and rejecting an unsafe name, backup created/omitted across all target+operation combinations, single-version `.bak` overwrite, a backup-failure path that warns yet still completes the mutation, dedup against existing content and within a batch (including full-width U+3000 whitespace), all-duplicate batch leaving the file untouched, and non-long-term appends never deduplicating.
- The subagent-exclusion and backup-hidden-from-list tests drive the real production code paths (`subagents::builder::subagent_memory_tools()` and `Mem::list()`), not hand-copied mirrors, so a regression that leaked `memory_edit` into subagents or a `.bak` into the list would fail the suite.

## Reviewing

Seven commits, each a coherent step; most of the added lines are tests. The behavior change itself is small: `backup_file`/`backup_warning`/`normalize_line`/`is_safe_daily_name` helpers, the append-dedup block in `Mem::write`, `Mem::edit`, and the `MemoryEdit` rig tool (the last is boilerplate matching the sibling `MemoryWrite`/`MemoryRead` tools).

Suggested reading order:
1. `src/extras/memory/mod.rs`: `Mem::edit` (the new operation), then the `Append` branch of `Mem::write` (the dedup state machine), then the `backup_file`/`backup_warning`/`normalize_line`/`is_safe_daily_name`/`Mem::list` helpers.
2. `docs/MEMORY.md`: the prose contract for all of the above.
3. `src/agent/builder.rs`, `src/agent/prompt.rs`: one-line tool registration and prompt text.
4. Tests last.

Commit order: (1) unique-match content replacement, (2) whole-note deletion, (3) backup before destructive mutation, (4) long-term append dedup, then three review-hardening commits: (5) honor and validate a daily date in `memory_edit`, (6) warn when a backup cannot be written, (7) validate the daily date name in the `memory_read` path.

## Notes

- `src/extras/subagents/builder.rs` is modified even though it registers no new tool for subagents. The edit extracts the read-only memory tool set into a `subagent_memory_tools()` function that the builder now uses, so the "subagents cannot mutate memory" guarantee has a single source of truth a test can assert against directly. The guarantee itself is unchanged (subagents still get only `memory_read` and `memory_search`).
- Commit (7) fixes a pre-existing traversal in `memory_read`: its `daily` source spliced the caller-supplied `name` straight into `daily_file` with no sanitization. It is included here because this PR introduces the shared `is_safe_daily_name` check that closes the same class for `memory_edit`; reusing it for the read path is a one-line change.
- `memory_edit` deletes a whole note when `old_str` is omitted (with `target=note` and a `name`); this is intentional. `new_str` is ignored on that path, so a caller that means "overwrite a note" should use `memory_write mode=overwrite`, not `memory_edit`.
- Whole-line deletion via `memory_edit` requires including the trailing newline in `old_str`; otherwise a blank line is left behind. This is documented in the tool description and is self-correctable with a follow-up edit.
- Unrelated to this change: `just check` currently reports pre-existing `cargo fmt`/`clippy` failures in `src/setup/mod.rs` (identical to `main`; the project's CI runs `cargo build` + `cargo test`, not the local lint gate). This PR touches none of that file, and its own diff is `cargo fmt` and `clippy -D warnings` clean.
