### PR TITLE
refactor(ui): group App state into UiContext/AgentRunState/ChainState/SlashState

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Single crate, no workspace. All source under `src/`.
 | `src/agent/` | Agent lifecycle: `builder.rs` (rig Agent construction + tool injection), `runner.rs` (spawn, stream), `prompt.rs` (system prompts), `tools/` (8 core tool impls: read, write, edit, bash, grep, find_files, list_dir, todo; plus feature-gated `TaskTool` and `AdvisorTool`) |
 | `src/session/` | Session state: `mod.rs` (messages, compactions, costs), `storage.rs` (JSON file I/O), `chat_history.rs` |
 | `src/permission/` | Security: `checker.rs` (glob+regex rules, doom-loop detection), `ask.rs` (user prompt UI), `pattern.rs` |
-| `src/ui/` | Custom TUI on crossterm (no ratatui): `mod.rs` (event loop), `terminal.rs` (raw mode guard), `renderer.rs` (line buffer + viewport), `input/` (text editor + pickers), `status.rs`, `markdown.rs`, `event_handler.rs`, `cmd_picker.rs` |
+| `src/ui/` | Custom TUI on crossterm (no ratatui): `mod.rs` (event loop), `terminal.rs` (raw mode guard), `renderer.rs` (line buffer + viewport), `input/` (text editor + pickers), `status.rs`, `markdown.rs`, `event_handler.rs`, `state.rs` (grouped TUI state: `UiContext`, `AgentRunState`, `ChainState`, `SlashState`), `cmd_picker.rs` |
 | `src/context/` | Context gathering: embedded prompt themes (`prompts.rs`, `themes.rs`), AGENTS.md/ARCHITECTURE.md loading |
 | `src/config/` | Configuration: `load.rs` (TOML/YAML/JSON from disk+env), `types.rs` (QuickModel, CustomProvider, Colors, EditSystem) |
 | `src/extras/` | Feature-gated extensions: `loop/` (headless), `mcp/` (MCP client), `acp/` (ACP server), `memory/` (persistent memory), `subagents/` (parallel task delegation), `git_worktree/`, `archmd/`, `advisor/` (external model consultation, `/advisor`), `multimodal/` (image/PDF ingestion, gated separately by `multimodal`/`pdf`), `hooks/` (lifecycle hook dispatch: `PreToolUse`/`PostToolUse`/`Stop`/`UserPromptSubmit`/session+subagent events, trust-hash confirmation). Two subsystems are always compiled (not feature-gated): `chain/` (brainstorm→plan→code prompt transitions) and `status_signals` (Unix-socket start/stop/git-conflict signals, itself gated by the `status-signals` feature at the call site) |
@@ -121,7 +121,7 @@ Optional (`mcp` feature): `rmcp 2.0` (MCP client with child-process + HTTP trans
 - **`--print`** / `-p` — `agent.run_print()` → single reply, then exit (`main.rs:774`)
 - **`--loop`** — `run_headless_loop()` → iterative prompt/validate loop (branch at `main.rs:891`, definition at `:1160`)
 - **`--acp`** — `extras::acp::serve()` → ACP server mode (`main.rs:417`)
-- **Default (no flags)** — `ui::run_interactive()` → full TUI (call at `main.rs:931`, definition at `src/ui/mod.rs:751`)
+- **Default (no flags)** — `ui::run_interactive()` → full TUI (call at `main.rs:931`, definition at `src/ui/mod.rs:636`)
 - **`--resume`** / `--continue` / `--session <id>` — loads prior session before entering TUI/print
 - **`--advisor`** (feature `advisor`) — registers `AdvisorTool` so the agent can consult a second model for strategic guidance mid-session (`src/agent/builder.rs:269-273`)
 - **`--no-hooks`** / **`--hooks-test`** (feature `hooks`) — disables the hook dispatcher, or dry-runs a single hook invocation against stdin and exits (`src/main.rs:178`, `:191`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -952,18 +952,20 @@ async fn run() -> anyhow::Result<()> {
             session.add_message(MessageRole::User, &initial_msg);
         }
         ui::run_interactive(
-            client,
+            crate::ui::state::UiContext::new(
+                &cli,
+                &cfg,
+                &mut session,
+                &mut context,
+                client,
+                permission,
+                ask_tx,
+                sandbox,
+                status_signals,
+            ),
             None,
-            &cli,
-            &cfg,
-            &mut session,
-            &mut context,
-            permission,
-            ask_tx,
             ask_rx,
-            sandbox,
             arch_msg,
-            status_signals,
             #[cfg(feature = "advisor")]
             handoff_rx,
         )

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -10,18 +9,12 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crossterm::style::Color;
 use tokio::sync::mpsc;
 
-use crate::cli::Cli;
-use crate::config::{self, Config};
-use crate::context::ContextFiles;
+use crate::config;
 use crate::event::{AgentEvent, BtwEvent, UserEvent};
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::McpClientManager;
-use crate::extras::status_signals::StatusSignals;
-use crate::permission::ask::AskSender;
-use crate::permission::checker::PermCheck;
-use crate::provider::{AnyAgent, AnyClient};
-use crate::sandbox::Sandbox;
-use crate::session::{MessageRole, Session};
+use crate::provider::AnyAgent;
+use crate::session::MessageRole;
 use crate::ui::event_handler;
 use crate::ui::events::{render_session, sanitize_output};
 use crate::ui::input::InputEditor;
@@ -29,10 +22,13 @@ use crate::ui::permission_handler::handle_permission_request;
 use crate::ui::pickers::rewind::RewindOutcome;
 use crate::ui::renderer::{self as renderer_mod, ChainPrompt, Renderer, copy_to_clipboard};
 use crate::ui::slash::{apply_prompt_model, handle_compress, handle_slash};
+#[cfg(feature = "git-worktree")]
+use crate::ui::state::MergeRequest;
+use crate::ui::state::{AgentRunState, BtwStats, ChainState, SlashState, UiContext};
 use crate::ui::terminal::TerminalGuard;
 use crate::ui::utils::{parse_color, to_ansi_256};
 
-#[cfg(feature = "mcp")]
+#[cfg(all(feature = "mcp", feature = "git-worktree"))]
 use super::ensure_mcp_manager;
 #[cfg(feature = "advisor")]
 use super::handle_human_handoff;
@@ -49,43 +45,17 @@ use super::{C_PERM, apply_current_prompt_mode};
 const TURN_TRACE_MAX: usize = 64;
 
 pub(crate) struct App<'a> {
-    cli: &'a Cli,
-    cfg: &'a Config,
-    session: &'a mut Session,
-    context: &'a mut ContextFiles,
-    permission: Option<PermCheck>,
-    ask_tx: Option<AskSender>,
-    ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
-    sandbox: Sandbox,
-    status_signals: Option<StatusSignals>,
-    #[cfg(feature = "advisor")]
-    handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
+    ui: UiContext<'a>,
+    run: AgentRunState,
+    chain: ChainState,
+    slash: SlashState,
 
-    client: AnyClient,
-    agent: Option<AnyAgent>,
     renderer: Renderer,
     input: InputEditor,
     last_branch_check: std::time::Instant,
-    #[cfg(feature = "mcp")]
-    mcp_manager: Option<McpClientManager>,
-
-    is_running: bool,
-    agent_rx: Option<mpsc::Receiver<AgentEvent>>,
-    main_abort: Option<tokio::task::AbortHandle>,
-    pending_inputs: VecDeque<String>,
-    agent_line_started: bool,
-    response_buf: String,
-    response_start_block: Option<usize>,
-    show_reasoning: bool,
-    reasoning_enabled: bool,
-    pending_send: Option<String>,
-    was_reasoning: bool,
-    todo_tools_enabled: bool,
-    loop_label: Option<String>,
-    #[cfg(feature = "loop")]
-    loop_state: Option<crate::extras::r#loop::LoopState>,
-    #[cfg(feature = "git-worktree")]
-    wt_return_path: Option<(String, String, String, bool)>,
+    ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
+    #[cfg(feature = "advisor")]
+    handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
 
     btw_tx: mpsc::Sender<BtwEvent>,
     btw_rx: mpsc::Receiver<BtwEvent>,
@@ -96,12 +66,6 @@ pub(crate) struct App<'a> {
     btw_total_in: u64,
     btw_total_out: u64,
 
-    turn_trace: Vec<compact_str::CompactString>,
-    awaiting_compaction_relief: bool,
-    dot_prompt_restore: Option<String>,
-    chain_pending: Option<crate::extras::chain::ChainPhase>,
-    chain_label_msg: Option<String>,
-
     user_tx: mpsc::Sender<UserEvent>,
     user_rx: mpsc::Receiver<UserEvent>,
     running: Arc<AtomicBool>,
@@ -111,45 +75,33 @@ pub(crate) struct App<'a> {
 }
 
 impl<'a> App<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
-        client: AnyClient,
-        mut agent: Option<AnyAgent>,
-        cli: &'a Cli,
-        cfg: &'a Config,
-        session: &'a mut Session,
-        context: &'a mut ContextFiles,
-        permission: Option<PermCheck>,
-        ask_tx: Option<AskSender>,
+        mut ui: UiContext<'a>,
+        agent: Option<AnyAgent>,
         ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
-        sandbox: Sandbox,
         auto_trigger_msg: Option<String>,
-        status_signals: Option<StatusSignals>,
         #[cfg(feature = "advisor")] handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
     ) -> anyhow::Result<Self> {
         let _terminal_guard = TerminalGuard::new()?;
 
-        session.show_cost_always = cfg.resolve_show_cost_always();
-        crate::ui::statusline::init(cfg);
+        ui.session.show_cost_always = ui.cfg.resolve_show_cost_always();
+        crate::ui::statusline::init(ui.cfg);
 
-        session.refresh_git_branch();
+        ui.session.refresh_git_branch();
         if crate::ui::statusline::needs_git_status() {
-            session.refresh_git_status();
+            ui.session.refresh_git_status();
         }
         let last_branch_check = std::time::Instant::now();
 
-        #[cfg(feature = "mcp")]
-        let mut mcp_manager: Option<McpClientManager> = None;
-
         let mut renderer = Renderer::new()?;
         renderer.set_statusline_height(crate::ui::statusline::line_count());
-        renderer.set_monochrome(cli.no_color);
-        renderer.set_chat_margin(cfg.resolve_chat_left_margin());
-        if let Some(ref theme_name) = context.current_theme_name {
-            if let Some(content) = context.themes.get(theme_name.as_str()) {
+        renderer.set_monochrome(ui.cli.no_color);
+        renderer.set_chat_margin(ui.cfg.resolve_chat_left_margin());
+        if let Some(ref theme_name) = ui.context.current_theme_name {
+            if let Some(content) = ui.context.themes.get(theme_name.as_str()) {
                 crate::context::themes::apply(content, &mut renderer);
             }
-        } else if let Some(colors) = &cfg.colors {
+        } else if let Some(colors) = &ui.cfg.colors {
             let chat_bg = colors.chat_background.as_deref().and_then(parse_color);
             let input_bg = colors.input_background.as_deref().and_then(parse_color);
             let status_bg = colors.status_background.as_deref().and_then(parse_color);
@@ -165,60 +117,43 @@ impl<'a> App<'a> {
         }
 
         let mut input = InputEditor::new();
-        input.set_monochrome(cli.no_color);
-        input.set_prompt_names(context.prompts.keys().cloned().collect());
-        input.set_theme_names(context.themes.keys().cloned().collect());
-        if let Some(editor) = &cfg.editor {
+        input.set_monochrome(ui.cli.no_color);
+        input.set_prompt_names(ui.context.prompts.keys().cloned().collect());
+        input.set_theme_names(ui.context.themes.keys().cloned().collect());
+        if let Some(editor) = &ui.cfg.editor {
             input.set_editor(editor.clone());
         }
-        input.set_quick_model_names(config::quick_models_map(cfg).into_keys().collect());
+        input.set_quick_model_names(config::quick_models_map(ui.cfg).into_keys().collect());
         {
             let mut providers: Vec<String> =
                 ["anthropic", "openai", "gemini", "openrouter", "ollama"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect();
-            providers.extend(cfg.custom_providers_map().keys().cloned());
+            providers.extend(ui.cfg.custom_providers_map().keys().cloned());
             input.set_provider_names(providers);
         }
         input.load_global_history();
 
-        let mut is_running = false;
-        let mut agent_rx: Option<mpsc::Receiver<AgentEvent>> = None;
-        let mut main_abort: Option<tokio::task::AbortHandle> = None;
-        let pending_inputs: VecDeque<String> = VecDeque::new();
-        let agent_line_started = false;
-        let response_buf = String::new();
-        let response_start_block: Option<usize> = None;
-        let show_reasoning = cfg.resolve_show_reasoning();
-        let reasoning_enabled = true;
-        session.reasoning_enabled = reasoning_enabled;
-        let pending_send: Option<String> = None;
-        let was_reasoning = false;
-        let todo_tools_enabled = false;
-        let loop_label: Option<String> = None;
-        #[cfg(feature = "loop")]
-        let loop_state: Option<crate::extras::r#loop::LoopState> = None;
-        #[cfg(feature = "git-worktree")]
-        let wt_return_path: Option<(String, String, String, bool)> = None;
-
-        session.overhead_tokens =
-            crate::agent::builder::estimate_overhead(context, reasoning_enabled);
-
-        let perm_mode = || -> Option<String> {
-            permission.as_ref().map(|p| {
-                p.lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .mode()
-                    .to_string()
-            })
+        let mut run = AgentRunState {
+            agent,
+            ..AgentRunState::default()
         };
+        let chain = ChainState::default();
+        let slash = SlashState {
+            show_reasoning: ui.cfg.resolve_show_reasoning(),
+            reasoning_enabled: true,
+            todo_tools_enabled: false,
+        };
+        ui.session.reasoning_enabled = slash.reasoning_enabled;
+        ui.session.overhead_tokens =
+            crate::agent::builder::estimate_overhead(ui.context, slash.reasoning_enabled);
 
-        render_session(&mut renderer, session, cli, cfg, context)?;
+        render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context)?;
         let marker_path = crate::session::storage::data_dir().join("shown_welcome_msg");
-        if cfg.resolve_always_show_welcome() || !marker_path.exists() {
+        if ui.cfg.resolve_always_show_welcome() || !marker_path.exists() {
             crate::ui::events::show_welcome(&mut renderer)?;
-            if !cfg.resolve_always_show_welcome() {
+            if !ui.cfg.resolve_always_show_welcome() {
                 if let Some(dir) = marker_path.parent() {
                     let _ = std::fs::create_dir_all(dir);
                 }
@@ -228,49 +163,48 @@ impl<'a> App<'a> {
         refresh_display(
             &mut renderer,
             &mut input,
-            session,
-            false,
-            None,
-            context.current_prompt_name.as_deref(),
-            perm_mode().as_deref(),
-            None,
-            0.0,
-            0,
-            0,
+            &ui,
+            &run,
+            &chain,
+            BtwStats::default(),
         )?;
 
         {
-            let provider = session.provider.to_string();
-            let is_custom = cfg.custom_providers_map().contains_key(&provider);
-            let ids =
-                crate::ui::slash::warm_model_cache(&provider, is_custom, &client, cli, cfg).await;
+            let provider = ui.session.provider.to_string();
+            let is_custom = ui.cfg.custom_providers_map().contains_key(&provider);
+            let ids = crate::ui::slash::warm_model_cache(
+                &provider, is_custom, &ui.client, ui.cli, ui.cfg,
+            )
+            .await;
             input.set_live_model_names(ids);
         }
 
         #[cfg(feature = "git-worktree")]
-        if let Some(name) = &cli.worktree {
-            let wt_base_dir = cli.resolve_wt_base_dir(cfg);
+        if let Some(name) = &ui.cli.worktree {
+            let wt_base_dir = ui.cli.resolve_wt_base_dir(ui.cfg);
             match crate::extras::git_worktree::create(name, wt_base_dir.as_deref()) {
                 Ok((path, _info)) => {
                     std::env::set_current_dir(&path).ok();
-                    session.working_dir = compact_str::CompactString::new(path.to_string_lossy());
-                    context.reload();
-                    apply_current_prompt_mode(context, &permission);
+                    ui.session.working_dir =
+                        compact_str::CompactString::new(path.to_string_lossy());
+                    ui.context.reload();
+                    apply_current_prompt_mode(ui.context, &ui.permission);
                     #[cfg(feature = "mcp")]
-                    let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
-                    let model = client.completion_model(session.model.to_string());
-                    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-                    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
-                    agent = Some(
+                    let mcp_ref = ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
+                    let model = ui.client.completion_model(ui.session.model.to_string());
+                    let temperature =
+                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
+                    run.agent = Some(
                         crate::provider::build_agent(
                             model,
-                            cli,
-                            cfg,
-                            context,
-                            permission.clone(),
-                            ask_tx.clone(),
-                            sandbox.clone(),
-                            reasoning_enabled,
+                            ui.cli,
+                            ui.cfg,
+                            ui.context,
+                            ui.permission.clone(),
+                            ui.ask_tx.clone(),
+                            ui.sandbox.clone(),
+                            slash.reasoning_enabled,
                             temperature,
                             extra_body,
                             #[cfg(feature = "mcp")]
@@ -278,7 +212,7 @@ impl<'a> App<'a> {
                         )
                         .await,
                     );
-                    let _ = render_session(&mut renderer, session, cli, cfg, context);
+                    let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
                 }
                 Err(e) => {
                     let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
@@ -286,34 +220,36 @@ impl<'a> App<'a> {
             }
         }
         #[cfg(feature = "git-worktree")]
-        if cli.parallel {
+        if ui.cli.parallel {
             let ts = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
             let name = ts.to_string();
-            let wt_base_dir = cli.resolve_wt_base_dir(cfg);
+            let wt_base_dir = ui.cli.resolve_wt_base_dir(ui.cfg);
             match crate::extras::git_worktree::create(&name, wt_base_dir.as_deref()) {
                 Ok((path, _info)) => {
                     std::env::set_current_dir(&path).ok();
-                    session.working_dir = compact_str::CompactString::new(path.to_string_lossy());
-                    context.reload();
-                    apply_current_prompt_mode(context, &permission);
+                    ui.session.working_dir =
+                        compact_str::CompactString::new(path.to_string_lossy());
+                    ui.context.reload();
+                    apply_current_prompt_mode(ui.context, &ui.permission);
                     #[cfg(feature = "mcp")]
-                    let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
-                    let model = client.completion_model(session.model.to_string());
-                    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-                    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
-                    agent = Some(
+                    let mcp_ref = ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
+                    let model = ui.client.completion_model(ui.session.model.to_string());
+                    let temperature =
+                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
+                    run.agent = Some(
                         crate::provider::build_agent(
                             model,
-                            cli,
-                            cfg,
-                            context,
-                            permission.clone(),
-                            ask_tx.clone(),
-                            sandbox.clone(),
-                            reasoning_enabled,
+                            ui.cli,
+                            ui.cfg,
+                            ui.context,
+                            ui.permission.clone(),
+                            ui.ask_tx.clone(),
+                            ui.sandbox.clone(),
+                            slash.reasoning_enabled,
                             temperature,
                             extra_body,
                             #[cfg(feature = "mcp")]
@@ -321,7 +257,7 @@ impl<'a> App<'a> {
                         )
                         .await,
                     );
-                    let _ = render_session(&mut renderer, session, cli, cfg, context);
+                    let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
                 }
                 Err(e) => {
                     let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
@@ -336,45 +272,30 @@ impl<'a> App<'a> {
             }
             renderer.write_line("", Color::White)?;
 
-            #[cfg(feature = "mcp")]
-            let mcp_ref = ensure_mcp_manager(&mut mcp_manager, cfg).await;
-            event_handler::ensure_agent(
-                &mut agent,
-                &client,
-                session,
-                cli,
-                cfg,
-                context,
-                &permission,
-                &ask_tx,
-                &sandbox,
-                reasoning_enabled,
-                #[cfg(feature = "mcp")]
-                mcp_ref,
-            )
-            .await;
-            let history = crate::agent::runner::convert_history(session);
-            let runner = agent
+            event_handler::ensure_agent(&mut run.agent, &mut ui, slash.reasoning_enabled).await;
+            let history = crate::agent::runner::convert_history(ui.session);
+            let runner = run
+                .agent
                 .as_ref()
                 .unwrap()
                 .clone()
                 .spawn_runner(
                     trigger_msg.to_string(),
                     history,
-                    cfg.retry.clone(),
+                    ui.cfg.retry.clone(),
                     #[cfg(feature = "hooks")]
                     None,
                 )
                 .await;
-            agent_rx = Some(runner.event_rx);
-            main_abort = Some(runner.abort_handle);
-            is_running = true;
-            if let Some(ss) = status_signals.as_ref() {
+            run.agent_rx = Some(runner.event_rx);
+            run.main_abort = Some(runner.abort_handle);
+            run.is_running = true;
+            if let Some(ss) = ui.status_signals.as_ref() {
                 ss.send_start();
             }
-            session.add_message(MessageRole::User, trigger_msg);
+            ui.session.add_message(MessageRole::User, trigger_msg);
             #[cfg(feature = "advisor")]
-            crate::extras::advisor::set_session_messages(session.messages.clone());
+            crate::extras::advisor::set_session_messages(ui.session.messages.clone());
         }
 
         let (user_tx, user_rx) = mpsc::channel::<UserEvent>(64);
@@ -383,15 +304,16 @@ impl<'a> App<'a> {
 
         let (prebuild_tx, prebuild_rx_raw) = mpsc::channel::<PrebuildPayload>(1);
         let prebuild_rx = Some(prebuild_rx_raw);
-        if auto_trigger_msg.is_none() && agent.is_none() {
-            let client_clone = client.clone();
-            let session_model = session.model.to_string();
-            let cli_clone = cli.clone();
-            let cfg_clone = cfg.clone();
-            let context_clone = context.clone();
-            let permission_clone = permission.clone();
-            let ask_tx_clone = ask_tx.clone();
-            let sandbox_clone = sandbox.clone();
+        if auto_trigger_msg.is_none() && run.agent.is_none() {
+            let client_clone = ui.client.clone();
+            let session_model = ui.session.model.to_string();
+            let cli_clone = ui.cli.clone();
+            let cfg_clone = ui.cfg.clone();
+            let context_clone = ui.context.clone();
+            let permission_clone = ui.permission.clone();
+            let ask_tx_clone = ui.ask_tx.clone();
+            let sandbox_clone = ui.sandbox.clone();
+            let reasoning_enabled = slash.reasoning_enabled;
             tokio::spawn(async move {
                 #[cfg(feature = "mcp")]
                 let mcp = if let Some(ref servers) = cfg_clone.mcp_servers {
@@ -434,41 +356,16 @@ impl<'a> App<'a> {
         let (btw_tx, btw_rx) = mpsc::channel::<BtwEvent>(32);
 
         Ok(Self {
-            cli,
-            cfg,
-            session,
-            context,
-            permission,
-            ask_tx,
-            ask_rx,
-            sandbox,
-            status_signals,
-            #[cfg(feature = "advisor")]
-            handoff_rx,
-            client,
-            agent,
+            ui,
+            run,
+            chain,
+            slash,
             renderer,
             input,
             last_branch_check,
-            #[cfg(feature = "mcp")]
-            mcp_manager,
-            is_running,
-            agent_rx,
-            main_abort,
-            pending_inputs,
-            agent_line_started,
-            response_buf,
-            response_start_block,
-            show_reasoning,
-            reasoning_enabled,
-            pending_send,
-            was_reasoning,
-            todo_tools_enabled,
-            loop_label,
-            #[cfg(feature = "loop")]
-            loop_state,
-            #[cfg(feature = "git-worktree")]
-            wt_return_path,
+            ask_rx,
+            #[cfg(feature = "advisor")]
+            handoff_rx,
             btw_tx,
             btw_rx,
             btw_abort: Vec::new(),
@@ -477,11 +374,6 @@ impl<'a> App<'a> {
             btw_total_cost: 0.0,
             btw_total_in: 0,
             btw_total_out: 0,
-            turn_trace: Vec::new(),
-            awaiting_compaction_relief: false,
-            dot_prompt_restore: None,
-            chain_pending: None,
-            chain_label_msg: None,
             user_tx,
             user_rx,
             running,
@@ -493,11 +385,11 @@ impl<'a> App<'a> {
 
     pub(crate) async fn run(&mut self) -> anyhow::Result<()> {
         loop {
-            self.session.reasoning_enabled = self.reasoning_enabled;
+            self.ui.session.reasoning_enabled = self.slash.reasoning_enabled;
             if self.last_branch_check.elapsed() >= Duration::from_secs(1) {
-                self.session.refresh_git_branch();
+                self.ui.session.refresh_git_branch();
                 if crate::ui::statusline::needs_git_status() {
-                    self.session.refresh_git_status();
+                    self.ui.session.refresh_git_status();
                 }
                 self.last_branch_check = std::time::Instant::now();
             }
@@ -509,22 +401,20 @@ impl<'a> App<'a> {
                         ControlFlow::Continue(()) => {}
                     }
                 }
-                Some(prebuilt) = async { self.prebuild_rx.as_mut()?.recv().await }, if self.agent.is_none() => {
+                Some(prebuilt) = async { self.prebuild_rx.as_mut()?.recv().await }, if self.run.agent.is_none() => {
                     self.take_prebuild(prebuilt, true)?;
                     self.refresh()?;
                 }
-                Some(event) = async { self.agent_rx.as_mut()?.recv().await } => {
+                Some(event) = async { self.run.agent_rx.as_mut()?.recv().await } => {
                     self.handle_agent_event(event).await?;
                 }
                 Some(ask_req) = async { self.ask_rx.as_mut()?.recv().await } => {
                     handle_permission_request(
                         ask_req,
                         &mut self.renderer,
-                        self.session,
-                        self.cli,
+                        &mut self.ui,
+                        &mut self.run,
                         &mut self.user_rx,
-                        &mut self.agent_line_started,
-                        &mut self.was_reasoning,
                     ).await?;
                     self.refresh()?;
                 }
@@ -532,12 +422,12 @@ impl<'a> App<'a> {
                     self.handle_btw_event(bev)?;
                     self.refresh()?;
                 }
-                _ = tokio::time::sleep(Duration::from_millis(100)), if self.is_running => {
+                _ = tokio::time::sleep(Duration::from_millis(100)), if self.run.is_running => {
                     self.refresh()?;
                 }
                 else => {
                     if let Some(rx) = self.prebuild_rx.as_mut()
-                        && self.agent.is_none()
+                        && self.run.agent.is_none()
                         && let Ok(payload) = rx.try_recv()
                     {
                         self.take_prebuild(payload, false)?;
@@ -550,14 +440,8 @@ impl<'a> App<'a> {
             if let Some(ref mut rx) = self.handoff_rx
                 && let Ok(req) = rx.try_recv()
             {
-                handle_human_handoff(
-                    req,
-                    &mut self.renderer,
-                    &mut self.user_rx,
-                    &mut self.agent_line_started,
-                    &mut self.was_reasoning,
-                )
-                .await?;
+                handle_human_handoff(req, &mut self.renderer, &mut self.user_rx, &mut self.run)
+                    .await?;
                 self.refresh()?;
             }
         }
@@ -572,35 +456,24 @@ impl<'a> App<'a> {
             let _ = h.join();
         }
         #[cfg(feature = "mcp")]
-        if let Some(mgr) = self.mcp_manager {
+        if let Some(mgr) = self.ui.mcp_manager {
             mgr.shutdown().await;
         }
     }
 
     fn refresh(&mut self) -> io::Result<()> {
-        let perm_mode = self.perm_mode();
         refresh_display(
             &mut self.renderer,
             &mut self.input,
-            self.session,
-            self.is_running,
-            self.loop_label.as_deref(),
-            self.context.current_prompt_name.as_deref(),
-            perm_mode.as_deref(),
-            self.chain_label_msg.as_deref(),
-            self.btw_total_cost,
-            self.btw_total_in,
-            self.btw_total_out,
+            &self.ui,
+            &self.run,
+            &self.chain,
+            BtwStats {
+                cost: self.btw_total_cost,
+                input: self.btw_total_in,
+                output: self.btw_total_out,
+            },
         )
-    }
-
-    fn perm_mode(&self) -> Option<String> {
-        self.permission.as_ref().map(|p| {
-            p.lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .mode()
-                .to_string()
-        })
     }
 
     async fn handle_user_event(&mut self, ev: UserEvent) -> anyhow::Result<ControlFlow<(), ()>> {
@@ -675,7 +548,7 @@ impl<'a> App<'a> {
                         }
                         self.btw_inflight = 0;
                         self.renderer.write_line("btw cancelled", C_ERROR)?;
-                    } else if self.is_running {
+                    } else if self.run.is_running {
                         self.abort_main_run()?;
                     } else {
                         return Ok(ControlFlow::Break(()));
@@ -716,11 +589,15 @@ impl<'a> App<'a> {
         let ctrl_r =
             key.code == KeyCode::Char('r') && key.modifiers.contains(KeyModifiers::CONTROL);
         if ctrl_r {
-            self.show_reasoning = !self.show_reasoning;
+            self.slash.show_reasoning = !self.slash.show_reasoning;
             self.renderer.write_line(
                 &format!(
                     "reasoning visibility: {}",
-                    if self.show_reasoning { "on" } else { "off" }
+                    if self.slash.show_reasoning {
+                        "on"
+                    } else {
+                        "off"
+                    }
                 ),
                 Color::White,
             )?;
@@ -752,23 +629,24 @@ impl<'a> App<'a> {
         {
             if let Some(RewindOutcome::Confirmed(idx)) = self.input.take_rewind_outcome() {
                 let text = self
+                    .ui
                     .session
                     .messages
                     .get(idx)
                     .map(|m| m.content.to_string());
-                if self.session.rewind_to(idx) > 0 {
+                if self.ui.session.rewind_to(idx) > 0 {
                     if let Some(text) = text {
                         self.input.load_text(&text);
                     }
-                    if !self.cli.no_session {
-                        let _ = crate::session::storage::save_session(self.session);
+                    if !self.ui.cli.no_session {
+                        let _ = crate::session::storage::save_session(self.ui.session);
                     }
                     render_session(
                         &mut self.renderer,
-                        self.session,
-                        self.cli,
-                        self.cfg,
-                        self.context,
+                        self.ui.session,
+                        self.ui.cli,
+                        self.ui.cfg,
+                        self.ui.context,
                     )?;
                     self.renderer
                         .write_line("rewound; /redo to restore", Color::Green)?;
@@ -793,22 +671,22 @@ impl<'a> App<'a> {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     self.renderer.chain_prompt = None;
-                    if let Some(phase) = self.chain_pending.take() {
-                        self.chain_label_msg = None;
+                    if let Some(phase) = self.chain.pending.take() {
+                        self.chain.label_msg = None;
                         self.run_chain_transition(phase, None).await?;
                     }
                     return Ok(());
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') => {
                     self.renderer.chain_prompt = None;
-                    self.chain_pending = None;
-                    self.chain_label_msg = None;
+                    self.chain.pending = None;
+                    self.chain.label_msg = None;
                     self.renderer
                         .write_line("chain declined — won't ask again this session", C_AGENT)?;
-                    if let Some(ref name) = self.context.current_prompt_name
-                        && !self.context.chain_declined.contains(name)
+                    if let Some(ref name) = self.ui.context.current_prompt_name
+                        && !self.ui.context.chain_declined.contains(name)
                     {
-                        self.context.chain_declined.push(name.clone());
+                        self.ui.context.chain_declined.push(name.clone());
                     }
                     return Ok(());
                 }
@@ -816,7 +694,7 @@ impl<'a> App<'a> {
                     self.renderer.chain_but_mode = true;
                     self.renderer.chain_prompt = None;
                     self.input.clear_buffer();
-                    self.chain_label_msg = self.chain_pending.map(|p| p.chain_label().to_string());
+                    self.chain.label_msg = self.chain.pending.map(|p| p.chain_label().to_string());
                     return Ok(());
                 }
                 _ => {
@@ -828,11 +706,11 @@ impl<'a> App<'a> {
         // Chain but mode: Esc cancels back to ask
         if self.renderer.chain_but_mode && key.code == KeyCode::Esc {
             self.renderer.chain_but_mode = false;
-            if let Some(phase) = self.chain_pending {
+            if let Some(phase) = self.chain.pending {
                 self.renderer.chain_prompt = Some(ChainPrompt {
                     question: compact_str::CompactString::from(phase.chain_label()),
                 });
-                self.chain_label_msg = Some(phase.chain_label().to_string());
+                self.chain.label_msg = Some(phase.chain_label().to_string());
             }
             self.input.clear_buffer();
             return Ok(());
@@ -840,7 +718,8 @@ impl<'a> App<'a> {
 
         if let Some(mut text) = self.input.handle_key(key) {
             #[cfg(feature = "loop")]
-            if self.loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
+            if self.chain.loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/')
+            {
                 self.renderer
                     .write_line("loop active: /loop stop to cancel", C_ERROR)?;
                 return Ok(());
@@ -850,15 +729,15 @@ impl<'a> App<'a> {
             }
 
             // Chain-of-prompts: handle text submission after B (but) mode
-            if !self.is_running
-                && let Some(phase) = self.chain_pending.take()
+            if !self.run.is_running
+                && let Some(phase) = self.chain.pending.take()
             {
-                self.chain_label_msg = None;
+                self.chain.label_msg = None;
                 self.renderer.chain_but_mode = false;
                 let trimmed = text.trim().to_string();
                 if trimmed.is_empty() {
-                    self.chain_pending = Some(phase);
-                    self.chain_label_msg = Some(phase.chain_label().to_string());
+                    self.chain.pending = Some(phase);
+                    self.chain.label_msg = Some(phase.chain_label().to_string());
                     self.renderer.chain_prompt = Some(ChainPrompt {
                         question: compact_str::CompactString::from(phase.chain_label()),
                     });
@@ -868,7 +747,7 @@ impl<'a> App<'a> {
                 return Ok(());
             }
 
-            match classify_submission(self.is_running, &text) {
+            match classify_submission(self.run.is_running, &text) {
                 super::SubmitAction::Run => {}
                 super::SubmitAction::Ignore => {
                     return Ok(());
@@ -881,7 +760,7 @@ impl<'a> App<'a> {
                     return Ok(());
                 }
                 super::SubmitAction::Queue => {
-                    self.pending_inputs.push_back(text.to_string());
+                    self.run.pending_inputs.push_back(text.to_string());
                     self.renderer
                         .write_line(&format!("queued: {}", sanitize_output(&text)), C_TOOL)?;
                     return Ok(());
@@ -930,8 +809,9 @@ impl<'a> App<'a> {
     async fn handle_agent_event(&mut self, event: AgentEvent) -> anyhow::Result<()> {
         match &event {
             AgentEvent::ToolCall { name, args } => {
-                if self.turn_trace.len() < TURN_TRACE_MAX {
-                    self.turn_trace
+                if self.run.turn_trace.len() < TURN_TRACE_MAX {
+                    self.run
+                        .turn_trace
                         .push(compact_str::CompactString::from(format!(
                             "→ {}",
                             crate::ui::utils::format_tool_call_summary(name, args)
@@ -939,8 +819,9 @@ impl<'a> App<'a> {
                 }
             }
             AgentEvent::ToolResult { output, .. } => {
-                if self.turn_trace.len() < TURN_TRACE_MAX {
-                    self.turn_trace
+                if self.run.turn_trace.len() < TURN_TRACE_MAX {
+                    self.run
+                        .turn_trace
                         .push(compact_str::CompactString::from(format!(
                             "← {}",
                             crate::extras::truncate::truncate_cjk(output, 500, "…")
@@ -948,14 +829,14 @@ impl<'a> App<'a> {
                 }
             }
             AgentEvent::Done { .. } | AgentEvent::Error(_) => {
-                self.turn_trace.clear();
-                self.awaiting_compaction_relief = false;
+                self.run.turn_trace.clear();
+                self.run.awaiting_compaction_relief = false;
             }
             _ => {}
         }
 
         #[cfg(feature = "loop")]
-        let loop_running = self.loop_state.as_ref().is_some_and(|ls| ls.active);
+        let loop_running = self.chain.loop_state.as_ref().is_some_and(|ls| ls.active);
         #[cfg(not(feature = "loop"))]
         let loop_running = false;
 
@@ -965,65 +846,43 @@ impl<'a> App<'a> {
             cache_creation_input_tokens,
             ..
         } = &event
-            && self.is_running
+            && self.run.is_running
             && !loop_running
-            && !self.cli.no_session
-            && self.cfg.resolve_compact_enabled()
-            && self.session.context_window > 0
-            && let Some(threshold) = self.cfg.resolve_mid_turn_compact_threshold()
+            && !self.ui.cli.no_session
+            && self.ui.cfg.resolve_compact_enabled()
+            && self.ui.session.context_window > 0
+            && let Some(threshold) = self.ui.cfg.resolve_mid_turn_compact_threshold()
         {
             let real_input_tokens = crate::session::Session::real_input_tokens(
-                self.cfg.is_anthropic_native(&self.session.provider),
+                self.ui.cfg.is_anthropic_native(&self.ui.session.provider),
                 *input_tokens,
                 *cached_input_tokens,
                 *cache_creation_input_tokens,
             );
-            let pressure = real_input_tokens as f64 / self.session.context_window as f64;
+            let pressure = real_input_tokens as f64 / self.ui.session.context_window as f64;
             if pressure > threshold {
-                if self.awaiting_compaction_relief {
+                if self.run.awaiting_compaction_relief {
                     self.stop_context_exhausted(real_input_tokens, threshold)?;
-                    self.awaiting_compaction_relief = false;
+                    self.run.awaiting_compaction_relief = false;
                 } else {
                     self.mid_turn_compact(pressure).await?;
-                    self.awaiting_compaction_relief = true;
+                    self.run.awaiting_compaction_relief = true;
                 }
                 self.refresh()?;
                 return Ok(());
             } else {
-                self.awaiting_compaction_relief = false;
+                self.run.awaiting_compaction_relief = false;
             }
         }
 
-        #[cfg(feature = "mcp")]
-        let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
         let turn_errored = matches!(&event, AgentEvent::Error(_));
         event_handler::handle_agent_event(
             event,
             &mut self.renderer,
-            self.session,
-            self.cfg,
-            self.cli,
-            self.context,
-            &mut self.is_running,
-            &mut self.agent_rx,
-            &mut self.agent_line_started,
-            &mut self.response_buf,
-            &mut self.response_start_block,
-            &mut self.was_reasoning,
-            self.show_reasoning,
-            &mut self.agent,
-            &mut self.client,
-            &mut self.loop_label,
-            &self.permission,
-            &self.ask_tx,
-            &self.sandbox,
-            &self.status_signals,
-            #[cfg(feature = "loop")]
-            &mut self.loop_state,
-            #[cfg(feature = "git-worktree")]
-            &mut self.wt_return_path,
-            #[cfg(feature = "mcp")]
-            mcp_ref,
+            &mut self.run,
+            &mut self.ui,
+            &self.slash,
+            &mut self.chain,
         )
         .await?;
 
@@ -1033,56 +892,56 @@ impl<'a> App<'a> {
 
     async fn finalize_turn(&mut self, turn_errored: bool) -> anyhow::Result<()> {
         if turn_errored {
-            if let Some(text) = self.pending_send.take() {
-                let len = self.session.messages.len();
-                if len > 0 && self.session.messages[len - 1].role == MessageRole::User {
-                    self.session.truncate_to(len - 1);
+            if let Some(text) = self.run.pending_send.take() {
+                let len = self.ui.session.messages.len();
+                if len > 0 && self.ui.session.messages[len - 1].role == MessageRole::User {
+                    self.ui.session.truncate_to(len - 1);
                 }
                 self.input.buffer = text.into();
                 self.input.cursor = self.input.buffer.len();
             }
-        } else if !self.is_running {
-            self.pending_send = None;
+        } else if !self.run.is_running {
+            self.run.pending_send = None;
         }
 
-        if !self.is_running
-            && let Some(restore_name) = self.dot_prompt_restore.take()
+        if !self.run.is_running
+            && let Some(restore_name) = self.chain.dot_prompt_restore.take()
         {
-            self.context.current_prompt = self.context.prompts.get(&restore_name).cloned();
-            self.context.current_prompt_name = if self.context.current_prompt.is_some() {
+            self.ui.context.current_prompt = self.ui.context.prompts.get(&restore_name).cloned();
+            self.ui.context.current_prompt_name = if self.ui.context.current_prompt.is_some() {
                 Some(restore_name)
             } else {
                 None
             };
-            if let Some(perm) = &self.permission {
+            if let Some(perm) = &self.ui.permission {
                 let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                 guard.restore_user_mode();
             }
         }
 
-        if !self.is_running
-            && self.chain_pending.is_none()
-            && let Some(ref name) = self.context.current_prompt_name
-            && !self.context.chain_declined.contains(name)
+        if !self.run.is_running
+            && self.chain.pending.is_none()
+            && let Some(ref name) = self.ui.context.current_prompt_name
+            && !self.ui.context.chain_declined.contains(name)
             && let Some(phase) = crate::extras::chain::ChainPhase::from_prompt_name(name)
-            && let Some(ref chain_cfg) = self.cfg.chain
+            && let Some(ref chain_cfg) = self.ui.cfg.chain
             && phase.is_enabled(chain_cfg)
         {
-            self.chain_pending = Some(phase);
-            self.chain_label_msg = Some(phase.chain_label().to_string());
+            self.chain.pending = Some(phase);
+            self.chain.label_msg = Some(phase.chain_label().to_string());
             self.renderer.chain_but_mode = false;
             self.renderer.chain_prompt = Some(ChainPrompt {
                 question: compact_str::CompactString::from(phase.chain_label()),
             });
         }
 
-        if !self.is_running {
-            self.main_abort = None;
-            if let Some(next) = self.pending_inputs.pop_front() {
+        if !self.run.is_running {
+            self.run.main_abort = None;
+            if let Some(next) = self.run.pending_inputs.pop_front() {
                 self.renderer.chain_prompt = None;
                 self.renderer.chain_but_mode = false;
-                self.chain_pending = None;
-                self.chain_label_msg = None;
+                self.chain.pending = None;
+                self.chain.label_msg = None;
                 for line in next.lines() {
                     self.renderer
                         .write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
@@ -1096,34 +955,34 @@ impl<'a> App<'a> {
     }
 
     fn abort_main_run(&mut self) -> anyhow::Result<()> {
-        if let Some(h) = self.main_abort.take() {
+        if let Some(h) = self.run.main_abort.take() {
             h.abort();
         }
-        self.sandbox.kill_active();
-        self.is_running = false;
-        if let Some(ss) = self.status_signals.as_ref() {
+        self.ui.sandbox.kill_active();
+        self.run.is_running = false;
+        if let Some(ss) = self.ui.status_signals.as_ref() {
             ss.send_stop();
         }
-        self.agent_rx = None;
-        self.turn_trace.clear();
-        self.awaiting_compaction_relief = false;
-        self.pending_inputs.clear();
+        self.run.agent_rx = None;
+        self.run.turn_trace.clear();
+        self.run.awaiting_compaction_relief = false;
+        self.run.pending_inputs.clear();
         #[cfg(feature = "loop")]
-        if let Some(ref mut ls) = self.loop_state {
+        if let Some(ref mut ls) = self.chain.loop_state {
             ls.active = false;
-            self.loop_label = None;
+            self.chain.loop_label = None;
         }
         if !self.input.buffer.is_empty() {
             self.input.clear_buffer();
         }
-        if let Some(restore_name) = self.dot_prompt_restore.take() {
-            self.context.current_prompt = self.context.prompts.get(&restore_name).cloned();
-            self.context.current_prompt_name = if self.context.current_prompt.is_some() {
+        if let Some(restore_name) = self.chain.dot_prompt_restore.take() {
+            self.ui.context.current_prompt = self.ui.context.prompts.get(&restore_name).cloned();
+            self.ui.context.current_prompt_name = if self.ui.context.current_prompt.is_some() {
                 Some(restore_name)
             } else {
                 None
             };
-            if let Some(perm) = &self.permission {
+            if let Some(perm) = &self.ui.permission {
                 let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                 guard.restore_user_mode();
             }
@@ -1138,44 +997,19 @@ impl<'a> App<'a> {
     async fn start_main_run(&mut self, text: &str) {
         start_main_run(
             text,
-            &mut self.agent,
-            &self.client,
-            self.session,
-            self.cli,
-            self.cfg,
-            self.context,
-            &self.permission,
-            &self.ask_tx,
-            &self.sandbox,
-            self.reasoning_enabled,
-            &mut self.agent_rx,
-            &mut self.main_abort,
-            &mut self.is_running,
-            &self.status_signals,
-            #[cfg(feature = "mcp")]
-            &mut self.mcp_manager,
+            &mut self.run,
+            &mut self.ui,
+            &self.slash,
             &mut self.prebuild_rx,
-            &mut self.pending_send,
         )
         .await;
     }
 
     async fn ensure_agent(&mut self) {
-        #[cfg(feature = "mcp")]
-        let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
         event_handler::ensure_agent(
-            &mut self.agent,
-            &self.client,
-            self.session,
-            self.cli,
-            self.cfg,
-            self.context,
-            &self.permission,
-            &self.ask_tx,
-            &self.sandbox,
-            self.reasoning_enabled,
-            #[cfg(feature = "mcp")]
-            mcp_ref,
+            &mut self.run.agent,
+            &mut self.ui,
+            self.slash.reasoning_enabled,
         )
         .await;
     }
@@ -1186,47 +1020,36 @@ impl<'a> App<'a> {
         extra: Option<&str>,
     ) -> anyhow::Result<()> {
         let next_name = phase.next_prompt_name();
-        if let Some(content) = self.context.prompts.get(next_name).cloned() {
+        if let Some(content) = self.ui.context.prompts.get(next_name).cloned() {
             let (mode_directive_str, clean_content) =
                 crate::permission::parse_prompt_mode(&content);
             let mode_directive = mode_directive_str.map(|s| s.to_string());
-            self.context.current_prompt = Some(if mode_directive.is_some() {
+            self.ui.context.current_prompt = Some(if mode_directive.is_some() {
                 clean_content.to_string()
             } else {
                 content
             });
-            self.context.current_prompt_name = Some(next_name.to_string());
+            self.ui.context.current_prompt_name = Some(next_name.to_string());
             if let Some(ref mode_str) = mode_directive {
                 if mode_str == "last_user_mode"
-                    && let Some(perm) = &self.permission
+                    && let Some(perm) = &self.ui.permission
                 {
                     let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                     guard.restore_user_mode();
                 } else if let Some(mode) = crate::permission::SecurityMode::from_str(mode_str)
-                    && let Some(perm) = &self.permission
+                    && let Some(perm) = &self.ui.permission
                 {
                     let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                     guard.set_prompt_mode(mode);
                 }
             }
         }
-        #[cfg(feature = "mcp")]
-        let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
         apply_prompt_model(
             next_name,
-            self.cfg,
-            self.cli,
-            &mut self.client,
-            self.session,
-            &mut self.agent,
-            self.context,
-            &self.permission,
-            &self.ask_tx,
-            &self.sandbox,
-            self.reasoning_enabled,
+            &mut self.ui,
+            &mut self.run.agent,
+            self.slash.reasoning_enabled,
             &mut self.renderer,
-            #[cfg(feature = "mcp")]
-            mcp_ref,
         )
         .await;
         let base_msg = phase.transition_message().to_string();
@@ -1240,8 +1063,8 @@ impl<'a> App<'a> {
                 .write_line(&format!("> {}", sanitize_output(line)), Color::Green)?;
         }
         self.renderer.write_line("", Color::White)?;
-        self.session.add_message(MessageRole::User, &msg);
-        self.agent = None;
+        self.ui.session.add_message(MessageRole::User, &msg);
+        self.run.agent = None;
         self.start_main_run(&msg).await;
         Ok(())
     }
@@ -1272,33 +1095,22 @@ impl<'a> App<'a> {
         if let Some((prompt_name, msg)) = after_dot.split_once(char::is_whitespace) {
             let prompt_name = prompt_name.trim();
             let msg = msg.trim();
-            if !prompt_name.is_empty() && self.context.prompts.contains_key(prompt_name) {
-                self.dot_prompt_restore = self.context.current_prompt_name.clone();
-                if let Some(content) = self.context.prompts.get(prompt_name).cloned() {
+            if !prompt_name.is_empty() && self.ui.context.prompts.contains_key(prompt_name) {
+                self.chain.dot_prompt_restore = self.ui.context.current_prompt_name.clone();
+                if let Some(content) = self.ui.context.prompts.get(prompt_name).cloned() {
                     self.apply_prompt_from_content(&content, prompt_name)
                         .await?;
                 }
-                #[cfg(feature = "mcp")]
-                let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
                 apply_prompt_model(
                     prompt_name,
-                    self.cfg,
-                    self.cli,
-                    &mut self.client,
-                    self.session,
-                    &mut self.agent,
-                    self.context,
-                    &self.permission,
-                    &self.ask_tx,
-                    &self.sandbox,
-                    self.reasoning_enabled,
+                    &mut self.ui,
+                    &mut self.run.agent,
+                    self.slash.reasoning_enabled,
                     &mut self.renderer,
-                    #[cfg(feature = "mcp")]
-                    mcp_ref,
                 )
                 .await;
                 *text = msg.to_string().into();
-                self.agent = None;
+                self.run.agent = None;
                 return Ok(false);
             } else {
                 self.renderer
@@ -1308,31 +1120,20 @@ impl<'a> App<'a> {
         }
 
         let prompt_name = after_dot.trim();
-        if self.context.prompts.contains_key(prompt_name) {
-            if let Some(content) = self.context.prompts.get(prompt_name).cloned() {
+        if self.ui.context.prompts.contains_key(prompt_name) {
+            if let Some(content) = self.ui.context.prompts.get(prompt_name).cloned() {
                 self.apply_prompt_from_content(&content, prompt_name)
                     .await?;
             }
-            #[cfg(feature = "mcp")]
-            let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
             apply_prompt_model(
                 prompt_name,
-                self.cfg,
-                self.cli,
-                &mut self.client,
-                self.session,
-                &mut self.agent,
-                self.context,
-                &self.permission,
-                &self.ask_tx,
-                &self.sandbox,
-                self.reasoning_enabled,
+                &mut self.ui,
+                &mut self.run.agent,
+                self.slash.reasoning_enabled,
                 &mut self.renderer,
-                #[cfg(feature = "mcp")]
-                mcp_ref,
             )
             .await;
-            self.agent = None;
+            self.run.agent = None;
             self.renderer
                 .write_line(&format!("switched to prompt '{}'", prompt_name), C_AGENT)?;
             self.save_session()?;
@@ -1351,14 +1152,14 @@ impl<'a> App<'a> {
     ) -> anyhow::Result<()> {
         let (mode_directive_str, clean_content) = crate::permission::parse_prompt_mode(content);
         let mode_directive = mode_directive_str.map(|s| s.to_string());
-        self.context.current_prompt = Some(if mode_directive.is_some() {
+        self.ui.context.current_prompt = Some(if mode_directive.is_some() {
             clean_content.to_string()
         } else {
             content.to_string()
         });
-        self.context.current_prompt_name = Some(prompt_name.to_string());
+        self.ui.context.current_prompt_name = Some(prompt_name.to_string());
         if let Some(ref mode_str) = mode_directive
-            && let Some(perm) = &self.permission
+            && let Some(perm) = &self.ui.permission
         {
             let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
             if mode_str == "last_user_mode" {
@@ -1373,24 +1174,26 @@ impl<'a> App<'a> {
     fn run_queue_command(&mut self, arg: &str) -> anyhow::Result<()> {
         match arg {
             "clear" => {
-                let n = self.pending_inputs.len();
-                self.pending_inputs.clear();
+                let n = self.run.pending_inputs.len();
+                self.run.pending_inputs.clear();
                 self.renderer
                     .write_line(&format!("queue cleared ({} removed)", n), C_TOOL)?;
             }
-            "pop" => match self.pending_inputs.pop_back() {
+            "pop" => match self.run.pending_inputs.pop_back() {
                 Some(x) => self
                     .renderer
                     .write_line(&format!("unqueued: {}", sanitize_output(&x)), C_TOOL)?,
                 None => self.renderer.write_line("queue is empty", C_TOOL)?,
             },
             "" | "ls" | "list" => {
-                if self.pending_inputs.is_empty() {
+                if self.run.pending_inputs.is_empty() {
                     self.renderer.write_line("queue is empty", C_TOOL)?;
                 } else {
-                    self.renderer
-                        .write_line(&format!("queued ({}):", self.pending_inputs.len()), C_TOOL)?;
-                    for (i, q) in self.pending_inputs.iter().enumerate() {
+                    self.renderer.write_line(
+                        &format!("queued ({}):", self.run.pending_inputs.len()),
+                        C_TOOL,
+                    )?;
+                    for (i, q) in self.run.pending_inputs.iter().enumerate() {
                         self.renderer
                             .write_line(&format!("  {}. {}", i + 1, sanitize_output(q)), C_TOOL)?;
                     }
@@ -1421,22 +1224,25 @@ impl<'a> App<'a> {
         let id = self.btw_next_id;
         self.btw_next_id = self.btw_next_id.wrapping_add(1);
         let snapshot = crate::agent::runner::build_btw_snapshot(
-            self.session,
-            &self.turn_trace,
-            self.is_running,
+            self.ui.session,
+            &self.run.turn_trace,
+            self.run.is_running,
         );
-        let model = self.client.completion_model(self.session.model.to_string());
+        let model = self
+            .ui
+            .client
+            .completion_model(self.ui.session.model.to_string());
         let temperature =
-            crate::config::resolve_temperature(self.cli, self.cfg, &self.session.model);
-        let extra_body = crate::config::resolve_extra_body(self.cfg, &self.session.model);
+            crate::config::resolve_temperature(self.ui.cli, self.ui.cfg, &self.ui.session.model);
+        let extra_body = crate::config::resolve_extra_body(self.ui.cfg, &self.ui.session.model);
         let btw_agent = crate::provider::build_btw_agent(
             model,
-            self.cli,
-            self.cfg,
-            self.context,
-            &self.permission,
-            &self.ask_tx,
-            self.reasoning_enabled,
+            self.ui.cli,
+            self.ui.cfg,
+            self.ui.context,
+            &self.ui.permission,
+            &self.ui.ask_tx,
+            self.slash.reasoning_enabled,
             temperature,
             extra_body,
         );
@@ -1445,7 +1251,7 @@ impl<'a> App<'a> {
             snapshot,
             self.btw_tx.clone(),
             id,
-            self.cfg.retry.clone(),
+            self.ui.cfg.retry.clone(),
         );
         self.btw_abort.push((id, runner.abort_handle));
         self.btw_inflight += 1;
@@ -1462,41 +1268,26 @@ impl<'a> App<'a> {
         }
         self.renderer.write_line("", Color::White)?;
 
-        #[cfg(feature = "mcp")]
-        let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
         let result = handle_slash(
             text,
-            &mut self.agent,
-            &mut self.client,
             &mut self.renderer,
-            self.session,
-            self.cli,
-            self.cfg,
-            self.context,
-            &mut self.show_reasoning,
-            &mut self.reasoning_enabled,
-            &mut self.is_running,
             &mut self.input,
-            &self.permission,
-            &self.ask_tx,
-            &mut self.todo_tools_enabled,
-            &self.sandbox,
-            #[cfg(feature = "loop")]
-            &mut self.loop_state,
-            #[cfg(feature = "mcp")]
-            mcp_ref,
+            &mut self.run,
+            &mut self.ui,
+            &mut self.slash,
+            &mut self.chain,
         )
         .await;
 
         {
-            let provider = self.session.provider.to_string();
-            let is_custom = self.cfg.custom_providers_map().contains_key(&provider);
+            let provider = self.ui.session.provider.to_string();
+            let is_custom = self.ui.cfg.custom_providers_map().contains_key(&provider);
             let ids = crate::ui::slash::warm_model_cache(
                 &provider,
                 is_custom,
-                &self.client,
-                self.cli,
-                self.cfg,
+                &self.ui.client,
+                self.ui.cli,
+                self.ui.cfg,
             )
             .await;
             self.input.set_live_model_names(ids);
@@ -1519,31 +1310,20 @@ impl<'a> App<'a> {
                         Some(s.to_string())
                     }
                 });
-                #[cfg(feature = "mcp")]
-                let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
                 let compress_result = handle_compress(
                     instructions.as_deref(),
                     false,
-                    &mut self.agent,
-                    &mut self.client,
+                    &mut self.run.agent,
                     &mut self.renderer,
-                    self.session,
-                    self.cli,
-                    self.cfg,
-                    self.context,
-                    self.reasoning_enabled,
-                    &self.permission,
-                    &self.ask_tx,
-                    &self.sandbox,
-                    #[cfg(feature = "mcp")]
-                    mcp_ref,
+                    &mut self.ui,
+                    self.slash.reasoning_enabled,
                 )
                 .await;
                 if let Err(e) = compress_result {
                     self.renderer
                         .write_line(&format!("compress error: {}", e), C_ERROR)?;
                 }
-                let _ = crate::session::storage::save_session(self.session);
+                let _ = crate::session::storage::save_session(self.ui.session);
             }
             #[cfg(feature = "mcp")]
             Err(e)
@@ -1557,6 +1337,7 @@ impl<'a> App<'a> {
                     .trim()
                     .to_string();
                 let resolved = self
+                    .ui
                     .cfg
                     .mcp_servers
                     .as_ref()
@@ -1646,59 +1427,51 @@ impl<'a> App<'a> {
                         main_path,
                         wt_path,
                     } => {
-                        let force_flag = self.cli.resolve_wt_force(self.cfg);
+                        let force_flag = self.ui.cli.resolve_wt_force(self.ui.cfg);
                         spawn_merge_agent(
-                            branch,
-                            target,
-                            main_path,
-                            wt_path,
-                            force_flag,
-                            self.session,
-                            &mut self.agent,
-                            &self.client,
-                            self.cli,
-                            self.cfg,
-                            self.context,
-                            &self.permission,
-                            &self.ask_tx,
-                            &self.sandbox,
-                            self.reasoning_enabled,
-                            &mut self.agent_rx,
-                            &mut self.main_abort,
-                            &mut self.is_running,
-                            &self.status_signals,
-                            &mut self.wt_return_path,
-                            #[cfg(feature = "mcp")]
-                            &mut self.mcp_manager,
+                            MergeRequest {
+                                branch,
+                                target,
+                                main_path,
+                                wt_path,
+                                force: force_flag,
+                            },
+                            &mut self.run,
+                            &mut self.ui,
+                            &mut self.chain,
                         )
                         .await;
                     }
                     crate::extras::git_worktree::DeferredWorktreeAction::Exit { main_path } => {
                         std::env::set_current_dir(main_path)
                             .map_err(|e| anyhow::anyhow!("failed to change directory: {}", e))?;
-                        self.session.working_dir = compact_str::CompactString::new(main_path);
-                        self.context.reload();
-                        apply_current_prompt_mode(self.context, &self.permission);
+                        self.ui.session.working_dir = compact_str::CompactString::new(main_path);
+                        self.ui.context.reload();
+                        apply_current_prompt_mode(self.ui.context, &self.ui.permission);
                         #[cfg(feature = "mcp")]
-                        let mcp_ref = ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
-                        let model = self.client.completion_model(self.session.model.to_string());
+                        let mcp_ref =
+                            ensure_mcp_manager(&mut self.ui.mcp_manager, self.ui.cfg).await;
+                        let model = self
+                            .ui
+                            .client
+                            .completion_model(self.ui.session.model.to_string());
                         let temperature = crate::config::resolve_temperature(
-                            self.cli,
-                            self.cfg,
-                            &self.session.model,
+                            self.ui.cli,
+                            self.ui.cfg,
+                            &self.ui.session.model,
                         );
                         let extra_body =
-                            crate::config::resolve_extra_body(self.cfg, &self.session.model);
-                        self.agent = Some(
+                            crate::config::resolve_extra_body(self.ui.cfg, &self.ui.session.model);
+                        self.run.agent = Some(
                             crate::provider::build_agent(
                                 model,
-                                self.cli,
-                                self.cfg,
-                                self.context,
-                                self.permission.clone(),
-                                self.ask_tx.clone(),
-                                self.sandbox.clone(),
-                                self.reasoning_enabled,
+                                self.ui.cli,
+                                self.ui.cfg,
+                                self.ui.context,
+                                self.ui.permission.clone(),
+                                self.ui.ask_tx.clone(),
+                                self.ui.sandbox.clone(),
+                                self.slash.reasoning_enabled,
                                 temperature,
                                 extra_body,
                                 #[cfg(feature = "mcp")]
@@ -1708,10 +1481,10 @@ impl<'a> App<'a> {
                         );
                         render_session(
                             &mut self.renderer,
-                            self.session,
-                            self.cli,
-                            self.cfg,
-                            self.context,
+                            self.ui.session,
+                            self.ui.cli,
+                            self.ui.cfg,
+                            self.ui.context,
                         )?;
                         self.renderer.write_line(
                             &format!("returned to main repo at {}", main_path),
@@ -1727,8 +1500,9 @@ impl<'a> App<'a> {
                     .unwrap_or("")
                     .to_string();
                 self.ensure_agent().await;
-                let history = crate::agent::runner::convert_history(self.session);
+                let history = crate::agent::runner::convert_history(self.ui.session);
                 let runner = self
+                    .run
                     .agent
                     .as_ref()
                     .unwrap()
@@ -1736,15 +1510,15 @@ impl<'a> App<'a> {
                     .spawn_runner(
                         prompt,
                         history,
-                        self.cfg.retry.clone(),
+                        self.ui.cfg.retry.clone(),
                         #[cfg(feature = "hooks")]
                         None,
                     )
                     .await;
-                self.agent_rx = Some(runner.event_rx);
-                self.main_abort = Some(runner.abort_handle);
-                self.is_running = true;
-                if let Some(ss) = self.status_signals.as_ref() {
+                self.run.agent_rx = Some(runner.event_rx);
+                self.run.main_abort = Some(runner.abort_handle);
+                self.run.is_running = true;
+                if let Some(ss) = self.ui.status_signals.as_ref() {
                     ss.send_start();
                 }
             }
@@ -1754,11 +1528,12 @@ impl<'a> App<'a> {
                     .strip_prefix("DEFER_REVIEW:")
                     .unwrap_or("")
                     .to_string();
-                self.dot_prompt_restore = self.context.one_shot_restore.take();
-                self.session.add_message(MessageRole::User, &msg);
+                self.chain.dot_prompt_restore = self.ui.context.one_shot_restore.take();
+                self.ui.session.add_message(MessageRole::User, &msg);
                 self.ensure_agent().await;
-                let history = crate::agent::runner::convert_history(self.session);
+                let history = crate::agent::runner::convert_history(self.ui.session);
                 let runner = self
+                    .run
                     .agent
                     .as_ref()
                     .unwrap()
@@ -1766,15 +1541,15 @@ impl<'a> App<'a> {
                     .spawn_runner(
                         msg,
                         history,
-                        self.cfg.retry.clone(),
+                        self.ui.cfg.retry.clone(),
                         #[cfg(feature = "hooks")]
                         None,
                     )
                     .await;
-                self.agent_rx = Some(runner.event_rx);
-                self.main_abort = Some(runner.abort_handle);
-                self.is_running = true;
-                if let Some(ss) = self.status_signals.as_ref() {
+                self.run.agent_rx = Some(runner.event_rx);
+                self.run.main_abort = Some(runner.abort_handle);
+                self.run.is_running = true;
+                if let Some(ss) = self.ui.status_signals.as_ref() {
                     ss.send_start();
                 }
             }
@@ -1785,6 +1560,7 @@ impl<'a> App<'a> {
                     .unwrap_or("")
                     .to_string();
                 let editor = self
+                    .ui
                     .cfg
                     .editor
                     .clone()
@@ -1809,10 +1585,10 @@ impl<'a> App<'a> {
                 let _ = crossterm::terminal::enable_raw_mode();
                 render_session(
                     &mut self.renderer,
-                    self.session,
-                    self.cli,
-                    self.cfg,
-                    self.context,
+                    self.ui.session,
+                    self.ui.cli,
+                    self.ui.cfg,
+                    self.ui.context,
                 )?;
                 self.renderer
                     .write_line(&format!("returned from editing {}", path), C_AGENT)?;
@@ -1831,18 +1607,20 @@ impl<'a> App<'a> {
                 self.save_session()?;
                 #[cfg(feature = "loop")]
                 if self
+                    .chain
                     .loop_state
                     .as_ref()
-                    .is_some_and(|ls| ls.active && ls.iteration == 0 && !self.is_running)
+                    .is_some_and(|ls| ls.active && ls.iteration == 0 && !self.run.is_running)
                 {
                     #[allow(unused_variables)]
                     let (prompt, label, active) = {
-                        let ls = self.loop_state.as_mut().unwrap();
+                        let ls = self.chain.loop_state.as_mut().unwrap();
                         ls.iteration = 1;
                         (ls.build_prompt(), ls.iteration_label(), ls.active)
                     };
                     self.ensure_agent().await;
                     let runner = self
+                        .run
                         .agent
                         .as_ref()
                         .unwrap()
@@ -1850,7 +1628,7 @@ impl<'a> App<'a> {
                         .spawn_runner(
                             prompt,
                             Vec::new(),
-                            self.cfg.retry.clone(),
+                            self.ui.cfg.retry.clone(),
                             #[cfg(feature = "hooks")]
                             Some(crate::extras::hooks::LoopInfo {
                                 iteration: 1,
@@ -1858,10 +1636,10 @@ impl<'a> App<'a> {
                             }),
                         )
                         .await;
-                    self.agent_rx = Some(runner.event_rx);
-                    self.main_abort = Some(runner.abort_handle);
-                    self.is_running = true;
-                    self.loop_label = Some(label);
+                    self.run.agent_rx = Some(runner.event_rx);
+                    self.run.main_abort = Some(runner.abort_handle);
+                    self.run.is_running = true;
+                    self.chain.loop_label = Some(label);
                 }
             }
         }
@@ -1918,13 +1696,13 @@ impl<'a> App<'a> {
         }
         self.renderer.write_line("", Color::White)?;
 
-        self.session.add_message(MessageRole::User, text);
-        self.session.add_message(MessageRole::Assistant, &result);
-        if !self.cli.no_session {
+        self.ui.session.add_message(MessageRole::User, text);
+        self.ui.session.add_message(MessageRole::Assistant, &result);
+        if !self.ui.cli.no_session {
             let _ = crate::session::chat_history::append_entry(
                 &crate::session::chat_history::ChatHistoryEntry {
                     content: text.to_string(),
-                    timestamp: self.session.updated_at.clone(),
+                    timestamp: self.ui.session.updated_at.clone(),
                 },
             );
         }
@@ -1935,27 +1713,9 @@ impl<'a> App<'a> {
         mid_turn_compact_and_respawn(
             pressure,
             &mut self.renderer,
-            &mut self.agent,
-            &mut self.client,
-            self.session,
-            self.cli,
-            self.cfg,
-            self.context,
-            &self.permission,
-            &self.ask_tx,
-            &self.sandbox,
-            self.reasoning_enabled,
-            &mut self.agent_rx,
-            &mut self.main_abort,
-            &mut self.is_running,
-            &self.status_signals,
-            &mut self.turn_trace,
-            &mut self.response_buf,
-            &mut self.response_start_block,
-            &mut self.agent_line_started,
-            &mut self.was_reasoning,
-            #[cfg(feature = "mcp")]
-            &mut self.mcp_manager,
+            &mut self.run,
+            &mut self.ui,
+            &self.slash,
         )
         .await
     }
@@ -1965,17 +1725,8 @@ impl<'a> App<'a> {
             prompt_tokens,
             threshold,
             &mut self.renderer,
-            self.session,
-            self.cfg,
-            &mut self.agent_rx,
-            &mut self.main_abort,
-            &mut self.is_running,
-            &self.status_signals,
-            &mut self.turn_trace,
-            &mut self.response_buf,
-            &mut self.response_start_block,
-            &mut self.agent_line_started,
-            &mut self.was_reasoning,
+            &self.ui,
+            &mut self.run,
         )
     }
 
@@ -1991,14 +1742,14 @@ impl<'a> App<'a> {
             } => {
                 self.btw_total_cost += crate::pricing::estimate_cost(
                     crate::pricing::billable_input_tokens(
-                        self.cfg.is_anthropic_native(&self.session.provider),
+                        self.ui.cfg.is_anthropic_native(&self.ui.session.provider),
                         input_tokens,
                         cached_input_tokens,
                         cache_creation_input_tokens,
                     ),
                     output_tokens,
-                    self.session.input_token_cost,
-                    self.session.output_token_cost,
+                    self.ui.session.input_token_cost,
+                    self.ui.session.output_token_cost,
                 );
                 self.btw_total_in = self.btw_total_in.saturating_add(input_tokens);
                 self.btw_total_out = self.btw_total_out.saturating_add(output_tokens);
@@ -2027,9 +1778,9 @@ impl<'a> App<'a> {
         #[cfg(feature = "mcp")]
         {
             let (built_agent, built_mcp) = prebuilt;
-            self.agent = Some(built_agent);
-            self.mcp_manager = built_mcp;
-            if notify && let Some(m) = self.mcp_manager.as_mut() {
+            self.run.agent = Some(built_agent);
+            self.ui.mcp_manager = built_mcp;
+            if notify && let Some(m) = self.ui.mcp_manager.as_mut() {
                 for notice in m.take_notices() {
                     self.renderer.write_line(&notice, C_ERROR)?;
                 }
@@ -2038,7 +1789,7 @@ impl<'a> App<'a> {
         #[cfg(not(feature = "mcp"))]
         {
             let _ = notify;
-            self.agent = Some(prebuilt);
+            self.run.agent = Some(prebuilt);
         }
         self.prebuild_rx = None;
         Ok(())
@@ -2056,34 +1807,38 @@ impl<'a> App<'a> {
         } else {
             let server = server.to_string();
             let server_cfg = self
+                .ui
                 .cfg
                 .mcp_servers
                 .as_ref()
                 .and_then(|m| m.get(&server).cloned());
-            match (self.mcp_manager.as_mut(), server_cfg) {
+            match (self.ui.mcp_manager.as_mut(), server_cfg) {
                 (Some(mgr), Some(scfg)) => match mgr.reconnect(&server, &scfg).await {
                     Ok(()) => {
-                        let model = self.client.completion_model(self.session.model.to_string());
+                        let model = self
+                            .ui
+                            .client
+                            .completion_model(self.ui.session.model.to_string());
                         let temperature = crate::config::resolve_temperature(
-                            self.cli,
-                            self.cfg,
-                            &self.session.model,
+                            self.ui.cli,
+                            self.ui.cfg,
+                            &self.ui.session.model,
                         );
                         let extra_body =
-                            crate::config::resolve_extra_body(self.cfg, &self.session.model);
-                        self.agent = Some(
+                            crate::config::resolve_extra_body(self.ui.cfg, &self.ui.session.model);
+                        self.run.agent = Some(
                             crate::provider::build_agent(
                                 model,
-                                self.cli,
-                                self.cfg,
-                                self.context,
-                                self.permission.clone(),
-                                self.ask_tx.clone(),
-                                self.sandbox.clone(),
-                                self.reasoning_enabled,
+                                self.ui.cli,
+                                self.ui.cfg,
+                                self.ui.context,
+                                self.ui.permission.clone(),
+                                self.ui.ask_tx.clone(),
+                                self.ui.sandbox.clone(),
+                                self.slash.reasoning_enabled,
                                 temperature,
                                 extra_body,
-                                self.mcp_manager.as_ref(),
+                                self.ui.mcp_manager.as_ref(),
                             )
                             .await,
                         );
@@ -2158,8 +1913,8 @@ impl<'a> App<'a> {
     }
 
     fn save_session(&mut self) -> anyhow::Result<()> {
-        if !self.cli.no_session
-            && let Err(e) = crate::session::storage::save_session(self.session)
+        if !self.ui.cli.no_session
+            && let Err(e) = crate::session::storage::save_session(self.ui.session)
         {
             self.renderer
                 .write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
@@ -2169,7 +1924,7 @@ impl<'a> App<'a> {
 
     #[cfg(feature = "git-worktree")]
     async fn handle_worktree_auto_merge(&mut self) -> anyhow::Result<()> {
-        if !self.cli.resolve_wt_auto_merge(self.cfg) {
+        if !self.ui.cli.resolve_wt_auto_merge(self.ui.cfg) {
             return Ok(());
         }
         let info = match crate::extras::git_worktree::detect() {
@@ -2192,7 +1947,7 @@ impl<'a> App<'a> {
                 "worktree has uncommitted changes. [c]ommit all and continue  [a]bort merge",
                 C_PERM,
             );
-            if let Some(ss) = self.status_signals.as_ref() {
+            if let Some(ss) = self.ui.status_signals.as_ref() {
                 ss.send_git_conflict();
             }
             let action = loop {
@@ -2249,7 +2004,7 @@ impl<'a> App<'a> {
         };
         match outcome {
             crate::extras::git_worktree::MergeOutcome::Success => {
-                let merge_result = if self.cli.resolve_wt_force(self.cfg) {
+                let merge_result = if self.ui.cli.resolve_wt_force(self.ui.cfg) {
                     crate::extras::git_worktree::complete_merge_force(&state)
                 } else {
                     crate::extras::git_worktree::complete_merge(&state)
@@ -2277,7 +2032,7 @@ impl<'a> App<'a> {
                 for f in &files {
                     let _ = self.renderer.write_line(&format!("  {}", f), C_ERROR);
                 }
-                if let Some(ss) = self.status_signals.as_ref() {
+                if let Some(ss) = self.ui.status_signals.as_ref() {
                     ss.send_git_conflict();
                 }
                 let _ = self.renderer.write_line(
@@ -2308,7 +2063,7 @@ impl<'a> App<'a> {
                             &info.worktree_path.to_string_lossy(),
                             &info.branch,
                             &info.main_repo_path.to_string_lossy(),
-                            self.cli.resolve_wt_force(self.cfg),
+                            self.ui.cli.resolve_wt_force(self.ui.cfg),
                         );
                         let _ = self
                             .renderer
@@ -2330,39 +2085,30 @@ impl<'a> App<'a> {
                             .write_line("agent resolving merge...", C_AGENT);
                         let main_path = info.main_repo_path.display().to_string();
                         let wt_path = info.worktree_path.display().to_string();
-                        let force_flag = self.cli.resolve_wt_force(self.cfg);
+                        let force_flag = self.ui.cli.resolve_wt_force(self.ui.cfg);
                         spawn_merge_agent(
-                            &info.branch,
-                            &target,
-                            &main_path,
-                            &wt_path,
-                            force_flag,
-                            self.session,
-                            &mut self.agent,
-                            &self.client,
-                            self.cli,
-                            self.cfg,
-                            self.context,
-                            &self.permission,
-                            &self.ask_tx,
-                            &self.sandbox,
-                            self.reasoning_enabled,
-                            &mut self.agent_rx,
-                            &mut self.main_abort,
-                            &mut self.is_running,
-                            &self.status_signals,
-                            &mut self.wt_return_path,
-                            #[cfg(feature = "mcp")]
-                            &mut self.mcp_manager,
+                            MergeRequest {
+                                branch: &info.branch,
+                                target: &target,
+                                main_path: &main_path,
+                                wt_path: &wt_path,
+                                force: force_flag,
+                            },
+                            &mut self.run,
+                            &mut self.ui,
+                            &mut self.chain,
                         )
                         .await;
 
-                        let mut agent_line_started = false;
-                        let mut merge_response_buf = String::new();
-                        let mut merge_response_start_block = None;
-                        let mut merge_was_reasoning = false;
-                        while self.is_running {
-                            let ev = match self.agent_rx.as_mut() {
+                        // The merge agent streams through the main run state; reset
+                        // the streaming scratch so no stale partial line leaks in.
+                        self.run.agent_line_started = false;
+                        self.run.response_buf.clear();
+                        self.run.response_start_block = None;
+                        self.run.was_reasoning = false;
+                        let mut merge_rx = self.run.agent_rx.take();
+                        while self.run.is_running {
+                            let ev = match merge_rx.as_mut() {
                                 Some(rx) => {
                                     tokio::select! {
                                         Some(e) = rx.recv() => Some(e),
@@ -2371,15 +2117,15 @@ impl<'a> App<'a> {
                                                 let is_ctrl_c = key.code == KeyCode::Char('c')
                                                     && key.modifiers.contains(KeyModifiers::CONTROL);
                                                 if is_ctrl_c {
-                                                    if let Some(h) = self.main_abort.take() {
+                                                    if let Some(h) = self.run.main_abort.take() {
                                                         h.abort();
                                                     }
-                                                    self.sandbox.kill_active();
-                                                    self.is_running = false;
-                                                    if let Some(ss) = self.status_signals.as_ref() {
+                                                    self.ui.sandbox.kill_active();
+                                                    self.run.is_running = false;
+                                                    if let Some(ss) = self.ui.status_signals.as_ref() {
                                                         ss.send_stop();
                                                     }
-                                                    self.agent_rx = None;
+                                                    self.run.agent_rx = None;
                                                 }
                                             }
                                             None
@@ -2394,11 +2140,9 @@ impl<'a> App<'a> {
                                             let _ = handle_permission_request(
                                                 ask_req,
                                                 &mut self.renderer,
-                                                self.session,
-                                                self.cli,
+                                                &mut self.ui,
+                                                &mut self.run,
                                                 &mut self.user_rx,
-                                                &mut agent_line_started,
-                                                &mut merge_was_reasoning,
                                             ).await;
                                             None
                                         }
@@ -2407,36 +2151,13 @@ impl<'a> App<'a> {
                                 None => break,
                             };
                             if let Some(ev) = ev {
-                                #[cfg(feature = "mcp")]
-                                let mcp_ref =
-                                    ensure_mcp_manager(&mut self.mcp_manager, self.cfg).await;
                                 event_handler::handle_agent_event(
                                     ev,
                                     &mut self.renderer,
-                                    self.session,
-                                    self.cfg,
-                                    self.cli,
-                                    self.context,
-                                    &mut self.is_running,
-                                    &mut self.agent_rx,
-                                    &mut agent_line_started,
-                                    &mut merge_response_buf,
-                                    &mut merge_response_start_block,
-                                    &mut merge_was_reasoning,
-                                    self.show_reasoning,
-                                    &mut self.agent,
-                                    &mut self.client,
-                                    &mut self.loop_label,
-                                    &self.permission,
-                                    &self.ask_tx,
-                                    &self.sandbox,
-                                    &self.status_signals,
-                                    #[cfg(feature = "loop")]
-                                    &mut self.loop_state,
-                                    #[cfg(feature = "git-worktree")]
-                                    &mut self.wt_return_path,
-                                    #[cfg(feature = "mcp")]
-                                    mcp_ref,
+                                    &mut self.run,
+                                    &mut self.ui,
+                                    &self.slash,
+                                    &mut self.chain,
                                 )
                                 .await?;
                             }

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -1,25 +1,18 @@
 use compact_str::CompactString;
 use crossterm::style::Color;
-use tokio::sync::mpsc;
 
 use crate::agent::tools::todo::TODO_LIST;
 use crate::cli::Cli;
-use crate::config::{Config, ResolvedShowToolDetails};
-use crate::context::ContextFiles;
+use crate::config::ResolvedShowToolDetails;
 use crate::event::AgentEvent;
-#[cfg(feature = "mcp")]
-use crate::extras::mcp::McpClientManager;
-use crate::extras::status_signals::StatusSignals;
-use crate::permission::ask::AskSender;
-use crate::permission::checker::PermCheck;
-use crate::provider::{AnyAgent, AnyClient};
-use crate::sandbox::Sandbox;
+use crate::provider::AnyAgent;
 use crate::session::storage::save_session;
 use crate::session::{MessageRole, Session};
 use crate::ui::events::sanitize_output;
 use crate::ui::feed::BlockStyle;
 use crate::ui::renderer::Renderer;
 use crate::ui::slash::handle_compress;
+use crate::ui::state::{AgentRunState, ChainState, SlashState, TurnUsage, UiContext};
 
 #[cfg(any(feature = "git-worktree", feature = "loop"))]
 use super::C_AGENT;
@@ -27,139 +20,77 @@ use super::C_AGENT;
 use super::apply_current_prompt_mode;
 use super::{C_ERROR, C_TOOL};
 
-#[cfg(feature = "mcp")]
-#[allow(clippy::too_many_arguments)]
+/// Build the main agent on first use, lazily connecting MCP as well. Callers
+/// only reach the build when `agent` is `None`, so MCP connects at most once.
 pub async fn ensure_agent(
     agent: &mut Option<AnyAgent>,
-    client: &AnyClient,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    reasoning_enabled: bool,
-    mcp_manager: Option<&McpClientManager>,
-) {
-    if agent.is_some() {
-        return;
-    }
-    let model = client.completion_model(session.model.to_string());
-    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
-    *agent = Some(
-        crate::provider::build_agent(
-            model,
-            cli,
-            cfg,
-            context,
-            permission.clone(),
-            ask_tx.clone(),
-            sandbox.clone(),
-            reasoning_enabled,
-            temperature,
-            extra_body,
-            mcp_manager,
-        )
-        .await,
-    );
-    // Keep the pre-calibration context estimate in sync with the preamble we
-    // just built (system prompt + tools + context files).
-    session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
-}
-
-#[cfg(not(feature = "mcp"))]
-#[allow(clippy::too_many_arguments)]
-pub async fn ensure_agent(
-    agent: &mut Option<AnyAgent>,
-    client: &AnyClient,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
+    ui: &mut UiContext<'_>,
     reasoning_enabled: bool,
 ) {
     if agent.is_some() {
         return;
     }
-    let model = client.completion_model(session.model.to_string());
-    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+    let model = ui.client.completion_model(ui.session.model.to_string());
+    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
+    #[cfg(feature = "mcp")]
+    let mcp_ref = crate::ui::ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
     *agent = Some(
         crate::provider::build_agent(
             model,
-            cli,
-            cfg,
-            context,
-            permission.clone(),
-            ask_tx.clone(),
-            sandbox.clone(),
+            ui.cli,
+            ui.cfg,
+            ui.context,
+            ui.permission.clone(),
+            ui.ask_tx.clone(),
+            ui.sandbox.clone(),
             reasoning_enabled,
             temperature,
             extra_body,
+            #[cfg(feature = "mcp")]
+            mcp_ref,
         )
         .await,
     );
     // Keep the pre-calibration context estimate in sync with the preamble we
     // just built (system prompt + tools + context files).
-    session.overhead_tokens = crate::agent::builder::estimate_overhead(context, reasoning_enabled);
+    ui.session.overhead_tokens =
+        crate::agent::builder::estimate_overhead(ui.context, reasoning_enabled);
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn handle_agent_event(
     event: AgentEvent,
     renderer: &mut Renderer,
-    session: &mut Session,
-    cfg: &Config,
-    cli: &Cli,
-    context: &mut ContextFiles,
-    is_running: &mut bool,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    agent_line_started: &mut bool,
-    response_buf: &mut String,
-    response_start_block: &mut Option<usize>,
-    was_reasoning: &mut bool,
-    show_reasoning: bool,
-    agent: &mut Option<AnyAgent>,
-    client: &mut AnyClient,
-    loop_label: &mut Option<String>,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    status_signals: &Option<StatusSignals>,
-    #[cfg(feature = "loop")] loop_state: &mut Option<crate::extras::r#loop::LoopState>,
-    #[cfg(feature = "git-worktree")] wt_return_path: &mut Option<(String, String, String, bool)>,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    slash: &SlashState,
+    chain: &mut ChainState,
 ) -> anyhow::Result<()> {
     match event {
         AgentEvent::Reasoning(text) => {
-            if !show_reasoning {
+            if !slash.show_reasoning {
                 return Ok(());
             }
-            if !*agent_line_started {
+            if !run.agent_line_started {
                 renderer.write("< ", Color::DarkMagenta)?;
-                *agent_line_started = true;
+                run.agent_line_started = true;
             }
             let safe = sanitize_output(&text);
             renderer.write(&safe, Color::DarkMagenta)?;
-            *was_reasoning = true;
+            run.was_reasoning = true;
         }
         AgentEvent::Token(text) => {
-            if *was_reasoning {
+            if run.was_reasoning {
                 renderer.write_line("", Color::White)?;
-                *agent_line_started = false;
-                *was_reasoning = false;
-                response_buf.clear();
-                *response_start_block = None;
+                run.agent_line_started = false;
+                run.was_reasoning = false;
+                run.response_buf.clear();
+                run.response_start_block = None;
             }
             let safe = sanitize_output(&text);
-            response_buf.push_str(&safe);
+            run.response_buf.push_str(&safe);
 
-            if response_buf.is_empty() {
+            if run.response_buf.is_empty() {
                 return Ok(());
             }
 
@@ -168,30 +99,30 @@ pub async fn handle_agent_event(
             // boundaries) or when the buffer is small. This avoids O(n²)
             // re-parsing on every token. The final parse happens in
             // handle_agent_done.
-            if response_buf.len() >= 200 && !response_buf.ends_with('\n') {
+            if run.response_buf.len() >= 200 && !run.response_buf.ends_with('\n') {
                 return Ok(());
             }
 
-            if response_start_block.is_none() {
+            if run.response_start_block.is_none() {
                 renderer.feed_mut().push_block(BlockStyle::Agent, "");
-                *response_start_block = Some(renderer.feed().block_count() - 1);
+                run.response_start_block = Some(renderer.feed().block_count() - 1);
             }
             renderer
                 .feed_mut()
-                .replace_last(BlockStyle::Agent, response_buf.as_str());
+                .replace_last(BlockStyle::Agent, run.response_buf.as_str());
             renderer.render_viewport()?;
-            *agent_line_started = true;
+            run.agent_line_started = true;
         }
         AgentEvent::ToolCall { name, args } => {
-            *was_reasoning = false;
-            if *agent_line_started {
+            run.was_reasoning = false;
+            if run.agent_line_started {
                 renderer.write_line("", Color::White)?;
-                *agent_line_started = false;
+                run.agent_line_started = false;
             }
-            response_buf.clear();
-            *response_start_block = None;
-            session.add_tool_call(&name, &args);
-            save_session_if_enabled(session, cli, renderer)?;
+            run.response_buf.clear();
+            run.response_start_block = None;
+            ui.session.add_tool_call(&name, &args);
+            save_session_if_enabled(ui.session, ui.cli, renderer)?;
             let line = format!(
                 "◈ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
@@ -200,8 +131,8 @@ pub async fn handle_agent_event(
         }
         #[cfg(any(feature = "subagents", feature = "acp"))]
         AgentEvent::SubagentToolCall { name, args } => {
-            session.add_subagent_tool_call(&name, &args);
-            save_session_if_enabled(session, cli, renderer)?;
+            ui.session.add_subagent_tool_call(&name, &args);
+            save_session_if_enabled(ui.session, ui.cli, renderer)?;
             let line = format!(
                 "⌥ {}",
                 crate::ui::utils::format_tool_call_summary(&name, &args)
@@ -209,8 +140,8 @@ pub async fn handle_agent_event(
             renderer.write_line(&sanitize_output(&line), C_TOOL)?;
         }
         AgentEvent::ToolResult { name, output } => {
-            session.add_tool_result(&name, &output);
-            save_session_if_enabled(session, cli, renderer)?;
+            ui.session.add_tool_result(&name, &output);
+            save_session_if_enabled(ui.session, ui.cli, renderer)?;
             if name == "todo_write" {
                 let list = TODO_LIST.lock().unwrap_or_else(|e| e.into_inner());
                 if list.is_empty() {
@@ -247,7 +178,8 @@ pub async fn handle_agent_event(
                     }
                 }
             } else {
-                let show_details = cfg
+                let show_details = ui
+                    .cfg
                     .show_tool_details
                     .as_ref()
                     .map(|s| s.resolve())
@@ -292,34 +224,16 @@ pub async fn handle_agent_event(
         } => {
             handle_agent_done(
                 response,
-                input_tokens,
-                output_tokens,
-                cached_input_tokens,
-                cache_creation_input_tokens,
+                TurnUsage {
+                    input_tokens,
+                    output_tokens,
+                    cached_input_tokens,
+                    cache_creation_input_tokens,
+                },
                 renderer,
-                session,
-                cfg,
-                cli,
-                context,
-                is_running,
-                agent_rx,
-                agent_line_started,
-                response_buf,
-                response_start_block,
-                was_reasoning,
-                agent,
-                client,
-                loop_label,
-                permission,
-                ask_tx,
-                sandbox,
-                status_signals,
-                #[cfg(feature = "loop")]
-                loop_state,
-                #[cfg(feature = "git-worktree")]
-                wt_return_path,
-                #[cfg(feature = "mcp")]
-                mcp_manager,
+                run,
+                ui,
+                chain,
             )
             .await?;
         }
@@ -336,55 +250,57 @@ pub async fn handle_agent_event(
             // Use the cache-inclusive prompt size so Anthropic cache hits (which
             // report input_tokens excluding cached tokens) don't deflate it.
             let real = Session::real_input_tokens(
-                cfg.is_anthropic_native(&session.provider),
+                ui.cfg.is_anthropic_native(&ui.session.provider),
                 input_tokens,
                 cached_input_tokens,
                 cache_creation_input_tokens,
             )
             .saturating_add(output_tokens);
-            if real > session.total_estimated_tokens {
-                session.total_estimated_tokens = real;
+            if real > ui.session.total_estimated_tokens {
+                ui.session.total_estimated_tokens = real;
             }
             // Accumulate cost for intermediate calls (tool-use turns). The Done
             // event only carries the final call's usage, so without this every
             // tool-call round-trip would go uncosted.
-            session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
-            session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
-            session.total_cost += crate::pricing::estimate_cost(
+            ui.session.total_input_tokens =
+                ui.session.total_input_tokens.saturating_add(input_tokens);
+            ui.session.total_output_tokens =
+                ui.session.total_output_tokens.saturating_add(output_tokens);
+            ui.session.total_cost += crate::pricing::estimate_cost(
                 crate::pricing::billable_input_tokens(
-                    cfg.is_anthropic_native(&session.provider),
+                    ui.cfg.is_anthropic_native(&ui.session.provider),
                     input_tokens,
                     cached_input_tokens,
                     cache_creation_input_tokens,
                 ),
                 output_tokens,
-                session.input_token_cost,
-                session.output_token_cost,
+                ui.session.input_token_cost,
+                ui.session.output_token_cost,
             );
         }
         AgentEvent::Retrying { attempt, max } => {
-            *was_reasoning = false;
-            if *agent_line_started {
+            run.was_reasoning = false;
+            if run.agent_line_started {
                 renderer.write_line("", Color::White)?;
-                *agent_line_started = false;
+                run.agent_line_started = false;
             }
-            response_buf.clear();
-            *response_start_block = None;
+            run.response_buf.clear();
+            run.response_start_block = None;
             renderer.write_line(&format!("retrying... ({}/{})", attempt, max), Color::Yellow)?;
         }
         AgentEvent::Error(e) => {
-            *was_reasoning = false;
+            run.was_reasoning = false;
             let safe = sanitize_output(&e);
             renderer.write_line(&format!("error: {}", safe), C_ERROR)?;
-            *is_running = false;
-            if let Some(ss) = status_signals.as_ref() {
+            run.is_running = false;
+            if let Some(ss) = ui.status_signals.as_ref() {
                 ss.send_stop();
             }
-            *agent_rx = None;
-            *agent_line_started = false;
-            response_buf.clear();
-            *response_start_block = None;
-            save_session_if_enabled(session, cli, renderer)?;
+            run.agent_rx = None;
+            run.agent_line_started = false;
+            run.response_buf.clear();
+            run.response_start_block = None;
+            save_session_if_enabled(ui.session, ui.cli, renderer)?;
         }
     }
     Ok(())
@@ -403,68 +319,56 @@ fn save_session_if_enabled(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn handle_agent_done(
     response: CompactString,
-    input_tokens: u64,
-    output_tokens: u64,
-    cached_input_tokens: u64,
-    cache_creation_input_tokens: u64,
+    usage: TurnUsage,
     renderer: &mut Renderer,
-    session: &mut Session,
-    cfg: &Config,
-    cli: &Cli,
-    context: &mut ContextFiles,
-    is_running: &mut bool,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    agent_line_started: &mut bool,
-    response_buf: &mut String,
-    response_start_block: &mut Option<usize>,
-    was_reasoning: &mut bool,
-    agent: &mut Option<AnyAgent>,
-    client: &mut AnyClient,
-    _loop_label: &mut Option<String>,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    status_signals: &Option<StatusSignals>,
-    #[cfg(feature = "loop")] loop_state: &mut Option<crate::extras::r#loop::LoopState>,
-    #[cfg(feature = "git-worktree")] wt_return_path: &mut Option<(String, String, String, bool)>,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    chain: &mut ChainState,
 ) -> anyhow::Result<()> {
-    *was_reasoning = false;
+    // `chain` is only read by the /loop-respawn and worktree-return paths.
+    #[cfg(not(any(feature = "loop", feature = "git-worktree")))]
+    let _ = &chain;
+    run.was_reasoning = false;
 
-    if !response_buf.is_empty() {
-        if let Some(start) = *response_start_block {
+    if !run.response_buf.is_empty() {
+        if let Some(start) = run.response_start_block {
             renderer.feed_mut().truncate_blocks(start + 1);
         }
         renderer
             .feed_mut()
-            .replace_last(BlockStyle::Agent, response_buf.as_str());
+            .replace_last(BlockStyle::Agent, run.response_buf.as_str());
         renderer.render_viewport()?;
-    } else if !*agent_line_started {
+    } else if !run.agent_line_started {
         renderer.feed_mut().push_line(BlockStyle::Agent, "< ");
     }
 
     renderer.write_line("", Color::White)?;
     renderer.write_line("", Color::White)?;
-    session.add_message(MessageRole::Assistant, &response);
+    ui.session.add_message(MessageRole::Assistant, &response);
     // `total_input_tokens`/`total_output_tokens` keep the raw provider-reported
     // counts (that's what those fields mean), but cost prices the *billable*
     // input — for Anthropic that folds in cache reads/writes, which the raw
     // `input_tokens` excludes yet are still billed (see `billable_input_tokens`).
-    session.total_input_tokens = session.total_input_tokens.saturating_add(input_tokens);
-    session.total_output_tokens = session.total_output_tokens.saturating_add(output_tokens);
-    session.total_cost += crate::pricing::estimate_cost(
+    ui.session.total_input_tokens = ui
+        .session
+        .total_input_tokens
+        .saturating_add(usage.input_tokens);
+    ui.session.total_output_tokens = ui
+        .session
+        .total_output_tokens
+        .saturating_add(usage.output_tokens);
+    ui.session.total_cost += crate::pricing::estimate_cost(
         crate::pricing::billable_input_tokens(
-            cfg.is_anthropic_native(&session.provider),
-            input_tokens,
-            cached_input_tokens,
-            cache_creation_input_tokens,
+            ui.cfg.is_anthropic_native(&ui.session.provider),
+            usage.input_tokens,
+            usage.cached_input_tokens,
+            usage.cache_creation_input_tokens,
         ),
-        output_tokens,
-        session.input_token_cost,
-        session.output_token_cost,
+        usage.output_tokens,
+        ui.session.input_token_cost,
+        ui.session.output_token_cost,
     );
     // Anchor context-size accounting to the provider's real usage. Context
     // measurement needs the full prompt size, so use the cache-inclusive count
@@ -472,72 +376,56 @@ async fn handle_agent_done(
     // which would otherwise collapse the context meter to ~0 on cache hits).
     // Must come after add_message so the anchor includes the just-appended response.
     let context_input_tokens = Session::real_input_tokens(
-        cfg.is_anthropic_native(&session.provider),
-        input_tokens,
-        cached_input_tokens,
-        cache_creation_input_tokens,
+        ui.cfg.is_anthropic_native(&ui.session.provider),
+        usage.input_tokens,
+        usage.cached_input_tokens,
+        usage.cache_creation_input_tokens,
     );
-    session.set_calibration(context_input_tokens, output_tokens);
-    *agent_line_started = false;
-    response_buf.clear();
-    *response_start_block = None;
+    ui.session
+        .set_calibration(context_input_tokens, usage.output_tokens);
+    run.agent_line_started = false;
+    run.response_buf.clear();
+    run.response_start_block = None;
 
     #[cfg(feature = "loop")]
-    let loop_running = loop_state.as_ref().is_some_and(|ls| ls.active);
+    let loop_running = chain.loop_state.as_ref().is_some_and(|ls| ls.active);
     #[cfg(not(feature = "loop"))]
     let loop_running = false;
 
-    let qm = crate::config::quick_models_map(cfg);
+    let qm = crate::config::quick_models_map(ui.cfg);
 
     #[cfg(feature = "memory")]
     let reserve = crate::extras::memory::effective_reserve(
-        cfg.resolve_reserve_tokens(&session.model, &qm),
-        context.memory.as_deref(),
+        ui.cfg.resolve_reserve_tokens(&ui.session.model, &qm),
+        ui.context.memory.as_deref(),
     );
     #[cfg(not(feature = "memory"))]
-    let reserve = cfg.resolve_reserve_tokens(&session.model, &qm);
+    let reserve = ui.cfg.resolve_reserve_tokens(&ui.session.model, &qm);
 
     if !loop_running
-        && cfg.resolve_compact_enabled()
-        && session.needs_compaction(reserve)
-        && !cli.no_session
+        && ui.cfg.resolve_compact_enabled()
+        && ui.session.needs_compaction(reserve)
+        && !ui.cli.no_session
     {
-        let compress_result = handle_compress(
-            None,
-            true,
-            agent,
-            client,
-            renderer,
-            session,
-            cli,
-            cfg,
-            context,
-            true,
-            permission,
-            ask_tx,
-            sandbox,
-            #[cfg(feature = "mcp")]
-            mcp_manager,
-        )
-        .await;
+        let compress_result = handle_compress(None, true, &mut run.agent, renderer, ui, true).await;
         if let Err(e) = compress_result {
             renderer.write_line(&format!("auto-compact error: {}", e), C_ERROR)?;
         }
     }
 
-    if !cli.no_session
-        && let Err(e) = save_session(session)
+    if !ui.cli.no_session
+        && let Err(e) = save_session(ui.session)
     {
         renderer.write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
     }
-    *is_running = false;
-    if let Some(ss) = status_signals.as_ref() {
+    run.is_running = false;
+    if let Some(ss) = ui.status_signals.as_ref() {
         ss.send_stop();
     }
-    *agent_rx = None;
+    run.agent_rx = None;
 
     #[cfg(feature = "loop")]
-    if let Some(ls) = loop_state
+    if let Some(ls) = chain.loop_state.as_mut()
         && ls.active
     {
         let summary: String = response
@@ -576,7 +464,7 @@ async fn handle_agent_done(
         ls.last_run_output = validation_output.clone();
 
         let _ = crate::extras::r#loop::transcript::save_iteration(
-            &session.id,
+            &ui.session.id,
             ls.iteration,
             &ls.build_prompt(),
             &response,
@@ -595,37 +483,39 @@ async fn handle_agent_done(
                 C_AGENT,
             )?;
             ls.active = false;
-            *_loop_label = None;
+            chain.loop_label = None;
         } else {
             let prompt = ls.build_prompt();
-            *agent = Some({
-                let model = client.completion_model(session.model.to_string());
-                let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-                let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+            run.agent = Some({
+                let model = ui.client.completion_model(ui.session.model.to_string());
+                let temperature =
+                    crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+                let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
                 crate::provider::build_agent(
                     model,
-                    cli,
-                    cfg,
-                    context,
-                    permission.clone(),
-                    ask_tx.clone(),
-                    sandbox.clone(),
+                    ui.cli,
+                    ui.cfg,
+                    ui.context,
+                    ui.permission.clone(),
+                    ui.ask_tx.clone(),
+                    ui.sandbox.clone(),
                     true,
                     temperature,
                     extra_body,
                     #[cfg(feature = "mcp")]
-                    mcp_manager,
+                    ui.mcp_manager.as_ref(),
                 )
                 .await
             });
-            let runner = agent
+            let runner = run
+                .agent
                 .as_ref()
                 .unwrap()
                 .clone()
                 .spawn_runner(
                     prompt,
                     Vec::new(),
-                    cfg.retry.clone(),
+                    ui.cfg.retry.clone(),
                     #[cfg(feature = "hooks")]
                     Some(crate::extras::hooks::LoopInfo {
                         iteration: ls.iteration,
@@ -633,12 +523,12 @@ async fn handle_agent_done(
                     }),
                 )
                 .await;
-            *agent_rx = Some(runner.event_rx);
-            *is_running = true;
-            if let Some(ss) = status_signals.as_ref() {
+            run.agent_rx = Some(runner.event_rx);
+            run.is_running = true;
+            if let Some(ss) = ui.status_signals.as_ref() {
                 ss.send_start();
             }
-            *_loop_label = Some(ls.iteration_label());
+            chain.loop_label = Some(ls.iteration_label());
             renderer.write_line(
                 &format!("[loop] launching {}", ls.iteration_label()),
                 C_AGENT,
@@ -647,34 +537,37 @@ async fn handle_agent_done(
     }
 
     #[cfg(feature = "git-worktree")]
-    if let Some((main_path, wt_path, branch, force)) = wt_return_path.take() {
+    if let Some((main_path, wt_path, branch, force)) = chain.wt_return_path.take() {
         crate::extras::git_worktree::cleanup_worktree(&wt_path, &branch, &main_path, force);
         match std::env::set_current_dir(&main_path) {
             Ok(()) => {
-                session.working_dir = compact_str::CompactString::new(&main_path);
-                context.reload();
-                apply_current_prompt_mode(context, permission);
-                *agent = Some({
-                    let model = client.completion_model(session.model.to_string());
-                    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-                    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+                ui.session.working_dir = compact_str::CompactString::new(&main_path);
+                ui.context.reload();
+                apply_current_prompt_mode(ui.context, &ui.permission);
+                run.agent = Some({
+                    let model = ui.client.completion_model(ui.session.model.to_string());
+                    let temperature =
+                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
                     crate::provider::build_agent(
                         model,
-                        cli,
-                        cfg,
-                        context,
-                        permission.clone(),
-                        ask_tx.clone(),
-                        sandbox.clone(),
+                        ui.cli,
+                        ui.cfg,
+                        ui.context,
+                        ui.permission.clone(),
+                        ui.ask_tx.clone(),
+                        ui.sandbox.clone(),
                         true,
                         temperature,
                         extra_body,
                         #[cfg(feature = "mcp")]
-                        mcp_manager,
+                        ui.mcp_manager.as_ref(),
                     )
                     .await
                 });
-                crate::ui::events::render_session(renderer, session, cli, cfg, context)?;
+                crate::ui::events::render_session(
+                    renderer, ui.session, ui.cli, ui.cfg, ui.context,
+                )?;
                 renderer.write_line(
                     &format!("merged and returned to main repo at {}", main_path),
                     C_AGENT,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ mod permission_handler;
 pub(crate) mod pickers;
 pub(crate) mod renderer;
 pub(crate) mod slash;
+pub(crate) mod state;
 pub(crate) mod statusline;
 mod terminal;
 pub(crate) mod utils;
@@ -22,19 +23,19 @@ use crossterm::event::{KeyEventKind, MouseButton, MouseEventKind};
 use crossterm::style::Color;
 use tokio::sync::mpsc;
 
-use crate::cli::Cli;
+#[cfg(feature = "mcp")]
 use crate::config::Config;
+#[cfg(feature = "git-worktree")]
 use crate::context::ContextFiles;
-use crate::event::{AgentEvent, UserEvent};
+use crate::event::UserEvent;
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::McpClientManager;
-use crate::extras::status_signals::StatusSignals;
 #[cfg(feature = "git-worktree")]
 use crate::permission;
-use crate::permission::ask::{AskReceiver, AskSender};
+use crate::permission::ask::AskReceiver;
+#[cfg(feature = "git-worktree")]
 use crate::permission::checker::PermCheck;
-use crate::provider::{AnyAgent, AnyClient};
-use crate::sandbox::Sandbox;
+use crate::provider::AnyAgent;
 use crate::session::{MessageRole, Session};
 use crate::ui::event_handler::ensure_agent;
 #[cfg(feature = "advisor")]
@@ -42,6 +43,9 @@ use crate::ui::events::sanitize_output;
 use crate::ui::input::InputEditor;
 use crate::ui::renderer::Renderer;
 use crate::ui::slash::handle_compress;
+#[cfg(feature = "git-worktree")]
+use crate::ui::state::MergeRequest;
+use crate::ui::state::{AgentRunState, BtwStats, ChainState, SlashState, UiContext};
 
 #[cfg(feature = "git-worktree")]
 pub(crate) fn apply_current_prompt_mode(
@@ -75,36 +79,36 @@ pub(super) const C_BTW: Color = Color::Cyan;
 #[cfg(feature = "advisor")]
 pub(super) const C_HANDOFF: Color = Color::Green;
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn refresh_display(
     renderer: &mut Renderer,
     input: &mut InputEditor,
-    session: &Session,
-    is_running: bool,
-    loop_label: Option<&str>,
-    prompt_name: Option<&str>,
-    perm_mode: Option<&str>,
-    chain_label: Option<&str>,
-    btw_cost: f64,
-    btw_in: u64,
-    btw_out: u64,
+    ui: &UiContext,
+    run: &AgentRunState,
+    chain: &ChainState,
+    btw: BtwStats,
 ) -> io::Result<()> {
     // Reconcile the input height first so the chat viewport is drawn against
     // the size the input is about to occupy (avoids a stale separator when the
     // input shrinks, or chat text hidden under it when the input grows).
     renderer.sync_input_height(&input.buffer)?;
     renderer.render_viewport()?;
+    let perm_mode = ui.permission.as_ref().map(|p| {
+        p.lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .mode()
+            .to_string()
+    });
     let statusline_ctx = crate::ui::statusline::StatusContext {
-        loop_label,
-        prompt_name,
-        perm_mode,
-        chain_label,
-        btw_cost,
-        btw_in,
-        btw_out,
+        loop_label: chain.loop_label.as_deref(),
+        prompt_name: ui.context.current_prompt_name.as_deref(),
+        perm_mode: perm_mode.as_deref(),
+        chain_label: chain.label_msg.as_deref(),
+        btw_cost: btw.cost,
+        btw_in: btw.input,
+        btw_out: btw.output,
     };
-    let statusline = crate::ui::statusline::build(session, &statusline_ctx);
-    renderer.draw_bottom(&input.buffer, input.cursor, &statusline, is_running)?;
+    let statusline = crate::ui::statusline::build(ui.session, &statusline_ctx);
+    renderer.draw_bottom(&input.buffer, input.cursor, &statusline, run.is_running)?;
     if let Some(ref mut picker) = input.picker {
         picker.draw()?;
     }
@@ -242,32 +246,14 @@ pub(crate) fn classify_submission(is_running: bool, text: &str) -> SubmitAction 
 }
 
 #[cfg(feature = "git-worktree")]
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn spawn_merge_agent(
-    branch: &str,
-    target: &str,
-    main_path: &str,
-    wt_path: &str,
-    force_flag: bool,
-    session: &mut Session,
-    agent: &mut Option<AnyAgent>,
-    client: &AnyClient,
-    cli: &Cli,
-    cfg: &Config,
-    context: &ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    reasoning_enabled: bool,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    main_abort: &mut Option<tokio::task::AbortHandle>,
-    is_running: &mut bool,
-    status_signals: &Option<StatusSignals>,
-    wt_return_path: &mut Option<(String, String, String, bool)>,
-    #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
+    req: MergeRequest<'_>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    chain: &mut ChainState,
 ) {
-    let wt_remove_flag = if force_flag { "--force" } else { "" };
-    let branch_delete_flag = if force_flag { "-D" } else { "-d" };
+    let wt_remove_flag = if req.force { "--force" } else { "" };
+    let branch_delete_flag = if req.force { "-D" } else { "-d" };
     let prompt = format!(
         "I'm in a git worktree on branch '{branch}' at '{wt_path}'. \
          Merge it into '{target}' in the main repo at '{main_path}'.\n\n\
@@ -294,55 +280,41 @@ pub(crate) async fn spawn_merge_agent(
            - git branch {branch_delete_flag} {branch}\n\n\
          8. cd {main_path} and report completion.\n\n\
          Important: Do NOT skip any step. Always check for conflicts after merge.",
-        branch = branch,
-        wt_path = wt_path,
-        target = target,
-        main_path = main_path,
+        branch = req.branch,
+        wt_path = req.wt_path,
+        target = req.target,
+        main_path = req.main_path,
         wt_remove_flag = wt_remove_flag,
         branch_delete_flag = branch_delete_flag
     );
-    session.add_message(MessageRole::User, &prompt);
-    let history = crate::agent::runner::convert_history(session);
-    #[cfg(feature = "mcp")]
-    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
-    ensure_agent(
-        agent,
-        client,
-        session,
-        cli,
-        cfg,
-        context,
-        permission,
-        ask_tx,
-        sandbox,
-        reasoning_enabled,
-        #[cfg(feature = "mcp")]
-        mcp_ref,
-    )
-    .await;
-    let runner = agent
+    ui.session.add_message(MessageRole::User, &prompt);
+    let history = crate::agent::runner::convert_history(ui.session);
+    let reasoning_enabled = ui.session.reasoning_enabled;
+    ensure_agent(&mut run.agent, ui, reasoning_enabled).await;
+    let runner = run
+        .agent
         .as_ref()
         .unwrap()
         .clone()
         .spawn_runner(
             prompt,
             history,
-            cfg.retry.clone(),
+            ui.cfg.retry.clone(),
             #[cfg(feature = "hooks")]
             None,
         )
         .await;
-    *agent_rx = Some(runner.event_rx);
-    *main_abort = Some(runner.abort_handle);
-    *is_running = true;
-    if let Some(ss) = status_signals.as_ref() {
+    run.agent_rx = Some(runner.event_rx);
+    run.main_abort = Some(runner.abort_handle);
+    run.is_running = true;
+    if let Some(ss) = ui.status_signals.as_ref() {
         ss.send_start();
     }
-    *wt_return_path = Some((
-        main_path.to_string(),
-        wt_path.to_string(),
-        branch.to_string(),
-        force_flag,
+    chain.wt_return_path = Some((
+        req.main_path.to_string(),
+        req.wt_path.to_string(),
+        req.branch.to_string(),
+        req.force,
     ));
 }
 /// Result of a background agent prebuild.
@@ -390,54 +362,24 @@ pub(crate) async fn resolve_prebuild<'a>(
 /// The ONLY place that sets `agent_rx`/`is_running` for user-driven runs, so the
 /// "at most one main run" invariant is enforced in one spot. Callers must ensure
 /// no run is already active (otherwise the previous one would be orphaned).
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_main_run(
     text: &str,
-    agent: &mut Option<AnyAgent>,
-    client: &AnyClient,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    reasoning_enabled: bool,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    main_abort: &mut Option<tokio::task::AbortHandle>,
-    is_running: &mut bool,
-    status_signals: &Option<StatusSignals>,
-    #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    slash: &SlashState,
     prebuild_rx: &mut Option<mpsc::Receiver<PrebuildPayload>>,
-    pending_send: &mut Option<String>,
 ) {
     // Wait for the background prebuild if it hasn't completed yet.
     #[cfg(feature = "mcp")]
-    resolve_prebuild(agent, mcp_manager, prebuild_rx).await;
+    resolve_prebuild(&mut run.agent, &mut ui.mcp_manager, prebuild_rx).await;
     #[cfg(not(feature = "mcp"))]
-    resolve_prebuild(agent, prebuild_rx).await;
+    resolve_prebuild(&mut run.agent, prebuild_rx).await;
 
-    #[cfg(feature = "mcp")]
-    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
-    ensure_agent(
-        agent,
-        client,
-        session,
-        cli,
-        cfg,
-        context,
-        permission,
-        ask_tx,
-        sandbox,
-        reasoning_enabled,
-        #[cfg(feature = "mcp")]
-        mcp_ref,
-    )
-    .await;
-    let history = crate::agent::runner::convert_history(session);
+    ensure_agent(&mut run.agent, ui, slash.reasoning_enabled).await;
+    let history = crate::agent::runner::convert_history(ui.session);
     #[cfg(feature = "multimodal")]
     let history = {
-        let media = session.drain_media();
+        let media = ui.session.drain_media();
         if media.is_empty() {
             history
         } else {
@@ -446,35 +388,36 @@ pub(crate) async fn start_main_run(
             h
         }
     };
-    let runner = agent
+    let runner = run
+        .agent
         .as_ref()
         .unwrap()
         .clone()
         .spawn_runner(
             text.to_string(),
             history,
-            cfg.retry.clone(),
+            ui.cfg.retry.clone(),
             #[cfg(feature = "hooks")]
             None,
         )
         .await;
-    *agent_rx = Some(runner.event_rx);
-    *main_abort = Some(runner.abort_handle);
-    *is_running = true;
-    if let Some(ss) = status_signals.as_ref() {
+    run.agent_rx = Some(runner.event_rx);
+    run.main_abort = Some(runner.abort_handle);
+    run.is_running = true;
+    if let Some(ss) = ui.status_signals.as_ref() {
         ss.send_start();
     }
-    session.add_message(MessageRole::User, text);
+    ui.session.add_message(MessageRole::User, text);
     // Mark this message as the rollback target if the turn fails (see the
     // failed-send handling in the main event loop).
-    *pending_send = Some(text.to_string());
+    run.pending_send = Some(text.to_string());
     #[cfg(feature = "advisor")]
-    crate::extras::advisor::set_session_messages(session.messages.clone());
-    if !cli.no_session {
+    crate::extras::advisor::set_session_messages(ui.session.messages.clone());
+    if !ui.cli.no_session {
         let _ = crate::session::chat_history::append_entry(
             &crate::session::chat_history::ChatHistoryEntry {
                 content: text.to_string(),
-                timestamp: session.updated_at.clone(),
+                timestamp: ui.session.updated_at.clone(),
             },
         );
     }
@@ -506,61 +449,43 @@ wide ones until pressure subsides.";
 /// The dominant pressure relief is dropping the aborted run's in-flight tool
 /// context, which the respawn achieves even when the session itself is under the
 /// between-turn limit and `handle_compress` is a no-op.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn mid_turn_compact_and_respawn(
     pressure: f64,
     renderer: &mut Renderer,
-    agent: &mut Option<AnyAgent>,
-    client: &mut AnyClient,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &mut ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    reasoning_enabled: bool,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    main_abort: &mut Option<tokio::task::AbortHandle>,
-    is_running: &mut bool,
-    status_signals: &Option<StatusSignals>,
-    turn_trace: &mut Vec<compact_str::CompactString>,
-    response_buf: &mut String,
-    response_start_block: &mut Option<usize>,
-    agent_line_started: &mut bool,
-    was_reasoning: &mut bool,
-    #[cfg(feature = "mcp")] mcp_manager: &mut Option<McpClientManager>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    slash: &SlashState,
 ) -> anyhow::Result<()> {
     // 1. Stop the in-flight run. bash children die via kill_on_drop.
-    if let Some(h) = main_abort.take() {
+    if let Some(h) = run.main_abort.take() {
         h.abort();
     }
-    *is_running = false;
-    *agent_rx = None;
-    *was_reasoning = false;
+    run.is_running = false;
+    run.agent_rx = None;
+    run.was_reasoning = false;
 
     // 2. Record progress so far. `turn_trace` is a capped/truncated digest, so
     // this is best-effort continuity, paired with any partial response text.
     let mut recap = String::new();
-    if !response_buf.trim().is_empty() {
-        recap.push_str(response_buf.trim());
+    if !run.response_buf.trim().is_empty() {
+        recap.push_str(run.response_buf.trim());
         recap.push_str("\n\n");
     }
-    if !turn_trace.is_empty() {
+    if !run.turn_trace.is_empty() {
         recap.push_str("[Progress this turn before context compaction]\n");
-        for line in turn_trace.iter() {
+        for line in run.turn_trace.iter() {
             recap.push_str(line);
             recap.push('\n');
         }
     }
     let recap = recap.trim();
     if !recap.is_empty() {
-        session.add_message(MessageRole::Assistant, recap);
+        ui.session.add_message(MessageRole::Assistant, recap);
     }
-    turn_trace.clear();
-    response_buf.clear();
-    *response_start_block = None;
-    *agent_line_started = false;
+    run.turn_trace.clear();
+    run.response_buf.clear();
+    run.response_start_block = None;
+    run.agent_line_started = false;
 
     // Unlike the between-turn gate, this announces unconditionally: the relief
     // here is dropping the aborted run's in-flight tool context via the respawn
@@ -577,24 +502,13 @@ pub(crate) async fn mid_turn_compact_and_respawn(
     )?;
 
     // 3. Compact the session (no-op if its text history is under the limit).
-    #[cfg(feature = "mcp")]
-    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
     let compress_result = handle_compress(
         None,
         true,
-        agent,
-        client,
+        &mut run.agent,
         renderer,
-        session,
-        cli,
-        cfg,
-        context,
-        reasoning_enabled,
-        permission,
-        ask_tx,
-        sandbox,
-        #[cfg(feature = "mcp")]
-        mcp_ref,
+        ui,
+        slash.reasoning_enabled,
     )
     .await;
     if let Err(e) = compress_result {
@@ -602,40 +516,25 @@ pub(crate) async fn mid_turn_compact_and_respawn(
     }
 
     // 4. Respawn on the compacted history with the continuation prompt.
-    #[cfg(feature = "mcp")]
-    let mcp_ref = ensure_mcp_manager(mcp_manager, cfg).await;
-    ensure_agent(
-        agent,
-        client,
-        session,
-        cli,
-        cfg,
-        context,
-        permission,
-        ask_tx,
-        sandbox,
-        reasoning_enabled,
-        #[cfg(feature = "mcp")]
-        mcp_ref,
-    )
-    .await;
-    let history = crate::agent::runner::convert_history(session);
-    let runner = agent
+    ensure_agent(&mut run.agent, ui, slash.reasoning_enabled).await;
+    let history = crate::agent::runner::convert_history(ui.session);
+    let runner = run
+        .agent
         .as_ref()
         .unwrap()
         .clone()
         .spawn_runner(
             MID_TURN_CONTINUE_PROMPT.to_string(),
             history,
-            cfg.retry.clone(),
+            ui.cfg.retry.clone(),
             #[cfg(feature = "hooks")]
             None,
         )
         .await;
-    *agent_rx = Some(runner.event_rx);
-    *main_abort = Some(runner.abort_handle);
-    *is_running = true;
-    if let Some(ss) = status_signals.as_ref() {
+    run.agent_rx = Some(runner.event_rx);
+    run.main_abort = Some(runner.abort_handle);
+    run.is_running = true;
+    if let Some(ss) = ui.status_signals.as_ref() {
         ss.send_start();
     }
     Ok(())
@@ -647,34 +546,24 @@ pub(crate) async fn mid_turn_compact_and_respawn(
 /// space), so compacting again is futile. Aborts the run and shows the user the
 /// full arithmetic — the model and context-window combination is simply too
 /// small to run the agentic loop on this task.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn stop_turn_context_exhausted(
     prompt_tokens: u64,
     threshold: f64,
     renderer: &mut Renderer,
-    session: &Session,
-    cfg: &Config,
-    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
-    main_abort: &mut Option<tokio::task::AbortHandle>,
-    is_running: &mut bool,
-    status_signals: &Option<StatusSignals>,
-    turn_trace: &mut Vec<compact_str::CompactString>,
-    response_buf: &mut String,
-    response_start_block: &mut Option<usize>,
-    agent_line_started: &mut bool,
-    was_reasoning: &mut bool,
+    ui: &UiContext,
+    run: &mut AgentRunState,
 ) -> anyhow::Result<()> {
-    if let Some(h) = main_abort.take() {
+    if let Some(h) = run.main_abort.take() {
         h.abort();
     }
-    *is_running = false;
-    *agent_rx = None;
-    *was_reasoning = false;
-    *agent_line_started = false;
-    turn_trace.clear();
-    response_buf.clear();
-    *response_start_block = None;
-    if let Some(ss) = status_signals.as_ref() {
+    run.is_running = false;
+    run.agent_rx = None;
+    run.was_reasoning = false;
+    run.agent_line_started = false;
+    run.turn_trace.clear();
+    run.response_buf.clear();
+    run.response_start_block = None;
+    if let Some(ss) = ui.status_signals.as_ref() {
         ss.send_stop();
     }
 
@@ -690,9 +579,10 @@ pub(crate) fn stop_turn_context_exhausted(
     for line in context_exhausted_report(
         prompt_tokens,
         threshold,
-        session.context_window,
-        cfg.resolve_reserve_tokens(&session.model, &crate::config::quick_models_map(cfg)),
-        cfg.resolve_keep_recent_tokens(),
+        ui.session.context_window,
+        ui.cfg
+            .resolve_reserve_tokens(&ui.session.model, &crate::config::quick_models_map(ui.cfg)),
+        ui.cfg.resolve_keep_recent_tokens(),
     ) {
         renderer.write_line(&line, Color::White)?;
     }
@@ -743,35 +633,18 @@ pub(crate) fn context_exhausted_report(
     ]
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn run_interactive(
-    client: AnyClient,
+    ui: UiContext<'_>,
     agent: Option<AnyAgent>,
-    cli: &Cli,
-    cfg: &Config,
-    session: &mut Session,
-    context: &mut ContextFiles,
-    permission: Option<PermCheck>,
-    ask_tx: Option<AskSender>,
     ask_rx: Option<AskReceiver>,
-    sandbox: Sandbox,
     auto_trigger_msg: Option<String>,
-    status_signals: Option<StatusSignals>,
     #[cfg(feature = "advisor")] handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
 ) -> anyhow::Result<()> {
     let mut app = app::App::new(
-        client,
+        ui,
         agent,
-        cli,
-        cfg,
-        session,
-        context,
-        permission,
-        ask_tx,
         ask_rx,
-        sandbox,
         auto_trigger_msg,
-        status_signals,
         #[cfg(feature = "advisor")]
         handoff_rx,
     )
@@ -785,13 +658,12 @@ pub(crate) async fn handle_human_handoff(
     req: crate::extras::advisor::HandoffRequest,
     renderer: &mut Renderer,
     user_rx: &mut mpsc::Receiver<UserEvent>,
-    agent_line_started: &mut bool,
-    was_reasoning: &mut bool,
+    run: &mut AgentRunState,
 ) -> anyhow::Result<()> {
-    *was_reasoning = false;
-    if *agent_line_started {
+    run.was_reasoning = false;
+    if run.agent_line_started {
         renderer.write_line("", Color::White)?;
-        *agent_line_started = false;
+        run.agent_line_started = false;
     }
 
     renderer.write_line("[handoff] Model requests your guidance:", C_HANDOFF)?;

--- a/src/ui/permission_handler.rs
+++ b/src/ui/permission_handler.rs
@@ -1,28 +1,24 @@
 use crossterm::style::Color;
 use tokio::sync::mpsc;
 
-use crate::cli::Cli;
 use crate::event::UserEvent;
-use crate::session::Session;
 use crate::ui::renderer::Renderer;
+use crate::ui::state::{AgentRunState, UiContext};
 use crate::ui::utils::suggest_pattern;
 
 use super::C_PERM;
 
-#[allow(clippy::too_many_arguments)]
 pub async fn handle_permission_request(
     ask_req: crate::permission::ask::AskRequest,
     renderer: &mut Renderer,
-    session: &mut Session,
-    cli: &Cli,
+    ui: &mut UiContext<'_>,
+    run: &mut AgentRunState,
     user_rx: &mut mpsc::Receiver<UserEvent>,
-    agent_line_started: &mut bool,
-    was_reasoning: &mut bool,
 ) -> anyhow::Result<()> {
-    *was_reasoning = false;
-    if *agent_line_started {
+    run.was_reasoning = false;
+    if run.agent_line_started {
         renderer.write_line("", Color::White)?;
-        *agent_line_started = false;
+        run.agent_line_started = false;
     }
 
     renderer.write_line(
@@ -76,14 +72,14 @@ pub async fn handle_permission_request(
             &format!("  allowed {} {} (saved to session)", ask_req.tool, pattern),
             Color::Green,
         )?;
-        session
+        ui.session
             .permission_allowlist
             .push(crate::session::PermissionAllowEntry {
                 tool: ask_req.tool.clone(),
                 pattern: pattern.into(),
             });
-        if !cli.no_session {
-            let _ = crate::session::storage::save_session(session);
+        if !ui.cli.no_session {
+            let _ = crate::session::storage::save_session(ui.session);
         }
     }
 

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -26,6 +26,7 @@ use crate::session::{MessageRole, Session};
 use crate::ui::events::render_session;
 use crate::ui::input::InputEditor;
 use crate::ui::renderer::Renderer;
+use crate::ui::state::{AgentRunState, ChainState, SlashState, UiContext};
 
 pub(crate) const C_AGENT: crossterm::style::Color = crossterm::style::Color::White;
 pub(crate) const C_RESULT: crossterm::style::Color = crossterm::style::Color::DarkGrey;
@@ -214,47 +215,38 @@ impl SlashCtx<'_> {
 /// Free-function variant of [`SlashCtx::switch_to_prompt_model`] for call
 /// sites that don't have a `SlashCtx` (dot commands, chain transitions,
 /// startup). Returns `true` if a model switch occurred.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_prompt_model(
     prompt_name: &str,
-    cfg: &Config,
-    cli: &Cli,
-    client: &mut AnyClient,
-    session: &mut Session,
+    ui: &mut UiContext<'_>,
     agent: &mut Option<AnyAgent>,
-    context: &ContextFiles,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
     reasoning_enabled: bool,
     renderer: &mut Renderer,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
 ) -> bool {
-    let qm_name = match cfg.resolve_prompt_model(prompt_name) {
+    let qm_name = match ui.cfg.resolve_prompt_model(prompt_name) {
         Some(name) => name,
         None => return false,
     };
 
-    let qm = crate::config::quick_models_map(cfg);
+    let qm = crate::config::quick_models_map(ui.cfg);
     let Some(qmc) = qm.get(qm_name) else {
         return false;
     };
 
     let new_model = compact_str::CompactString::from(&*qmc.model);
-    let provider_changed = qmc.provider != session.provider;
+    let provider_changed = qmc.provider != ui.session.provider;
 
-    session.model = new_model.clone();
+    ui.session.model = new_model.clone();
 
     if provider_changed {
         match crate::provider::create_client(
             &qmc.provider,
-            cli.api_key.as_deref(),
-            &cfg.custom_providers_map(),
-            cfg.api_keys.as_ref(),
+            ui.cli.api_key.as_deref(),
+            &ui.cfg.custom_providers_map(),
+            ui.cfg.api_keys.as_ref(),
         ) {
             Ok(new_client) => {
-                *client = new_client;
-                session.provider = compact_str::CompactString::from(&*qmc.provider);
+                ui.client = new_client;
+                ui.session.provider = compact_str::CompactString::from(&*qmc.provider);
                 // Fall through to rebuild agent below
             }
             Err(e) => {
@@ -270,39 +262,40 @@ pub(crate) async fn apply_prompt_model(
         }
     }
 
-    let model = client.completion_model(new_model.to_string());
-    let temperature = crate::config::resolve_temperature(cli, cfg, &new_model);
-    let extra_body = crate::config::resolve_extra_body(cfg, &new_model);
+    let model = ui.client.completion_model(new_model.to_string());
+    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &new_model);
+    let extra_body = crate::config::resolve_extra_body(ui.cfg, &new_model);
     #[cfg(feature = "advisor")]
     {
-        crate::extras::advisor::update_client(client.clone());
-        crate::extras::advisor::set_session_messages(session.messages.clone());
+        crate::extras::advisor::update_client(ui.client.clone());
+        crate::extras::advisor::set_session_messages(ui.session.messages.clone());
     }
     *agent = Some(
         crate::provider::build_agent(
             model,
-            cli,
-            cfg,
-            context,
-            permission.clone(),
-            ask_tx.clone(),
-            sandbox.clone(),
+            ui.cli,
+            ui.cfg,
+            ui.context,
+            ui.permission.clone(),
+            ui.ask_tx.clone(),
+            ui.sandbox.clone(),
             reasoning_enabled,
             temperature,
             extra_body,
             #[cfg(feature = "mcp")]
-            mcp_manager,
+            ui.mcp_manager.as_ref(),
         )
         .await,
     );
 
-    session.input_token_cost = qmc.input_token_cost;
-    session.output_token_cost = qmc.output_token_cost;
-    session.update_context_window(cfg.resolve_context_window(
-        &session.provider,
-        &session.model,
-        &qm,
-    ));
+    ui.session.input_token_cost = qmc.input_token_cost;
+    ui.session.output_token_cost = qmc.output_token_cost;
+    ui.session
+        .update_context_window(ui.cfg.resolve_context_window(
+            &ui.session.provider,
+            &ui.session.model,
+            &qm,
+        ));
 
     let _ = renderer.write_line(
         &format!(
@@ -352,45 +345,36 @@ pub fn undo_last(session: &mut Session) -> usize {
     removed
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn handle_compress(
     instructions: Option<&str>,
     auto: bool,
     agent: &mut Option<AnyAgent>,
-    client: &mut AnyClient,
     renderer: &mut Renderer,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &mut ContextFiles,
+    ui: &mut UiContext<'_>,
     reasoning_enabled: bool,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    sandbox: &Sandbox,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
 ) -> anyhow::Result<()> {
     // Mirror the auto-compaction trigger's reserve exactly (including memory's
     // effective_reserve) so the budget gate here can never disagree with the
     // gate that decided to call us.
-    let qm = crate::config::quick_models_map(cfg);
+    let qm = crate::config::quick_models_map(ui.cfg);
     #[cfg(feature = "memory")]
     let reserve = crate::extras::memory::effective_reserve(
-        cfg.resolve_reserve_tokens(&session.model, &qm),
-        context.memory.as_deref(),
+        ui.cfg.resolve_reserve_tokens(&ui.session.model, &qm),
+        ui.context.memory.as_deref(),
     );
     #[cfg(not(feature = "memory"))]
-    let reserve = cfg.resolve_reserve_tokens(&session.model, &qm);
-    let keep_recent = cfg.resolve_keep_recent_tokens();
-    let max_tokens = session.context_window.saturating_sub(reserve);
+    let reserve = ui.cfg.resolve_reserve_tokens(&ui.session.model, &qm);
+    let keep_recent = ui.cfg.resolve_keep_recent_tokens();
+    let max_tokens = ui.session.context_window.saturating_sub(reserve);
 
     // Auto-compaction only makes sense when actually over budget; manual
     // /compress is the user's explicit intent, so it skips the budget gate and
     // proceeds regardless of how full the context is.
-    if auto && session.effective_context_tokens() <= max_tokens {
+    if auto && ui.session.effective_context_tokens() <= max_tokens {
         return Ok(());
     }
 
-    let cut_idx = crate::session::Session::select_compaction_cut(&session.messages, keep_recent);
+    let cut_idx = crate::session::Session::select_compaction_cut(&ui.session.messages, keep_recent);
 
     // Nothing old enough to summarize (everything is within keep_recent). This
     // is a real physical limit even when forced, so report it for manual runs;
@@ -411,12 +395,13 @@ pub async fn handle_compress(
     }
     renderer.write_line("", crossterm::style::Color::White)?;
 
-    let messages_to_summarize = &session.messages[..cut_idx];
-    let previous_summary = session.compactions.last().map(|c| c.summary.as_str());
+    let messages_to_summarize = &ui.session.messages[..cut_idx];
+    let previous_summary = ui.session.compactions.last().map(|c| c.summary.as_str());
 
-    let summary = client
+    let summary = ui
+        .client
         .compress_messages(
-            &session.model,
+            &ui.session.model,
             messages_to_summarize,
             previous_summary,
             instructions,
@@ -434,30 +419,30 @@ pub async fn handle_compress(
         &summary,
         Some(cut_idx), // = first_kept_index: how many messages were summarized
     );
-    session.compress(summary, cut_idx, tokens_before);
+    ui.session.compress(summary, cut_idx, tokens_before);
 
-    let model = client.completion_model(session.model.to_string());
-    let temperature = crate::config::resolve_temperature(cli, cfg, &session.model);
-    let extra_body = crate::config::resolve_extra_body(cfg, &session.model);
+    let model = ui.client.completion_model(ui.session.model.to_string());
+    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
+    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
     *agent = Some(
         crate::provider::build_agent(
             model,
-            cli,
-            cfg,
-            context,
-            permission.clone(),
-            ask_tx.clone(),
-            sandbox.clone(),
+            ui.cli,
+            ui.cfg,
+            ui.context,
+            ui.permission.clone(),
+            ui.ask_tx.clone(),
+            ui.sandbox.clone(),
             reasoning_enabled,
             temperature,
             extra_body,
             #[cfg(feature = "mcp")]
-            mcp_manager,
+            ui.mcp_manager.as_ref(),
         )
         .await,
     );
 
-    render_session(renderer, session, cli, cfg, context)?;
+    render_session(renderer, ui.session, ui.cli, ui.cfg, ui.context)?;
     renderer.write_line(
         &format!(
             "compressed {} messages (saved ~{} tokens)",
@@ -469,48 +454,40 @@ pub async fn handle_compress(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn handle_slash(
     text: &str,
-    agent: &mut Option<AnyAgent>,
-    client: &mut AnyClient,
     renderer: &mut Renderer,
-    session: &mut Session,
-    cli: &Cli,
-    cfg: &Config,
-    context: &mut ContextFiles,
-    show_reasoning: &mut bool,
-    reasoning_enabled: &mut bool,
-    is_running: &mut bool,
     input: &mut InputEditor,
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    todo_tools_enabled: &mut bool,
-    sandbox: &Sandbox,
-    #[cfg(feature = "loop")] loop_state: &mut Option<crate::extras::r#loop::LoopState>,
-    #[cfg(feature = "mcp")] mcp_manager: Option<&crate::extras::mcp::McpClientManager>,
+    run: &mut AgentRunState,
+    ui: &mut UiContext<'_>,
+    slash: &mut SlashState,
+    chain: &mut ChainState,
 ) -> anyhow::Result<()> {
+    // `chain` only feeds `SlashCtx::loop_state`; without the loop feature it
+    // has no consumer here.
+    #[cfg(not(feature = "loop"))]
+    let _ = &chain;
     let parts: SmallVec<[&str; 3]> = text.trim().splitn(3, ' ').collect();
     let mut ctx = SlashCtx {
-        agent,
-        client,
+        agent: &mut run.agent,
+        client: &mut ui.client,
         renderer,
-        session,
-        cli,
-        cfg,
-        context,
-        show_reasoning,
-        reasoning_enabled,
-        is_running,
+        session: ui.session,
+        cli: ui.cli,
+        cfg: ui.cfg,
+        context: ui.context,
+        show_reasoning: &mut slash.show_reasoning,
+        reasoning_enabled: &mut slash.reasoning_enabled,
+        is_running: &mut run.is_running,
         input,
-        permission,
-        ask_tx,
-        todo_tools_enabled,
-        sandbox,
+        permission: &ui.permission,
+        ask_tx: &ui.ask_tx,
+        todo_tools_enabled: &mut slash.todo_tools_enabled,
+        sandbox: &ui.sandbox,
         #[cfg(feature = "loop")]
-        loop_state,
+        loop_state: &mut chain.loop_state,
         #[cfg(feature = "mcp")]
-        mcp_manager,
+        mcp_manager: ui.mcp_manager.as_ref(),
     };
 
     match parts[0] {

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,0 +1,133 @@
+//! Grouped TUI state. The `App` used to carry ~40 flat fields and pass 10-20
+//! of them into every helper; these structs group that state by lifetime and
+//! purpose so helpers take a handful of coherent bundles instead.
+
+use std::collections::VecDeque;
+
+use tokio::sync::mpsc;
+
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::context::ContextFiles;
+use crate::event::AgentEvent;
+#[cfg(feature = "mcp")]
+use crate::extras::mcp::McpClientManager;
+use crate::extras::status_signals::StatusSignals;
+use crate::permission::ask::AskSender;
+use crate::permission::checker::PermCheck;
+use crate::provider::{AnyAgent, AnyClient};
+use crate::sandbox::Sandbox;
+use crate::session::Session;
+
+/// Shared resources every part of the TUI reaches for: static config, the
+/// session, context files, the provider client, and the capability handles
+/// needed to (re)build agents.
+pub(crate) struct UiContext<'a> {
+    pub cli: &'a Cli,
+    pub cfg: &'a Config,
+    pub session: &'a mut Session,
+    pub context: &'a mut ContextFiles,
+    pub client: AnyClient,
+    pub permission: Option<PermCheck>,
+    pub ask_tx: Option<AskSender>,
+    pub sandbox: Sandbox,
+    pub status_signals: Option<StatusSignals>,
+    #[cfg(feature = "mcp")]
+    pub mcp_manager: Option<McpClientManager>,
+}
+
+impl<'a> UiContext<'a> {
+    /// Composition root: built once in `main` and threaded through the TUI.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        cli: &'a Cli,
+        cfg: &'a Config,
+        session: &'a mut Session,
+        context: &'a mut ContextFiles,
+        client: AnyClient,
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        sandbox: Sandbox,
+        status_signals: Option<StatusSignals>,
+    ) -> Self {
+        Self {
+            cli,
+            cfg,
+            session,
+            context,
+            client,
+            permission,
+            ask_tx,
+            sandbox,
+            status_signals,
+            #[cfg(feature = "mcp")]
+            mcp_manager: None,
+        }
+    }
+}
+
+/// Transient state of the main agent run: the agent handle, its event
+/// stream and abort handle, queued user input, and streaming-response scratch.
+#[derive(Default)]
+pub(crate) struct AgentRunState {
+    pub agent: Option<AnyAgent>,
+    pub is_running: bool,
+    pub agent_rx: Option<mpsc::Receiver<AgentEvent>>,
+    pub main_abort: Option<tokio::task::AbortHandle>,
+    pub pending_inputs: VecDeque<String>,
+    pub agent_line_started: bool,
+    pub response_buf: String,
+    pub response_start_block: Option<usize>,
+    pub pending_send: Option<String>,
+    pub was_reasoning: bool,
+    pub turn_trace: Vec<compact_str::CompactString>,
+    pub awaiting_compaction_relief: bool,
+}
+
+/// What happens when the current run finishes: chained prompts, dot-prompt
+/// restore, /loop iterations, and worktree-merge returns.
+#[derive(Default)]
+pub(crate) struct ChainState {
+    pub pending: Option<crate::extras::chain::ChainPhase>,
+    pub label_msg: Option<String>,
+    pub dot_prompt_restore: Option<String>,
+    pub loop_label: Option<String>,
+    #[cfg(feature = "loop")]
+    pub loop_state: Option<crate::extras::r#loop::LoopState>,
+    #[cfg(feature = "git-worktree")]
+    pub wt_return_path: Option<(String, String, String, bool)>,
+}
+
+/// User-facing feature toggles owned by slash commands.
+pub(crate) struct SlashState {
+    pub show_reasoning: bool,
+    pub reasoning_enabled: bool,
+    pub todo_tools_enabled: bool,
+}
+
+/// Provider-reported token usage for one finished turn.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TurnUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+}
+
+/// /btw aggregate stats shown in the statusline.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct BtwStats {
+    pub cost: f64,
+    pub input: u64,
+    pub output: u64,
+}
+
+/// Parameters for a worktree merge-and-return run.
+#[cfg(feature = "git-worktree")]
+pub(crate) struct MergeRequest<'a> {
+    pub branch: &'a str,
+    pub target: &'a str,
+    pub main_path: &'a str,
+    pub wt_path: &'a str,
+    pub force: bool,
+}


### PR DESCRIPTION
Implements the 3rd item of the **Architecture** checklist in #186:

> Group related state into structs: `AgentRunState`, `UiContext`, `ChainState`, `SlashState`. Replace the 10-20 parameter functions.

## Changes

- **New `src/ui/state.rs`**: `UiContext` (shared config/session/client/capability handles), `AgentRunState` (agent handle, event stream, abort handle, queued input, streaming scratch), `ChainState` (chain/loop/worktree post-run transitions), `SlashState` (slash-owned feature toggles), plus small `TurnUsage`/`BtwStats`/`MergeRequest` carriers.
- **`App` regrouped**: the ~40 flat fields are now `ui` / `run` / `chain` / `slash` plus the infra fields that stay flat (renderer, input, `btw_*`, channels, event thread).
- **Long parameter lists replaced** (old → new arity):
  | function | before | after |
  |---|---|---|
  | `handle_agent_done` | 26 | 6 |
  | `handle_agent_event` | 23 | 6 |
  | `mid_turn_compact_and_respawn` | 22 | 5 |
  | `spawn_merge_agent` | 21 | 4 |
  | `start_main_run` / `handle_slash` | 18 | 5 / 7 |
  | `handle_compress` / `stop_turn_context_exhausted` | 14 | 6 / 5 |
  | `apply_prompt_model` / `run_interactive` | 13 | 5 |
  | `refresh_display` | 11 | 6 |
- **Bonus simplification**: the two cfg-split `ensure_agent` variants collapse into one that performs the MCP lazy-init itself, removing the repeated `ensure_mcp_manager` dance at every call site. MCP now connects on first actual agent build instead of eagerly per call site (same connect-on-first-use semantics).
- `SlashCtx` is deliberately left flat and is constructed from the new groups, so **all slash submodule files are untouched**.
- All `#[allow(clippy::too_many_arguments)]` on these functions removed (one remains on the `UiContext::new` composition-root constructor).

Out of scope (other checklist items): `DEFER_*` string control flow, rebuild centralization, renderer perf, `!command` gating, `open_in_editor`.

## Verification

- `cargo fmt --check` ✅
- `cargo test --locked` ✅ (603 passed)
- `cargo test --locked --no-default-features` ✅ (505 passed)
- `cargo test --locked --all-features` ✅ (807 passed)
- `cargo clippy --locked --no-default-features -- -D warnings` ✅
- `cargo clippy --locked --all-features -- -D warnings` ✅
- `cargo install --locked --path . --debug` ✅

Refs #186