### PR TITLE
fix(storage): expand tilde in ZS_DATA_DIR and ZS_CONFIG_DIR

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -26,7 +26,8 @@ fn dirs_path() -> PathBuf {
 
 pub fn data_dir() -> PathBuf {
     if let Some(dir) = std::env::var_os("ZS_DATA_DIR") {
-        return PathBuf::from(dir);
+        let expanded = crate::fs::expand_tilde(&dir.to_string_lossy());
+        return PathBuf::from(expanded);
     }
     let base = dirs::data_dir().unwrap_or_else(home_fallback);
     base.join("zerostack")
@@ -34,7 +35,8 @@ pub fn data_dir() -> PathBuf {
 
 pub(crate) fn config_path() -> PathBuf {
     if let Some(dir) = std::env::var_os("ZS_CONFIG_DIR") {
-        return PathBuf::from(dir);
+        let expanded = crate::fs::expand_tilde(&dir.to_string_lossy());
+        return PathBuf::from(expanded);
     }
     data_dir()
 }


### PR DESCRIPTION
Closes #187.

`ZS_DATA_DIR` and `ZS_CONFIG_DIR` are read as raw strings and converted directly to `PathBuf`. When a user exports them with an unexpanded tilde (e.g. `ZS_CONFIG_DIR=~/dotfiles/zerostack`), the literal `~` is treated as a directory name inside the current working directory.

This change applies `crate::fs::expand_tilde` to both variables before converting them to paths, matching how tool argument paths are already handled.

Verification: `cargo test --all-features` passes (787 tests).
