### PR TITLE
Introduce Feed model for TUI chat content

### DIFF
--- a/src/tests/feed_tests.rs
+++ b/src/tests/feed_tests.rs
@@ -1,0 +1,208 @@
+use crate::ui::feed::{BlockStyle, Feed};
+use crossterm::style::Color;
+
+#[test]
+fn block_style_color_mapping() {
+    assert_eq!(BlockStyle::User.color(), Color::Green);
+    assert_eq!(BlockStyle::Agent.color(), Color::White);
+    assert_eq!(BlockStyle::Reasoning.color(), Color::DarkMagenta);
+    assert_eq!(BlockStyle::Tool.color(), Color::Yellow);
+    assert_eq!(BlockStyle::ToolResult.color(), Color::DarkGrey);
+    assert_eq!(BlockStyle::Error.color(), Color::Red);
+    assert_eq!(BlockStyle::System.color(), Color::DarkGrey);
+    assert_eq!(BlockStyle::Welcome.color(), Color::Cyan);
+    assert_eq!(BlockStyle::Permission.color(), Color::Magenta);
+    assert_eq!(BlockStyle::Plain.color(), Color::White);
+}
+
+#[test]
+fn lines_wrap_plain_block() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "hello world");
+    let lines = feed.lines(20);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text, "hello world");
+    assert_eq!(lines[0].color, Color::White);
+}
+
+#[test]
+fn lines_wrap_narrow_width() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "hello world");
+    let lines = feed.lines(5);
+    assert!(lines.len() > 1);
+    for line in &lines {
+        assert!(line.text.chars().count() <= 5 || line.text == "hello" || line.text == "world");
+    }
+}
+
+#[test]
+fn empty_block_produces_empty_line() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "");
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text, "");
+}
+
+#[test]
+fn agent_block_gets_prefix_and_markdown() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Agent, "hello **world**");
+    let lines = feed.lines(80);
+    assert!(!lines.is_empty());
+    assert!(
+        lines[0].text.starts_with("< "),
+        "first agent line should start with '< ', got {:?}",
+        lines[0].text
+    );
+    let joined: String = lines
+        .iter()
+        .map(|l| l.text.as_str())
+        .collect::<Vec<_>>()
+        .join("");
+    assert!(
+        joined.contains("hello "),
+        "prose should be present: {}",
+        joined
+    );
+    assert!(
+        joined.contains("world"),
+        "bold text should be present: {}",
+        joined
+    );
+}
+
+#[test]
+fn agent_empty_block_no_lines() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Agent, "");
+    let lines = feed.lines(80);
+    assert!(lines.is_empty());
+}
+
+#[test]
+fn line_count_matches_lines() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "one");
+    feed.push_line(BlockStyle::Plain, "two");
+    feed.push_line(BlockStyle::Plain, "three");
+    assert_eq!(feed.line_count(80), 3);
+}
+
+#[test]
+fn visible_range_bottom_aligned_when_short() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "one");
+    feed.push_line(BlockStyle::Plain, "two");
+    let (start, end) = feed.visible_range(80, 0, 10);
+    assert_eq!(start, 0);
+    assert_eq!(end, 2);
+}
+
+#[test]
+fn visible_range_scrolled() {
+    let mut feed = Feed::new();
+    for i in 0..20 {
+        feed.push_line(BlockStyle::Plain, format!("line {}", i));
+    }
+    let (start, end) = feed.visible_range(80, 5, 10);
+    assert_eq!(end - start, 10);
+    assert_eq!(start, 5);
+}
+
+#[test]
+fn line_at_visual_row_bottom_pad() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "one");
+    // viewport height 10, auto-scroll, content shorter than viewport -> padding
+    assert_eq!(feed.line_at_visual_row(80, 0, 10, 0), None);
+    assert_eq!(feed.line_at_visual_row(80, 0, 10, 9), Some(0));
+}
+
+#[test]
+fn line_at_visual_row_scrolled() {
+    let mut feed = Feed::new();
+    for i in 0..20 {
+        feed.push_line(BlockStyle::Plain, format!("line {}", i));
+    }
+    assert_eq!(feed.line_at_visual_row(80, 5, 10, 0), Some(5));
+    assert_eq!(feed.line_at_visual_row(80, 5, 10, 9), Some(14));
+}
+
+#[test]
+fn selected_text_extracts_lines() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "alpha");
+    feed.push_line(BlockStyle::Plain, "beta");
+    feed.push_line(BlockStyle::Plain, "gamma");
+    let text = feed.selected_text(80, 0, 2);
+    assert_eq!(text.as_deref(), Some("alpha\nbeta\ngamma"));
+}
+
+#[test]
+fn selected_text_reversed_range() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "alpha");
+    feed.push_line(BlockStyle::Plain, "beta");
+    let text = feed.selected_text(80, 1, 0);
+    assert_eq!(text.as_deref(), Some("alpha\nbeta"));
+}
+
+#[test]
+fn append_to_last_extends_block() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Agent, "hello");
+    assert!(feed.append_to_last(" world"));
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].text.contains("hello world"));
+}
+
+#[test]
+fn append_to_last_returns_false_when_empty() {
+    let mut feed = Feed::new();
+    assert!(!feed.append_to_last("orphan"));
+}
+
+#[test]
+fn replace_last_updates_final_block() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "first");
+    feed.push_line(BlockStyle::Plain, "second");
+    feed.replace_last(BlockStyle::Agent, "replaced");
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].text, "first");
+    assert_eq!(lines[1].text, "< replaced");
+}
+
+#[test]
+fn replace_last_pushes_when_empty() {
+    let mut feed = Feed::new();
+    feed.replace_last(BlockStyle::Agent, "only");
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text, "< only");
+}
+
+#[test]
+fn truncate_blocks_keeps_prefix() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "first");
+    feed.push_line(BlockStyle::Plain, "second");
+    feed.push_line(BlockStyle::Plain, "third");
+    feed.truncate_blocks(2);
+    assert_eq!(feed.block_count(), 2);
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 2);
+}
+
+#[test]
+fn clear_empties_feed() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "hello");
+    feed.clear();
+    assert!(feed.is_empty());
+    assert_eq!(feed.line_count(80), 0);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -25,6 +25,8 @@ mod crc_tests;
 #[cfg(test)]
 mod edit_tests;
 #[cfg(test)]
+mod feed_tests;
+#[cfg(test)]
 mod grep_tests;
 #[cfg(all(test, feature = "hooks"))]
 mod hooks;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -73,7 +73,7 @@ pub(crate) struct App<'a> {
     pending_inputs: VecDeque<String>,
     agent_line_started: bool,
     response_buf: String,
-    response_start_line: Option<usize>,
+    response_start_block: Option<usize>,
     show_reasoning: bool,
     reasoning_enabled: bool,
     pending_send: Option<String>,
@@ -187,7 +187,7 @@ impl<'a> App<'a> {
         let pending_inputs: VecDeque<String> = VecDeque::new();
         let agent_line_started = false;
         let response_buf = String::new();
-        let response_start_line: Option<usize> = None;
+        let response_start_block: Option<usize> = None;
         let show_reasoning = cfg.resolve_show_reasoning();
         let reasoning_enabled = true;
         session.reasoning_enabled = reasoning_enabled;
@@ -456,7 +456,7 @@ impl<'a> App<'a> {
             pending_inputs,
             agent_line_started,
             response_buf,
-            response_start_line,
+            response_start_block,
             show_reasoning,
             reasoning_enabled,
             pending_send,
@@ -627,7 +627,7 @@ impl<'a> App<'a> {
                 } else if row < self.renderer.visible_lines() as u16 {
                     if let Some(idx) = self.renderer.buffer_line_at_row(row) {
                         if let Some(url) = self.renderer.link_url_at(idx, col) {
-                            renderer_mod::open_url(url);
+                            renderer_mod::open_url(&url);
                         } else {
                             self.renderer.selection_active = true;
                             self.renderer.selection_start = Some(idx);
@@ -1006,7 +1006,7 @@ impl<'a> App<'a> {
             &mut self.agent_rx,
             &mut self.agent_line_started,
             &mut self.response_buf,
-            &mut self.response_start_line,
+            &mut self.response_start_block,
             &mut self.was_reasoning,
             self.show_reasoning,
             &mut self.agent,
@@ -1949,7 +1949,7 @@ impl<'a> App<'a> {
             &self.status_signals,
             &mut self.turn_trace,
             &mut self.response_buf,
-            &mut self.response_start_line,
+            &mut self.response_start_block,
             &mut self.agent_line_started,
             &mut self.was_reasoning,
             #[cfg(feature = "mcp")]
@@ -1971,7 +1971,7 @@ impl<'a> App<'a> {
             &self.status_signals,
             &mut self.turn_trace,
             &mut self.response_buf,
-            &mut self.response_start_line,
+            &mut self.response_start_block,
             &mut self.agent_line_started,
             &mut self.was_reasoning,
         )
@@ -2359,7 +2359,7 @@ impl<'a> App<'a> {
 
                         let mut agent_line_started = false;
                         let mut merge_response_buf = String::new();
-                        let mut merge_response_start_line = None;
+                        let mut merge_response_start_block = None;
                         let mut merge_was_reasoning = false;
                         while self.is_running {
                             let ev = match self.agent_rx.as_mut() {
@@ -2421,7 +2421,7 @@ impl<'a> App<'a> {
                                     &mut self.agent_rx,
                                     &mut agent_line_started,
                                     &mut merge_response_buf,
-                                    &mut merge_response_start_line,
+                                    &mut merge_response_start_block,
                                     &mut merge_was_reasoning,
                                     self.show_reasoning,
                                     &mut self.agent,

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -17,6 +17,7 @@ use crate::sandbox::Sandbox;
 use crate::session::storage::save_session;
 use crate::session::{MessageRole, Session};
 use crate::ui::events::sanitize_output;
+use crate::ui::feed::BlockStyle;
 use crate::ui::renderer::Renderer;
 use crate::ui::slash::handle_compress;
 
@@ -116,7 +117,7 @@ pub async fn handle_agent_event(
     agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
     agent_line_started: &mut bool,
     response_buf: &mut String,
-    response_start_line: &mut Option<usize>,
+    response_start_block: &mut Option<usize>,
     was_reasoning: &mut bool,
     show_reasoning: bool,
     agent: &mut Option<AnyAgent>,
@@ -149,7 +150,7 @@ pub async fn handle_agent_event(
                 *agent_line_started = false;
                 *was_reasoning = false;
                 response_buf.clear();
-                *response_start_line = None;
+                *response_start_block = None;
             }
             let safe = sanitize_output(&text);
             response_buf.push_str(&safe);
@@ -167,20 +168,13 @@ pub async fn handle_agent_event(
                 return Ok(());
             }
 
-            let max_width = renderer.line_width();
-            let mut styled = crate::ui::markdown::markdown_to_styled(response_buf, max_width);
-
-            if !styled.is_empty() {
-                styled[0].text = CompactString::from(format!("< {}", styled[0].text));
+            if response_start_block.is_none() {
+                renderer.feed_mut().push_block(BlockStyle::Agent, "");
+                *response_start_block = Some(renderer.feed().block_count() - 1);
             }
-
-            if let Some(start) = *response_start_line {
-                renderer.replace_from(start, styled);
-            } else {
-                let start = renderer.buffer_len();
-                *response_start_line = Some(start);
-                renderer.replace_from(start, styled);
-            }
+            renderer
+                .feed_mut()
+                .replace_last(BlockStyle::Agent, response_buf.as_str());
             renderer.render_viewport()?;
             *agent_line_started = true;
         }
@@ -191,7 +185,7 @@ pub async fn handle_agent_event(
                 *agent_line_started = false;
             }
             response_buf.clear();
-            *response_start_line = None;
+            *response_start_block = None;
             session.add_tool_call(&name, &args);
             save_session_if_enabled(session, cli, renderer)?;
             let line = format!(
@@ -306,7 +300,7 @@ pub async fn handle_agent_event(
                 agent_rx,
                 agent_line_started,
                 response_buf,
-                response_start_line,
+                response_start_block,
                 was_reasoning,
                 agent,
                 client,
@@ -370,7 +364,7 @@ pub async fn handle_agent_event(
                 *agent_line_started = false;
             }
             response_buf.clear();
-            *response_start_line = None;
+            *response_start_block = None;
             renderer.write_line(&format!("retrying... ({}/{})", attempt, max), Color::Yellow)?;
         }
         AgentEvent::Error(e) => {
@@ -384,7 +378,7 @@ pub async fn handle_agent_event(
             *agent_rx = None;
             *agent_line_started = false;
             response_buf.clear();
-            *response_start_line = None;
+            *response_start_block = None;
             save_session_if_enabled(session, cli, renderer)?;
         }
     }
@@ -420,7 +414,7 @@ async fn handle_agent_done(
     agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
     agent_line_started: &mut bool,
     response_buf: &mut String,
-    response_start_line: &mut Option<usize>,
+    response_start_block: &mut Option<usize>,
     was_reasoning: &mut bool,
     agent: &mut Option<AnyAgent>,
     client: &mut AnyClient,
@@ -436,17 +430,15 @@ async fn handle_agent_done(
     *was_reasoning = false;
 
     if !response_buf.is_empty() {
-        let max_width = renderer.line_width();
-        let mut styled = crate::ui::markdown::markdown_to_styled(response_buf, max_width);
-        if !styled.is_empty() {
-            styled[0].text = CompactString::from(format!("< {}", styled[0].text));
+        if let Some(start) = *response_start_block {
+            renderer.feed_mut().truncate_blocks(start + 1);
         }
-        if let Some(start) = *response_start_line {
-            renderer.replace_from(start, styled);
-            renderer.render_viewport()?;
-        }
+        renderer
+            .feed_mut()
+            .replace_last(BlockStyle::Agent, response_buf.as_str());
+        renderer.render_viewport()?;
     } else if !*agent_line_started {
-        renderer.write("< ", C_AGENT)?;
+        renderer.feed_mut().push_line(BlockStyle::Agent, "< ");
     }
 
     renderer.write_line("", Color::White)?;
@@ -483,7 +475,7 @@ async fn handle_agent_done(
     session.set_calibration(context_input_tokens, output_tokens);
     *agent_line_started = false;
     response_buf.clear();
-    *response_start_line = None;
+    *response_start_block = None;
 
     #[cfg(feature = "loop")]
     let loop_running = loop_state.as_ref().is_some_and(|ls| ls.active);

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1,12 +1,11 @@
 use chrono::Datelike;
 use compact_str::CompactString;
-use crossterm::style::Color;
 
 use crate::cli::Cli;
 use crate::config::{Config, ResolvedShowToolDetails};
 use crate::context::ContextFiles;
 use crate::session::{MessageRole, Session};
-use crate::ui::markdown;
+use crate::ui::feed::BlockStyle;
 use crate::ui::renderer::Renderer;
 
 pub fn format_time(rfc3339: &str) -> CompactString {
@@ -34,18 +33,20 @@ pub fn render_session(
     context: &ContextFiles,
 ) -> anyhow::Result<()> {
     renderer.clear_content()?;
+    let feed = renderer.feed_mut();
     if context.agents.is_some() {
-        renderer.write_line("[system] loaded AGENTS.md", Color::DarkGrey)?;
-        renderer.write_line("", Color::White)?;
+        feed.push_line(BlockStyle::System, "[system] loaded AGENTS.md");
+        feed.push_line(BlockStyle::Plain, "");
     }
     #[cfg(feature = "archmd")]
     if context.architecture.is_some() {
-        renderer.write_line("[system] loaded ARCHITECTURE.md", Color::DarkGrey)?;
-        renderer.write_line("", Color::White)?;
+        feed.push_line(BlockStyle::System, "[system] loaded ARCHITECTURE.md");
+        feed.push_line(BlockStyle::Plain, "");
     }
     if !session.compactions.is_empty() {
-        renderer.write_line(
-            &format!(
+        feed.push_line(
+            BlockStyle::System,
+            format!(
                 "compacted {} times (saved ~{} tokens)",
                 session.compactions.len(),
                 session
@@ -54,36 +55,39 @@ pub fn render_session(
                     .map(|c| c.token_savings)
                     .unwrap_or(0),
             ),
-            Color::DarkGrey,
-        )?;
-        renderer.write_line("", Color::White)?;
+        );
+        feed.push_line(BlockStyle::Plain, "");
     }
     for msg in &session.messages {
-        let (prefix, _c) = match msg.role {
-            MessageRole::User => (">", Color::Green),
-            MessageRole::Assistant => ("<", Color::White),
-            MessageRole::System => ("#", Color::DarkGrey),
-            MessageRole::ToolCall => ("◈", super::C_TOOL),
-            MessageRole::ToolResult => ("◈ result", Color::DarkGrey),
-            MessageRole::SubagentToolCall => ("⌥", super::C_TOOL),
-        };
-        if msg.role == MessageRole::ToolResult {
-            render_tool_result(renderer, &msg.content, cfg)?;
-        } else if msg.role == MessageRole::Assistant {
-            let max_width = renderer.line_width();
-            let mut styled = markdown::markdown_to_styled(&msg.content, max_width);
-            if !styled.is_empty() {
-                styled[0].text = CompactString::from(format!("{} {}", prefix, styled[0].text));
+        match msg.role {
+            MessageRole::User => {
+                for line in msg.content.lines() {
+                    feed.push_line(BlockStyle::User, format!("> {}", line));
+                }
             }
-            for entry in styled {
-                renderer.write_line(&entry.text, entry.color)?;
+            MessageRole::Assistant => {
+                feed.push_block(BlockStyle::Agent, msg.content.to_string());
             }
-        } else {
-            for line in msg.content.lines() {
-                renderer.write_line(&format!("{} {}", prefix, line), _c)?;
+            MessageRole::System => {
+                for line in msg.content.lines() {
+                    feed.push_line(BlockStyle::System, format!("# {}", line));
+                }
+            }
+            MessageRole::ToolCall => {
+                for line in msg.content.lines() {
+                    feed.push_line(BlockStyle::Tool, format!("◈ {}", line));
+                }
+            }
+            MessageRole::ToolResult => {
+                render_tool_result_to_feed(feed, &msg.content, cfg)?;
+            }
+            MessageRole::SubagentToolCall => {
+                for line in msg.content.lines() {
+                    feed.push_line(BlockStyle::Tool, format!("⌥ {}", line));
+                }
             }
         }
-        renderer.write_line("", Color::White)?;
+        feed.push_line(BlockStyle::Plain, "");
     }
     if session.messages.is_empty() {
         let cwd = std::env::current_dir().ok();
@@ -92,29 +96,35 @@ pub fn render_session(
             .and_then(|p| p.file_name())
             .and_then(|n| n.to_str())
             .unwrap_or(".");
-        let welcome = format!(
-            "[>] zerostack {} | {} | {}",
-            env!("CARGO_PKG_VERSION"),
-            cli.resolve_model(cfg),
-            cwd_str,
+        feed.push_line(
+            BlockStyle::Welcome,
+            format!(
+                "[>] zerostack {} | {} | {}",
+                env!("CARGO_PKG_VERSION"),
+                cli.resolve_model(cfg),
+                cwd_str,
+            ),
         );
-        renderer.write_line(&welcome, Color::Cyan)?;
-        renderer.write_line(
+        feed.push_line(
+            BlockStyle::Welcome,
             "──────────────────────────────────────────────────",
-            Color::Cyan,
-        )?;
-        renderer.write_line(
+        );
+        feed.push_line(
+            BlockStyle::Welcome,
             "Ready to code; type a request or '/' for commands",
-            Color::White,
-        )?;
-        renderer.write_line("Run /welcome or /tutor to get started", Color::White)?;
-        renderer.write_line("", Color::White)?;
-        renderer.write_line("", Color::White)?;
+        );
+        feed.push_line(BlockStyle::Welcome, "Run /welcome or /tutor to get started");
+        feed.push_line(BlockStyle::Plain, "");
+        feed.push_line(BlockStyle::Plain, "");
     }
     Ok(())
 }
 
-fn render_tool_result(renderer: &mut Renderer, content: &str, cfg: &Config) -> anyhow::Result<()> {
+fn render_tool_result_to_feed(
+    feed: &mut crate::ui::feed::Feed,
+    content: &str,
+    cfg: &Config,
+) -> anyhow::Result<()> {
     let output = content
         .split_once(":\n")
         .map(|(_, output)| output)
@@ -126,10 +136,10 @@ fn render_tool_result(renderer: &mut Renderer, content: &str, cfg: &Config) -> a
         .unwrap_or(ResolvedShowToolDetails::Limited(3));
     match show_details {
         ResolvedShowToolDetails::Off => {
-            renderer.write_line(
+            feed.push_line(
+                BlockStyle::ToolResult,
                 "◈ result hidden by show_tool_details=false",
-                Color::DarkGrey,
-            )?;
+            );
         }
         ResolvedShowToolDetails::Limited(max_lines) => {
             let sanitized = sanitize_output(output);
@@ -137,82 +147,98 @@ fn render_tool_result(renderer: &mut Renderer, content: &str, cfg: &Config) -> a
             let lines: Vec<&str> = sanitized.lines().collect();
             if lines.len() > max_lines {
                 let shown = lines[..max_lines].join("\n");
-                renderer.write_line(
-                    &format!(
+                feed.push_line(
+                    BlockStyle::ToolResult,
+                    format!(
                         "◈ result ({} chars, {} lines, showing {}):\n{}",
                         char_count,
                         lines.len(),
                         max_lines,
                         shown
                     ),
-                    Color::DarkGrey,
-                )?;
+                );
             } else {
-                renderer.write_line(
-                    &format!("◈ result ({} chars):\n{}", char_count, sanitized),
-                    Color::DarkGrey,
-                )?;
+                feed.push_line(
+                    BlockStyle::ToolResult,
+                    format!("◈ result ({} chars):\n{}", char_count, sanitized),
+                );
             }
         }
         ResolvedShowToolDetails::Unlimited => {
             let sanitized = sanitize_output(output);
             let char_count = sanitized.chars().count();
-            renderer.write_line(
-                &format!("◈ result ({} chars):\n{}", char_count, sanitized),
-                Color::DarkGrey,
-            )?;
+            feed.push_line(
+                BlockStyle::ToolResult,
+                format!("◈ result ({} chars):\n{}", char_count, sanitized),
+            );
         }
     }
     Ok(())
 }
 
 pub fn show_welcome(renderer: &mut Renderer) -> std::io::Result<()> {
-    use super::C_TOOL;
-    use crossterm::style::Color;
-
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("  zerostack Quickstart", Color::Cyan)?;
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Pickers:", C_TOOL)?;
-    renderer.write_line(
+    let feed = renderer.feed_mut();
+    feed.push_line(
+        BlockStyle::Welcome,
+        "──────────────────────────────────────────",
+    );
+    feed.push_line(BlockStyle::Welcome, "  zerostack Quickstart");
+    feed.push_line(
+        BlockStyle::Welcome,
+        "──────────────────────────────────────────",
+    );
+    feed.push_line(BlockStyle::Plain, "");
+    feed.push_line(BlockStyle::Tool, "  Pickers:");
+    feed.push_line(
+        BlockStyle::Plain,
         "    @<path>     File picker / auto-complete paths",
-        Color::White,
-    )?;
-    renderer.write_line(
+    );
+    feed.push_line(
+        BlockStyle::Plain,
         "    !<command>  Run a shell command (output stored as assistant)",
-        Color::White,
-    )?;
-    renderer.write_line(
+    );
+    feed.push_line(
+        BlockStyle::Plain,
         "    .<prompt>   Switch prompt or one-shot .<prompt> <message>",
-        Color::White,
-    )?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Slash Commands:", C_TOOL)?;
-    renderer.write_line("    /model        Switch model", Color::White)?;
-    renderer.write_line("    /prompt       List / activate prompts", Color::White)?;
-    renderer.write_line(
+    );
+    feed.push_line(BlockStyle::Plain, "");
+    feed.push_line(BlockStyle::Tool, "  Slash Commands:");
+    feed.push_line(BlockStyle::Plain, "    /model        Switch model");
+    feed.push_line(
+        BlockStyle::Plain,
+        "    /prompt       List / activate prompts",
+    );
+    feed.push_line(
+        BlockStyle::Plain,
         "    .autoconfig        Switches to auto-configurator",
-        Color::White,
-    )?;
-    renderer.write_line("    /mode         Change security mode", Color::White)?;
-    renderer.write_line("    /clear        Clear session", Color::White)?;
-    renderer.write_line("    /undo         Undo last exchange", Color::White)?;
-    renderer.write_line("    /compress     Free context window space", Color::White)?;
-    renderer.write_line("    /help         Show all commands", Color::White)?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("  Keybindings:", C_TOOL)?;
-    renderer.write_line("    Ctrl+G     Open input in $EDITOR", Color::White)?;
-    renderer.write_line("    Ctrl+H     Launch lazygit", Color::White)?;
-    renderer.write_line("    Ctrl+S     Save session", Color::White)?;
-    renderer.write_line("    Tab        File picker / auto-complete", Color::White)?;
-    renderer.write_line(
+    );
+    feed.push_line(BlockStyle::Plain, "    /mode         Change security mode");
+    feed.push_line(BlockStyle::Plain, "    /clear        Clear session");
+    feed.push_line(BlockStyle::Plain, "    /undo         Undo last exchange");
+    feed.push_line(
+        BlockStyle::Plain,
+        "    /compress     Free context window space",
+    );
+    feed.push_line(BlockStyle::Plain, "    /help         Show all commands");
+    feed.push_line(BlockStyle::Plain, "");
+    feed.push_line(BlockStyle::Tool, "  Keybindings:");
+    feed.push_line(BlockStyle::Plain, "    Ctrl+G     Open input in $EDITOR");
+    feed.push_line(BlockStyle::Plain, "    Ctrl+H     Launch lazygit");
+    feed.push_line(BlockStyle::Plain, "    Ctrl+S     Save session");
+    feed.push_line(
+        BlockStyle::Plain,
+        "    Tab        File picker / auto-complete",
+    );
+    feed.push_line(
+        BlockStyle::Plain,
         "  Website: https://gi-dellav.github.io/zerostack/",
-        Color::White,
-    )?;
-    renderer.write_line("", Color::White)?;
-    renderer.write_line("──────────────────────────────────────────", Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
+    );
+    feed.push_line(BlockStyle::Plain, "");
+    feed.push_line(
+        BlockStyle::Welcome,
+        "──────────────────────────────────────────",
+    );
+    feed.push_line(BlockStyle::Plain, "");
     Ok(())
 }
 

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -1,0 +1,277 @@
+use compact_str::CompactString;
+use crossterm::style::Color;
+
+use super::markdown::{markdown_to_styled, word_wrap};
+use super::renderer::LineEntry;
+use super::{C_AGENT, C_ERROR, C_PERM, C_TOOL};
+
+/// Semantic role of a conversation block in the feed.
+///
+/// Roles are independent of terminal colors; `BlockStyle::color()` maps each
+/// role to the color used by the custom renderer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockStyle {
+    User,
+    Agent,
+    Reasoning,
+    Tool,
+    ToolResult,
+    Error,
+    System,
+    Welcome,
+    Permission,
+    Plain,
+}
+
+impl BlockStyle {
+    pub fn color(self) -> Color {
+        match self {
+            BlockStyle::User => Color::Green,
+            BlockStyle::Agent => C_AGENT,
+            BlockStyle::Reasoning => Color::DarkMagenta,
+            BlockStyle::Tool => C_TOOL,
+            BlockStyle::ToolResult => Color::DarkGrey,
+            BlockStyle::Error => C_ERROR,
+            BlockStyle::System => Color::DarkGrey,
+            BlockStyle::Welcome => Color::Cyan,
+            BlockStyle::Permission => C_PERM,
+            BlockStyle::Plain => Color::White,
+        }
+    }
+}
+
+/// Map a legacy terminal color to the closest semantic block style.
+///
+/// This is used while migrating callers from `Renderer::write_line(text, color)`
+/// to the feed model. New code should prefer `BlockStyle` directly.
+pub fn style_from_color(color: Color) -> BlockStyle {
+    match color {
+        Color::Green => BlockStyle::User,
+        Color::DarkMagenta => BlockStyle::Reasoning,
+        Color::Yellow => BlockStyle::Tool,
+        Color::DarkGrey => BlockStyle::System,
+        Color::Cyan => BlockStyle::Welcome,
+        Color::Red => BlockStyle::Error,
+        Color::Magenta => BlockStyle::Permission,
+        Color::White => BlockStyle::Plain,
+        _ => BlockStyle::Plain,
+    }
+}
+
+/// A single structured conversation block.
+///
+/// Blocks store raw text; layout (word-wrap, markdown parsing) happens when
+/// `Feed::lines(width)` is called. This keeps the feed independent of terminal
+/// geometry and makes layout math testable without a terminal.
+#[derive(Clone, Debug)]
+pub struct Block {
+    pub style: BlockStyle,
+    pub text: String,
+}
+
+impl Block {
+    pub fn new(style: BlockStyle, text: impl Into<String>) -> Self {
+        Self {
+            style,
+            text: text.into(),
+        }
+    }
+}
+
+/// Conversation feed: a sequence of semantic blocks that can be laid out at
+/// any width.
+#[derive(Clone, Debug, Default)]
+pub struct Feed {
+    blocks: Vec<Block>,
+}
+
+// Several helpers exist primarily for unit testing layout/scroll math without
+// a terminal; allow them even when not yet wired into the production path.
+#[allow(dead_code)]
+impl Feed {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    pub fn clear(&mut self) {
+        self.blocks.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub fn push_block(&mut self, style: BlockStyle, text: impl Into<String>) {
+        self.blocks.push(Block::new(style, text));
+    }
+
+    pub fn push_line(&mut self, style: BlockStyle, text: impl Into<String>) {
+        self.push_block(style, text);
+    }
+
+    /// Append text to the most recent block. Returns `false` when the feed is
+    /// empty and there is no block to append to.
+    pub fn append_to_last(&mut self, text: impl AsRef<str>) -> bool {
+        if let Some(last) = self.blocks.last_mut() {
+            last.text.push_str(text.as_ref());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Replace the last block, or push a new one if the feed is empty.
+    pub fn replace_last(&mut self, style: BlockStyle, text: impl Into<String>) {
+        if let Some(last) = self.blocks.last_mut() {
+            last.style = style;
+            last.text = text.into();
+        } else {
+            self.push_block(style, text);
+        }
+    }
+
+    pub fn truncate_blocks(&mut self, len: usize) {
+        self.blocks.truncate(len);
+    }
+
+    /// Return the fully laid-out chat lines for the given width.
+    ///
+    /// The result is a list of `LineEntry` values, one per visible row, that the
+    /// renderer can draw directly. Markdown is parsed for agent blocks; all
+    /// other blocks are word-wrapped and colored by their semantic role.
+    pub fn lines(&self, width: usize) -> Vec<LineEntry> {
+        let mut result = Vec::new();
+        for block in &self.blocks {
+            match block.style {
+                BlockStyle::Agent => {
+                    let mut styled = markdown_to_styled(&block.text, width);
+                    if !styled.is_empty() {
+                        styled[0].text = CompactString::from(format!("< {}", styled[0].text));
+                    }
+                    result.extend(styled);
+                }
+                _ => {
+                    let color = block.style.color();
+                    for line in block.text.split('\n') {
+                        let trimmed = line.trim_end_matches('\r');
+                        if trimmed.is_empty() {
+                            result.push(LineEntry {
+                                text: CompactString::new(""),
+                                color,
+                            });
+                        } else {
+                            for chunk in word_wrap(trimmed, width) {
+                                result.push(LineEntry { text: chunk, color });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /// Total number of visible rows for the given width.
+    pub fn line_count(&self, width: usize) -> usize {
+        self.lines(width).len()
+    }
+
+    /// Return the index of the first and last `LineEntry` that would be visible
+    /// in a viewport of `viewport_height` rows with `scroll_offset`.
+    ///
+    /// `scroll_offset == 0` means "stick to the bottom" (auto-scroll).
+    pub fn visible_range(
+        &self,
+        width: usize,
+        scroll_offset: usize,
+        viewport_height: usize,
+    ) -> (usize, usize) {
+        let total = self.line_count(width);
+        let visible = viewport_height.min(total);
+        let auto_scroll = scroll_offset == 0;
+
+        let start = if auto_scroll {
+            total.saturating_sub(visible)
+        } else {
+            total.saturating_sub((scroll_offset + visible).min(total))
+        };
+        let end = (start + visible).min(total);
+        (start, end)
+    }
+
+    /// Map a screen row (relative to the top of the viewport) to a `LineEntry`
+    /// index in `lines(width)`.
+    ///
+    /// Returns `None` when the row is padding above bottom-aligned content or
+    /// falls past the last visible line.
+    pub fn line_at_visual_row(
+        &self,
+        width: usize,
+        scroll_offset: usize,
+        viewport_height: usize,
+        row: u16,
+    ) -> Option<usize> {
+        let total = self.line_count(width);
+        if total == 0 {
+            return None;
+        }
+        let visible = viewport_height.min(total);
+        let auto_scroll = scroll_offset == 0;
+        let pad = if auto_scroll && total < viewport_height {
+            viewport_height - total
+        } else {
+            0
+        };
+
+        let row = row as usize;
+        if row < pad {
+            return None;
+        }
+
+        let start = if auto_scroll {
+            total.saturating_sub(visible)
+        } else {
+            total.saturating_sub((scroll_offset + visible).min(total))
+        };
+
+        let lines = self.lines(width);
+        let mut visual_row = pad;
+        let mut idx = start;
+        while idx < lines.len() {
+            if visual_row == row {
+                return Some(idx);
+            }
+            visual_row += 1;
+            idx += 1;
+        }
+        None
+    }
+
+    /// Concatenate the text of all visible lines in the given range.
+    pub fn selected_text(&self, width: usize, start: usize, end: usize) -> Option<String> {
+        let lines = self.lines(width);
+        let (lo, hi) = if start <= end {
+            (start, end)
+        } else {
+            (end, start)
+        };
+        let mut result = String::new();
+        for i in lo..=hi {
+            if let Some(entry) = lines.get(i) {
+                if !result.is_empty() {
+                    result.push('\n');
+                }
+                result.push_str(&entry.text);
+            }
+        }
+        if result.is_empty() {
+            None
+        } else {
+            Some(result)
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod app;
 mod event_handler;
 pub(crate) mod events;
+pub(crate) mod feed;
 pub(crate) mod input;
 pub(crate) mod markdown;
 mod permission_handler;
@@ -525,7 +526,7 @@ pub(crate) async fn mid_turn_compact_and_respawn(
     status_signals: &Option<StatusSignals>,
     turn_trace: &mut Vec<compact_str::CompactString>,
     response_buf: &mut String,
-    response_start_line: &mut Option<usize>,
+    response_start_block: &mut Option<usize>,
     agent_line_started: &mut bool,
     was_reasoning: &mut bool,
     #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
@@ -558,7 +559,7 @@ pub(crate) async fn mid_turn_compact_and_respawn(
     }
     turn_trace.clear();
     response_buf.clear();
-    *response_start_line = None;
+    *response_start_block = None;
     *agent_line_started = false;
 
     // Unlike the between-turn gate, this announces unconditionally: the relief
@@ -659,7 +660,7 @@ pub(crate) fn stop_turn_context_exhausted(
     status_signals: &Option<StatusSignals>,
     turn_trace: &mut Vec<compact_str::CompactString>,
     response_buf: &mut String,
-    response_start_line: &mut Option<usize>,
+    response_start_block: &mut Option<usize>,
     agent_line_started: &mut bool,
     was_reasoning: &mut bool,
 ) -> anyhow::Result<()> {
@@ -672,7 +673,7 @@ pub(crate) fn stop_turn_context_exhausted(
     *agent_line_started = false;
     turn_trace.clear();
     response_buf.clear();
-    *response_start_line = None;
+    *response_start_block = None;
     if let Some(ss) = status_signals.as_ref() {
         ss.send_stop();
     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -7,10 +7,11 @@ use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::style::{
     Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
 };
-use crossterm::terminal::{Clear, ClearType, ScrollUp};
+use crossterm::terminal::{Clear, ClearType};
 use regex::Regex;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 
+use super::feed::{BlockStyle, Feed, style_from_color};
 use super::markdown::word_wrap;
 use super::statusline::StatusSpan;
 use super::utils::{char_display_width, display_width, resolve_color};
@@ -50,12 +51,10 @@ pub struct ChainPrompt {
 }
 
 pub struct Renderer {
-    cursor_row: u16,
-    col: u16,
     spinner_frame: u8,
-    buffer: Vec<LineEntry>,
+    feed: Feed,
     partial: CompactString,
-    partial_color: Color,
+    partial_style: BlockStyle,
     scroll_offset: usize,
     input_scroll_offset: usize,
     input_vscroll_offset: usize,
@@ -90,12 +89,10 @@ pub struct Renderer {
 impl Renderer {
     pub fn new() -> io::Result<Self> {
         Ok(Renderer {
-            cursor_row: 0,
-            col: 0,
             spinner_frame: 0,
-            buffer: Vec::new(),
+            feed: Feed::new(),
             partial: CompactString::new(""),
-            partial_color: Color::White,
+            partial_style: BlockStyle::Plain,
             scroll_offset: 0,
             input_scroll_offset: 0,
             input_vscroll_offset: 0,
@@ -154,20 +151,6 @@ impl Renderer {
         Ok(())
     }
 
-    /// Position the cursor at the chat content column on row `r`, accounting for
-    /// the left margin. At the start of a line it first paints the margin gutter.
-    fn move_to_content(&self, stdout: &mut impl Write, r: u16) -> io::Result<()> {
-        if self.chat_margin > 0 && self.col == 0 {
-            stdout.execute(MoveTo(0, r))?;
-            if let Some(bg) = self.chat_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
-            }
-            self.write_chat_margin(stdout)?;
-        }
-        stdout.execute(MoveTo(self.col + self.chat_margin, r))?;
-        Ok(())
-    }
-
     pub fn set_background_colors(
         &mut self,
         chat_bg: Option<Color>,
@@ -192,26 +175,34 @@ impl Renderer {
         cols.saturating_sub(1 + self.chat_margin) as usize
     }
 
+    #[cfg(test)]
     pub fn line_width(&self) -> usize {
         self.max_line_width()
     }
 
-    pub fn buffer_len(&self) -> usize {
-        self.buffer.len()
+    fn chat_lines(&self, width: usize) -> Vec<LineEntry> {
+        let mut lines = self.feed.lines(width);
+        if !self.partial.is_empty() {
+            let color = self.partial_style.color();
+            for chunk in word_wrap(&self.partial, width) {
+                lines.push(LineEntry { text: chunk, color });
+            }
+        }
+        lines
     }
 
-    pub fn replace_from(&mut self, start: usize, lines: Vec<LineEntry>) {
-        self.commit_partial();
-        self.buffer.truncate(start);
-        self.buffer.extend(lines);
-        self.cursor_row = self.buffer.len() as u16;
-        self.col = 0;
-        self.partial.clear();
-        let visible = self.visible_lines();
-        let max_offset = self.buffer.len().saturating_sub(visible);
-        if self.scroll_offset > max_offset {
-            self.scroll_offset = max_offset;
-        }
+    pub fn buffer_len(&self) -> usize {
+        self.chat_lines(self.max_line_width()).len()
+    }
+
+    /// Access the underlying feed for callers that want to push semantic blocks
+    /// directly (e.g., session rendering or streaming agent responses).
+    pub fn feed(&self) -> &Feed {
+        &self.feed
+    }
+
+    pub fn feed_mut(&mut self) -> &mut Feed {
+        &mut self.feed
     }
 
     pub fn visible_lines(&self) -> usize {
@@ -244,14 +235,13 @@ impl Renderer {
     }
 
     pub fn buffer_line_at_row(&self, row: u16) -> Option<usize> {
-        let (cols, _rows) = self.terminal_size();
-        let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
-        let visible = self.visible_lines();
-        let total = self.buffer.len();
+        let width = self.max_line_width();
+        let total = self.chat_lines(width).len();
         if total == 0 {
             return None;
         }
 
+        let visible = self.visible_lines();
         let auto_scroll = self.scroll_offset == 0;
         let pad = if auto_scroll && total < visible {
             visible - total
@@ -265,32 +255,11 @@ impl Renderer {
         let start = if auto_scroll {
             total.saturating_sub(visible)
         } else {
-            total.saturating_sub(self.scroll_offset + visible)
+            total.saturating_sub((self.scroll_offset + visible).min(total))
         };
         let start = start.min(total.saturating_sub(visible));
 
-        let mut visual_row: u16 = pad as u16;
-        let mut buf_idx = start;
-
-        while buf_idx < total {
-            let entry = &self.buffer[buf_idx];
-            let text = &entry.text;
-
-            let wrapped_rows = if display_width(text) > max_width {
-                word_wrap(text, max_width).len() as u16
-            } else {
-                1
-            };
-
-            if visual_row + wrapped_rows > row {
-                return Some(buf_idx);
-            }
-
-            visual_row += wrapped_rows;
-            buf_idx += 1;
-        }
-
-        None
+        Some(start + (row as usize) - pad)
     }
 
     pub fn clear_selection(&mut self) {
@@ -299,8 +268,9 @@ impl Renderer {
         self.selection_end = None;
     }
 
-    pub fn link_url_at(&self, buf_idx: usize, col: u16) -> Option<&str> {
-        let entry = self.buffer.get(buf_idx)?;
+    pub fn link_url_at(&self, buf_idx: usize, col: u16) -> Option<String> {
+        let lines = self.chat_lines(self.max_line_width());
+        let entry = lines.get(buf_idx)?;
         let text: &str = &entry.text;
         let click_col = col.saturating_sub(self.chat_margin) as usize;
         for m in URL_RE.find_iter(text) {
@@ -308,7 +278,7 @@ impl Renderer {
             let url_start = display_width(prefix);
             let url_end = url_start + display_width(m.as_str());
             if click_col >= url_start && click_col < url_end {
-                return Some(m.as_str());
+                return Some(m.as_str().to_string());
             }
         }
         None
@@ -320,9 +290,10 @@ impl Renderer {
             (Some(s), Some(e)) => (e, s),
             _ => return None,
         };
+        let lines = self.chat_lines(self.max_line_width());
         let mut result = String::new();
         for i in start..=end {
-            if let Some(entry) = self.buffer.get(i) {
+            if let Some(entry) = lines.get(i) {
                 if !result.is_empty() {
                     result.push('\n');
                 }
@@ -336,20 +307,10 @@ impl Renderer {
         }
     }
 
-    fn wrap_line(&self, line: &str, max_width: usize) -> SmallVec<[CompactString; 4]> {
-        word_wrap(line, max_width)
-    }
-
     fn commit_partial(&mut self) {
         if !self.partial.is_empty() {
-            let max_width = self.max_line_width();
-            let c = self.partial_color;
-            for chunk in self.wrap_line(&self.partial, max_width) {
-                self.buffer.push(LineEntry {
-                    text: chunk,
-                    color: c,
-                });
-            }
+            self.feed
+                .push_block(self.partial_style, self.partial.as_str());
             self.partial.clear();
         }
     }
@@ -423,7 +384,7 @@ impl Renderer {
 
     pub fn scroll_line_up(&mut self) {
         let visible = self.visible_lines();
-        let max_offset = self.buffer.len().saturating_sub(visible);
+        let max_offset = self.buffer_len().saturating_sub(visible);
         if self.scroll_offset < max_offset {
             self.scroll_offset += 1;
         }
@@ -438,7 +399,7 @@ impl Renderer {
     pub fn scroll_page_up(&mut self) {
         let visible = self.visible_lines();
         let page = visible.saturating_sub(2).max(1);
-        let max_offset = self.buffer.len().saturating_sub(visible);
+        let max_offset = self.buffer_len().saturating_sub(visible);
         self.scroll_offset = (self.scroll_offset + page).min(max_offset);
     }
 
@@ -454,7 +415,7 @@ impl Renderer {
 
     pub fn scroll_to_top(&mut self) {
         let visible = self.visible_lines();
-        self.scroll_offset = self.buffer.len().saturating_sub(visible);
+        self.scroll_offset = self.buffer_len().saturating_sub(visible);
     }
 
     pub fn scroll_to_bottom(&mut self) -> io::Result<()> {
@@ -464,8 +425,6 @@ impl Renderer {
 
     fn sync_to_buffer(&mut self) -> io::Result<()> {
         self.commit_partial();
-        self.col = 0;
-        self.cursor_row = self.buffer.len() as u16;
         self.render_viewport()
     }
 
@@ -473,7 +432,8 @@ impl Renderer {
         let (cols, _rows) = self.terminal_size();
         let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
         let visible = self.visible_lines();
-        let total = self.buffer.len();
+        let buffer = self.chat_lines(max_width);
+        let total = buffer.len();
         let mut stdout = io::stdout();
         write!(stdout, "{}", Hide)?;
 
@@ -504,49 +464,40 @@ impl Renderer {
         }
 
         while (visual_row as usize) < visible && buf_idx < total {
-            let entry = &self.buffer[buf_idx];
-            let text = &entry.text;
+            let entry = &buffer[buf_idx];
+            let chunk = &entry.text;
 
-            let wrapped = if display_width(text) > max_width {
-                word_wrap(text, max_width)
-            } else {
-                smallvec![text.clone()]
-            };
-
-            for chunk in &wrapped {
-                if (visual_row as usize) >= visible {
-                    break;
-                }
-
-                stdout.execute(MoveTo(0, visual_row))?;
-
-                let is_selected = self.selection_active
-                    && if let (Some(s), Some(e)) = (self.selection_start, self.selection_end) {
-                        let lo = s.min(e);
-                        let hi = s.max(e);
-                        buf_idx >= lo && buf_idx <= hi
-                    } else {
-                        false
-                    };
-
-                if let Some(bg) = self.chat_bg {
-                    write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
-                }
-                self.write_chat_margin(&mut stdout)?;
-                if is_selected {
-                    write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
-                }
-                write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
-                write!(stdout, "{}", wrap_urls_osc8(chunk))?;
-                if is_selected {
-                    write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
-                }
-                write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-                write!(stdout, "{}", ResetColor)?;
-
-                visual_row += 1;
+            if (visual_row as usize) >= visible {
+                break;
             }
 
+            stdout.execute(MoveTo(0, visual_row))?;
+
+            let is_selected = self.selection_active
+                && if let (Some(s), Some(e)) = (self.selection_start, self.selection_end) {
+                    let lo = s.min(e);
+                    let hi = s.max(e);
+                    buf_idx >= lo && buf_idx <= hi
+                } else {
+                    false
+                };
+
+            if let Some(bg) = self.chat_bg {
+                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            }
+            self.write_chat_margin(&mut stdout)?;
+            if is_selected {
+                write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
+            }
+            write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
+            write!(stdout, "{}", wrap_urls_osc8(chunk))?;
+            if is_selected {
+                write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
+            }
+            write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
+            write!(stdout, "{}", ResetColor)?;
+
+            visual_row += 1;
             buf_idx += 1;
         }
 
@@ -585,74 +536,12 @@ impl Renderer {
         Ok(())
     }
 
-    fn ensure_room(&mut self) {
-        if self.scroll_offset > 0 {
-            return;
-        }
-        let (cols, _rows) = self.terminal_size();
-        let max_content = self.visible_lines() as u16;
-        if max_content < 2 {
-            return;
-        }
-        if self.cursor_row >= max_content {
-            let mut stdout = io::stdout();
-            let _ = stdout.execute(ScrollUp(1));
-            self.cursor_row = self.cursor_row.saturating_sub(1);
-            for &r in &[max_content.saturating_sub(1), max_content] {
-                let _ = stdout.execute(MoveTo(0, r));
-                if let Some(bg) = self.chat_bg {
-                    let _ = write!(stdout, "{}", SetBackgroundColor(self.color(bg)));
-                }
-                let _ = write!(stdout, "{}", " ".repeat(cols as usize));
-                let _ = write!(stdout, "{}", ResetColor);
-            }
-            let _ = stdout.flush();
-        }
-    }
-
-    fn content_row(&self) -> u16 {
-        let max_row = self.visible_lines().saturating_sub(1) as u16;
-        self.cursor_row.min(max_row)
-    }
-
-    pub fn resize(&mut self) {
-        let visible = self.visible_lines();
-        let max_offset = self.buffer.len().saturating_sub(visible);
-        if self.scroll_offset > max_offset {
-            self.scroll_offset = max_offset;
-        }
-    }
-
     pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
         self.commit_partial();
-        let max_width = self.max_line_width();
-        for segment in text.split('\n') {
-            let wrapped = self.wrap_line(segment, max_width);
-            for chunk in &wrapped {
-                self.buffer.push(LineEntry {
-                    text: chunk.clone(),
-                    color,
-                });
-                if self.scroll_offset == 0 {
-                    self.ensure_room();
-                    let mut stdout = io::stdout();
-                    let r = self.content_row();
-                    stdout.execute(MoveTo(0, r))?;
-                    if let Some(bg) = self.chat_bg {
-                        write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
-                    }
-                    write!(stdout, "{}", Clear(ClearType::CurrentLine))?;
-                    self.write_chat_margin(&mut stdout)?;
-                    write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
-                    writeln!(stdout, "{}", chunk)?;
-                    write!(stdout, "{}", ResetColor)?;
-                    self.cursor_row = self.cursor_row.saturating_add(1);
-                    self.col = 0;
-                }
-            }
-        }
+        let style = style_from_color(color);
+        self.feed.push_block(style, text);
         if self.scroll_offset == 0 {
-            io::stdout().flush()?;
+            self.render_viewport()?;
         }
         Ok(())
     }
@@ -661,119 +550,30 @@ impl Renderer {
         if text.is_empty() {
             return Ok(());
         }
-        let max_width = self.max_line_width();
-        if max_width == 0 {
-            return Ok(());
-        }
+        let style = style_from_color(color);
         let parts: SmallVec<[&str; 4]> = text.split('\n').collect();
         let last = parts.len() - 1;
         for (i, segment) in parts.iter().enumerate() {
             if i < last {
-                let len_before = self.buffer.len();
-                self.commit_partial();
-                let had_content = len_before < self.buffer.len();
-                if !segment.is_empty() {
-                    self.partial_color = color;
-                    self.partial.push_str(segment);
+                // Complete line segment: finalize any partial and push it.
+                if !self.partial.is_empty() {
                     self.commit_partial();
-                } else if !had_content {
-                    self.buffer.push(LineEntry {
-                        text: CompactString::new(""),
-                        color,
-                    });
                 }
-                if self.scroll_offset == 0 {
-                    self.ensure_room();
-                    let mut stdout = io::stdout();
-                    let r = self.content_row();
-                    self.move_to_content(&mut stdout, r)?;
-                    if let Some(bg) = self.chat_bg {
-                        write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
-                    }
-                    if !segment.is_empty() {
-                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
-                        write!(stdout, "{}", segment)?;
-                        write!(stdout, "{}", ResetColor)?;
-                    }
-                    writeln!(stdout)?;
-                    self.cursor_row = self.cursor_row.saturating_add(1);
-                    self.col = 0;
-                }
-            } else if !segment.is_empty() {
-                let chars: SmallVec<[char; 64]> = segment.chars().collect();
-                let mut idx = 0;
-                while idx < chars.len() {
-                    let avail = max_width.saturating_sub(self.col as usize);
-                    if avail == 0 {
-                        self.commit_partial();
-                        if self.scroll_offset == 0 {
-                            self.cursor_row = self.cursor_row.saturating_add(1);
-                            self.col = 0;
-                        }
-                        continue;
-                    }
-                    // Collect chars that fit within avail display columns
-                    let mut end = idx;
-                    let mut w: usize = 0;
-                    while end < chars.len() {
-                        let cw = char_display_width(chars[end]);
-                        if w + cw > avail {
-                            break;
-                        }
-                        w += cw;
-                        end += 1;
-                    }
-                    // Try to break at a word boundary
-                    if end < chars.len() && end > idx {
-                        let mut break_at = end;
-                        for i in (idx..end).rev() {
-                            if chars[i] == ' ' {
-                                break_at = i + 1;
-                                break;
-                            }
-                        }
-                        if break_at != idx {
-                            end = break_at;
-                            // Recalculate width for the shortened chunk
-                            w = chars[idx..end].iter().map(|&c| char_display_width(c)).sum();
-                        }
-                    }
-                    let chunk: String = chars[idx..end].iter().collect();
-                    self.partial_color = color;
-                    self.partial.push_str(&chunk);
-                    if self.scroll_offset == 0 {
-                        self.ensure_room();
-                        let mut stdout = io::stdout();
-                        let r = self.content_row();
-                        self.move_to_content(&mut stdout, r)?;
-                        if let Some(bg) = self.chat_bg {
-                            write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
-                        }
-                        write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
-                        write!(stdout, "{}", wrap_urls_osc8(&chunk))?;
-                        write!(stdout, "{}", ResetColor)?;
-
-                        self.col = self.col.saturating_add(w as u16);
-                    }
-                    idx = end;
-                    if idx < chars.len() {
-                        self.commit_partial();
-                        if self.scroll_offset == 0 {
-                            self.cursor_row = self.cursor_row.saturating_add(1);
-                            self.col = 0;
-                        }
-                    }
-                }
+                self.feed.push_block(style, *segment);
+            } else {
+                // Last segment may still be incomplete; accumulate in partial.
+                self.partial_style = style;
+                self.partial.push_str(segment);
             }
         }
         if self.scroll_offset == 0 {
-            io::stdout().flush()?;
+            self.render_viewport()?;
         }
         Ok(())
     }
 
     pub fn clear_content(&mut self) -> io::Result<()> {
-        self.buffer.clear();
+        self.feed.clear();
         self.partial.clear();
         self.scroll_offset = 0;
         self.clear_selection();
@@ -785,9 +585,15 @@ impl Renderer {
         write!(stdout, "{}", ResetColor)?;
         stdout.execute(MoveTo(0, 0))?;
         stdout.flush()?;
-        self.cursor_row = 0;
-        self.col = 0;
         Ok(())
+    }
+
+    pub fn resize(&mut self) {
+        let visible = self.visible_lines();
+        let max_offset = self.buffer_len().saturating_sub(visible);
+        if self.scroll_offset > max_offset {
+            self.scroll_offset = max_offset;
+        }
     }
 
     fn clear_shrunk_rows(&self, old_height: usize, new_height: usize) -> io::Result<()> {


### PR DESCRIPTION
Issue #186, architecture bullet 2:
- Add src/ui/feed.rs with BlockStyle, Block, and Feed.
- Feed::lines(width) returns wrapped/colored LineEntry rows.
- Renderer now owns Feed and draws Feed::lines(width).
- Move session rendering and streaming response updates to push semantic blocks.
- Rename response_start_line -> response_start_block.
- Add feed_tests.rs covering wrapping, markdown, scroll mapping, and selection.