### PR TITLE
docs: add MiniMax custom provider recipe

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -26,6 +26,10 @@ The model is set with `--model` or `ZS_MODEL`:
 zerostack --provider openai --model gpt-4o
 ```
 
+## Provider Recipes
+
+- [MiniMax](../providers/Minimax.md)
+
 ## Custom Providers
 
 Custom providers let you point zerostack at any OpenAI-compatible API (vLLM,

--- a/providers/Minimax.md
+++ b/providers/Minimax.md
@@ -1,0 +1,98 @@
+# MiniMax
+
+MiniMax is available in zerostack through custom provider definitions. The
+configuration below keeps the API protocol and region explicit while sharing a
+single `MINIMAX_API_KEY` environment variable.
+
+## Credentials
+
+Set the API key in your shell instead of storing it in the zerostack config:
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+## Provider Routes
+
+Add the routes you need to `~/.config/zerostack/config.toml`:
+
+```toml
+[custom_providers.minimax-global-openai]
+provider_type = "openai"
+base_url = "https://api.minimax.io/v1"
+api_key_env = "MINIMAX_API_KEY"
+api_style = "completions"
+model = "MiniMax-M3"
+
+[custom_providers.minimax-cn-openai]
+provider_type = "openai"
+base_url = "https://api.minimaxi.com/v1"
+api_key_env = "MINIMAX_API_KEY"
+api_style = "completions"
+model = "MiniMax-M3"
+
+[custom_providers.minimax-global-anthropic]
+provider_type = "anthropic"
+base_url = "https://api.minimax.io/anthropic"
+api_key_env = "MINIMAX_API_KEY"
+model = "MiniMax-M3"
+
+[custom_providers.minimax-cn-anthropic]
+provider_type = "anthropic"
+base_url = "https://api.minimaxi.com/anthropic"
+api_key_env = "MINIMAX_API_KEY"
+model = "MiniMax-M3"
+```
+
+Keep each Anthropic-compatible `base_url` ending in `/anthropic`. The
+Anthropic client appends `/v1/messages` when it sends a request, so do not add
+`/v1` to the configured base URL.
+
+Select any route and model with the standard CLI flags:
+
+```bash
+zerostack --provider minimax-global-openai --model MiniMax-M3
+zerostack --provider minimax-cn-openai --model MiniMax-M2.7
+zerostack --provider minimax-global-anthropic --model MiniMax-M3
+zerostack --provider minimax-cn-anthropic --model MiniMax-M2.7
+```
+
+## Model Configuration
+
+| Model | Context window | Input modes | Thinking | Input | Output | Cache read | Cache write |
+| ----- | -------------: | ----------- | -------- | ----: | -----: | ---------: | ----------: |
+| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive or disabled | $0.30 | $1.20 | $0.06 | not listed |
+| `MiniMax-M2.7` | 204,800 | text | always on | $0.30 | $1.20 | $0.06 | $0.375 |
+
+Prices are in USD per million tokens. MiniMax-M3 also has the following
+service-tier pricing:
+
+| Service tier | Context | Input | Output | Cache read |
+| ------------ | ------- | ----: | -----: | ---------: |
+| standard | up to 512,000 tokens | $0.30 | $1.20 | $0.06 |
+| standard | over 512,000 tokens | $0.60 | $2.40 | $0.12 |
+| priority | up to 512,000 tokens | $0.45 | $1.80 | $0.09 |
+| priority | over 512,000 tokens | $0.90 | $3.60 | $0.18 |
+
+The optional quick-model entries below use the standard tier at up to 512,000
+tokens for zerostack's local cost estimate:
+
+```toml
+[quick_models.minimax-m3]
+provider = "minimax-global-openai"
+model = "MiniMax-M3"
+context_window = 1000000
+input_token_cost = 0.3
+output_token_cost = 1.2
+
+[quick_models.minimax-m2-7]
+provider = "minimax-global-openai"
+model = "MiniMax-M2.7"
+context_window = 204800
+input_token_cost = 0.3
+output_token_cost = 1.2
+```
+
+Switch to either entry with `--quick-model minimax-m3` or
+`--quick-model minimax-m2-7`. Change the `provider` value in a quick-model
+entry to use another route from the configuration above.

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -2,12 +2,19 @@ use crate::auth::ProviderKind;
 use crate::config::{ApiStyle, CustomProviderConfig};
 use crate::provider::ModelEntry;
 use crate::provider::{
-    expand_env, is_agent_model, merge_extra_body, openrouter_anthropic_routing, resolve_api_style,
-    resolve_provider_config, serialize_conversation,
+    AnyClient, create_client, expand_env, is_agent_model, merge_extra_body,
+    openrouter_anthropic_routing, resolve_api_style, resolve_provider_config,
+    serialize_conversation,
 };
 use crate::session::{MessageRole, SessionMessage};
 use compact_str::CompactString;
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::Duration;
 
 fn cfg(api_style: Option<ApiStyle>) -> CustomProviderConfig {
     CustomProviderConfig {
@@ -229,6 +236,72 @@ fn resolve_custom_provider() {
     let cfg = resolve_provider_config("my-gw", &custom).unwrap();
     assert_eq!(cfg.kind, ProviderKind::OpenAI);
     assert_eq!(cfg.base_url.as_deref(), Some("https://mygw.example/v1"));
+}
+
+#[tokio::test]
+async fn anthropic_custom_base_appends_v1_messages() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            let count = stream.read(&mut buffer).unwrap();
+            if count == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..count]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_line = String::from_utf8_lossy(&request)
+            .lines()
+            .next()
+            .unwrap()
+            .to_string();
+        request_tx.send(request_line).unwrap();
+        stream
+            .write_all(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .unwrap();
+    });
+
+    let mut custom = HashMap::new();
+    custom.insert(
+        "anthropic-capture".to_string(),
+        CustomProviderConfig {
+            provider_type: "anthropic".into(),
+            base_url: format!("http://{address}/anthropic"),
+            api_key_env: None,
+            danger_accept_invalid_certs: None,
+            api_style: None,
+            headers: HashMap::new(),
+            timeout_secs: None,
+            model: None,
+        },
+    );
+
+    let client = create_client("anthropic-capture", Some("test-key"), &custom, None).unwrap();
+    let AnyClient::Anthropic(client) = client else {
+        panic!("expected an Anthropic client");
+    };
+    let agent = client.agent("MiniMax-M3").max_tokens(16).build();
+    assert!(agent.prompt("hello").await.is_err());
+
+    server.join().unwrap();
+    assert_eq!(
+        request_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+        "POST /anthropic/v1/messages HTTP/1.1"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a custom-provider recipe covering all configured regional and protocol routes
- document the current model context, input capabilities, thinking modes, pricing tiers, and quick-model setup
- add a request-capture regression test for the configured messages-compatible base path
- link the recipe from the main provider documentation

## Compatibility

This uses the existing custom-provider configuration path and does not change built-in provider defaults or existing model entries.

## Checks

- `cargo fmt`
- `cargo install --path . --debug`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::large-enum-variant -A clippy::collapsible-if -A clippy::needless-return`

The unmodified `cargo clippy --all-targets --all-features -- -D warnings` command currently reports existing warnings in untouched files under Rust 1.96.