### PR TITLE
fix(ui): coalesce paste bursts so multi-line paste lands as one block

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,7 +54,7 @@ CLI parse (main.rs:150) → config load → context load → session load
 ### Interactive TUI Event Loop (`src/ui/mod.rs`)
 
 Single `tokio::select!` with 6 branches plus an `else` fallback (line 1119):
-1. **`UserEvent` from `user_rx`** — keyboard/mouse/resize/paste from background event thread (polls crossterm every 50ms)
+1. **`UserEvent` from `user_rx`** — keyboard/mouse/resize/paste from background event thread (polls crossterm every 50ms idle, 10ms while coalescing a paste burst)
 2. **Background agent prebuild** from `prebuild_rx` — consumed once idle, so MCP connection notices land in the transcript instead of racing the alt-screen TUI
 3. **`AgentEvent` from `agent_rx`** — streaming LLM tokens, tool calls, errors
 4. **Permission `AskRequest` from `ask_rx`** — user must approve/reject tool calls

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -51,6 +51,8 @@ mod multimodal_tests;
 #[cfg(test)]
 mod normalize_tests;
 #[cfg(test)]
+mod paste_burst_tests;
+#[cfg(test)]
 mod picker_tests;
 #[cfg(test)]
 mod provider_tests;

--- a/src/tests/paste_burst_tests.rs
+++ b/src/tests/paste_burst_tests.rs
@@ -1,0 +1,65 @@
+use crate::ui::{EnterVerdict, PasteBurst, is_paste_newline_key};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+#[test]
+fn paste_newline_keys() {
+    // Bare Enter (Windows conhost injects VK_RETURN for pasted newlines).
+    assert!(is_paste_newline_key(KeyCode::Enter, KeyModifiers::NONE));
+    // Ctrl+J is how crossterm reports a raw pasted '\n' on Unix in raw mode.
+    assert!(is_paste_newline_key(
+        KeyCode::Char('j'),
+        KeyModifiers::CONTROL
+    ));
+    // Deliberate key combinations are not paste newlines.
+    assert!(!is_paste_newline_key(KeyCode::Enter, KeyModifiers::SHIFT));
+    assert!(!is_paste_newline_key(KeyCode::Enter, KeyModifiers::ALT));
+    assert!(!is_paste_newline_key(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE
+    ));
+    assert!(!is_paste_newline_key(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL
+    ));
+    assert!(!is_paste_newline_key(
+        KeyCode::Char('j'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT
+    ));
+}
+
+#[test]
+fn genuine_enter_is_submit() {
+    let mut burst = PasteBurst::default();
+    assert_eq!(burst.on_enter(false), EnterVerdict::Submit);
+    assert_eq!(burst.on_enter(false), EnterVerdict::Submit);
+}
+
+#[test]
+fn enter_with_pending_input_starts_burst() {
+    let mut burst = PasteBurst::default();
+    // First pasted newline: more input is queued right behind the Enter.
+    assert_eq!(burst.on_enter(true), EnterVerdict::Newline);
+    // Mid-burst Enters are newlines even when nothing is momentarily queued
+    // (the trailing newline of a paste must not submit).
+    assert_eq!(burst.on_enter(false), EnterVerdict::Newline);
+    assert_eq!(burst.on_enter(false), EnterVerdict::Newline);
+}
+
+#[test]
+fn burst_ends_after_input_goes_quiet() {
+    let mut burst = PasteBurst::default();
+    assert_eq!(burst.on_enter(true), EnterVerdict::Newline);
+    burst.on_timeout();
+    assert_eq!(burst.on_enter(false), EnterVerdict::Submit);
+}
+
+#[test]
+fn wait_timeout_shortens_during_burst() {
+    let mut burst = PasteBurst::default();
+    let idle = burst.wait_timeout();
+    assert_eq!(burst.on_enter(true), EnterVerdict::Newline);
+    let active = burst.wait_timeout();
+    assert!(active < idle);
+    burst.on_timeout();
+    assert_eq!(burst.wait_timeout(), idle);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crossterm::event;
-use crossterm::event::{KeyEventKind, MouseButton, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
 use crossterm::style::Color;
 use tokio::sync::mpsc;
 
@@ -111,61 +111,161 @@ pub(crate) fn refresh_display(
     Ok(())
 }
 
+/// Idle cadence of the event thread's poll loop.
+const IDLE_POLL: Duration = Duration::from_millis(50);
+
+/// How far ahead the event thread peeks after an `Enter`/`Ctrl+J` to decide
+/// whether it is really a pasted newline, and how long it waits for the next
+/// event before declaring a paste burst over. Terminals WITHOUT
+/// bracketed-paste support (common on Windows conhost and some SSH/tmux
+/// chains) deliver a multi-line paste as a rapid stream of key events whose
+/// newlines arrive as `KeyCode::Enter` (`VK_RETURN` on Windows, `\r` on
+/// Unix) or `Ctrl+J` (raw `\n` on Unix); without coalescing, each pasted
+/// line would be submitted/queued separately or gain literal `j`s (#197).
+/// 10 ms is far below the time a human needs to press another key after
+/// `Enter`, so genuine submits are unaffected.
+const PASTE_BURST_WINDOW: Duration = Duration::from_millis(10);
+
+/// What a plain `Enter` keypress means in the current input stream.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum EnterVerdict {
+    /// Genuine submit: no burst in progress and no input queued behind it.
+    Submit,
+    /// Pasted newline: mid-burst, or more input is already queued behind it.
+    Newline,
+}
+
+/// Whether a key event is a candidate pasted newline: a bare `Enter`
+/// (Windows conhost injects `VK_RETURN` records for pasted newlines, and
+/// `\r` maps to `Enter` on Unix), or `Ctrl+J` — which is how crossterm
+/// reports a raw pasted `\n` byte on Unix in raw mode (crossterm issue
+/// #371). `Enter`/`j` with any other modifier combo is a deliberate key
+/// combination and passes through untouched.
+pub(crate) fn is_paste_newline_key(code: KeyCode, modifiers: KeyModifiers) -> bool {
+    (code == KeyCode::Enter && modifiers == KeyModifiers::NONE)
+        || (code == KeyCode::Char('j') && modifiers == KeyModifiers::CONTROL)
+}
+
+/// Paste-burst state for terminals without bracketed paste. A burst starts
+/// when a paste-newline key (see [`is_paste_newline_key`]) has more input
+/// queued right behind it, and ends once the input stream goes quiet for
+/// [`PASTE_BURST_WINDOW`]. While a burst is active every such key is a pasted
+/// newline, never a submit (and never a literal `j`) — so a multi-line paste
+/// lands in the input buffer whole instead of submitting line by line (#197).
+/// Pure state machine so it can be unit-tested without a terminal.
+#[derive(Default)]
+pub(crate) struct PasteBurst {
+    active: bool,
+}
+
+impl PasteBurst {
+    /// Poll timeout for the next event: short while a burst is alive so its
+    /// end is detected quickly, idle cadence otherwise.
+    pub(crate) fn wait_timeout(&self) -> Duration {
+        if self.active {
+            PASTE_BURST_WINDOW
+        } else {
+            IDLE_POLL
+        }
+    }
+
+    /// No event arrived within the window: any burst in progress is over.
+    pub(crate) fn on_timeout(&mut self) {
+        self.active = false;
+    }
+
+    /// Classify a plain `Enter` press and update burst state.
+    /// `more_input_pending` is the result of peeking [`PASTE_BURST_WINDOW`]
+    /// ahead (callers skip the peek when a burst is already active).
+    pub(crate) fn on_enter(&mut self, more_input_pending: bool) -> EnterVerdict {
+        if self.active || more_input_pending {
+            self.active = true;
+            EnterVerdict::Newline
+        } else {
+            EnterVerdict::Submit
+        }
+    }
+}
+
 pub(crate) fn spawn_event_thread(
     user_tx: mpsc::Sender<UserEvent>,
     running: Arc<AtomicBool>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
+        let mut paste_burst = PasteBurst::default();
         while running.load(Ordering::Relaxed) {
-            if let Ok(true) = event::poll(Duration::from_millis(50)) {
-                match event::read() {
-                    Ok(event::Event::Key(key)) => {
-                        if key.kind == KeyEventKind::Press
-                            && user_tx.blocking_send(UserEvent::Key(key)).is_err()
-                        {
+            let Ok(ready) = event::poll(paste_burst.wait_timeout()) else {
+                continue;
+            };
+            if !ready {
+                paste_burst.on_timeout();
+                continue;
+            }
+            match event::read() {
+                Ok(event::Event::Key(key)) => {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    // A paste-newline key (bare Enter, or Ctrl+J — a raw
+                    // pasted '\n' on Unix) is either a submit/normal key or
+                    // — during a paste burst — a pasted newline (see
+                    // PasteBurst). Enter/j with other modifiers passes
+                    // through (Shift/Alt+Enter = literal newline).
+                    let ev = if is_paste_newline_key(key.code, key.modifiers) {
+                        let pending = paste_burst.active
+                            || matches!(event::poll(PASTE_BURST_WINDOW), Ok(true));
+                        match paste_burst.on_enter(pending) {
+                            EnterVerdict::Submit => UserEvent::Key(key),
+                            // Reuse the paste path: inserts a literal '\n'
+                            // into the input buffer.
+                            EnterVerdict::Newline => UserEvent::Paste("\n".to_string()),
+                        }
+                    } else {
+                        UserEvent::Key(key)
+                    };
+                    if user_tx.blocking_send(ev).is_err() {
+                        break;
+                    }
+                }
+                Ok(event::Event::Mouse(m)) => match m.kind {
+                    MouseEventKind::ScrollUp => {
+                        if user_tx.blocking_send(UserEvent::ScrollUp).is_err() {
                             break;
                         }
                     }
-                    Ok(event::Event::Mouse(m)) => match m.kind {
-                        MouseEventKind::ScrollUp => {
-                            if user_tx.blocking_send(UserEvent::ScrollUp).is_err() {
-                                break;
-                            }
+                    MouseEventKind::ScrollDown => {
+                        if user_tx.blocking_send(UserEvent::ScrollDown).is_err() {
+                            break;
                         }
-                        MouseEventKind::ScrollDown => {
-                            if user_tx.blocking_send(UserEvent::ScrollDown).is_err() {
-                                break;
-                            }
-                        }
-                        MouseEventKind::Down(MouseButton::Left) => {
-                            let _ = user_tx.blocking_send(UserEvent::MouseDown {
-                                row: m.row,
-                                col: m.column,
-                            });
-                        }
-                        MouseEventKind::Drag(MouseButton::Left) => {
-                            let _ = user_tx.blocking_send(UserEvent::MouseDrag {
-                                row: m.row,
-                                col: m.column,
-                            });
-                        }
-                        MouseEventKind::Up(MouseButton::Left) => {
-                            let _ = user_tx.blocking_send(UserEvent::MouseUp {
-                                row: m.row,
-                                col: m.column,
-                            });
-                        }
-                        _ => {}
-                    },
-                    Ok(event::Event::Resize(_cols, _rows)) => {
-                        let _ = user_tx.blocking_send(UserEvent::Resize);
                     }
-                    Ok(event::Event::Paste(data)) => {
-                        let _ = user_tx.blocking_send(UserEvent::Paste(data));
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        let _ = user_tx.blocking_send(UserEvent::MouseDown {
+                            row: m.row,
+                            col: m.column,
+                        });
                     }
-                    Err(_) => break,
+                    MouseEventKind::Drag(MouseButton::Left) => {
+                        let _ = user_tx.blocking_send(UserEvent::MouseDrag {
+                            row: m.row,
+                            col: m.column,
+                        });
+                    }
+                    MouseEventKind::Up(MouseButton::Left) => {
+                        let _ = user_tx.blocking_send(UserEvent::MouseUp {
+                            row: m.row,
+                            col: m.column,
+                        });
+                    }
                     _ => {}
+                },
+                Ok(event::Event::Resize(_cols, _rows)) => {
+                    let _ = user_tx.blocking_send(UserEvent::Resize);
                 }
+                Ok(event::Event::Paste(data)) => {
+                    let _ = user_tx.blocking_send(UserEvent::Paste(data));
+                }
+                Err(_) => break,
+                _ => {}
             }
         }
     })


### PR DESCRIPTION
Fixes #197.

## Problem

On terminals **without bracketed-paste support**, a multi-line paste arrives as a rapid stream of ordinary key events instead of one `Event::Paste`. Each pasted newline was therefore handled as a submit: the first line ran and the rest were queued.

Verified against the vendored crossterm 0.29.0 source:

- **Windows (the reporter's setup)**: crossterm 0.29 has *no* `Event::Paste` path at all — conhost injects `VK_RETURN` key records, which crossterm maps to `KeyCode::Enter` with empty modifiers (`event/sys/windows/parse.rs`). So every pasted newline submitted a line.
- **Unix raw mode**: a pasted `\n` byte does *not* map to `Enter` (crossterm issue #371) — it maps to `KeyCode::Char('j') + CONTROL`, which fell through to the plain char arm and inserted a literal `j` into the input.
- Unix terminals *with* bracketed paste (a default crossterm feature, enabled here) already worked and are untouched.

## Fix

The background event thread (`src/ui/mod.rs`) now runs a small `PasteBurst` state machine:

- A **paste-newline key** (bare `Enter`, or `Ctrl+J` — via the pure `is_paste_newline_key` predicate) with more input queued within **10 ms** starts a burst.
- While the burst lasts, those keys become `UserEvent::Paste("\n")` (the existing paste path inserts a literal newline into the buffer) instead of submits.
- The burst ends after 10 ms of quiet; the trailing newline of a paste never submits.

Why this is safe: 10 ms is far below human inter-key latency after pressing `Enter`, so genuine submits are unaffected; `Shift`/`Alt`+`Enter` (literal newline) and all other Ctrl bindings pass through unchanged; bracketed-paste terminals take the exact same code path as before.

## Verification

- `cargo fmt --check` ✅
- `cargo test --locked` ✅ (608 passed, incl. 5 new `paste_burst_tests`)
- `cargo test --locked --no-default-features` ✅ (510 passed)
- `cargo test --locked --all-features` ✅ (812 passed)
- `cargo clippy --locked --no-default-features -- -D warnings` ✅
- `cargo clippy --locked --all-features -- -D warnings` ✅
- `cargo install --locked --path . --debug` ✅

## Smoke test wanted 🙏

The Windows conhost path is verified by crossterm source analysis, not on real hardware — I don't have a Windows machine. @swork1 (or anyone on Windows 11): could you build this branch and confirm that pasting the multi-line text from the issue now lands in the input as one block (and that a normal `Enter` still submits)?

```
git fetch https://github.com/wowi42/zerostack.git fix-197-multiline-paste && git checkout FETCH_HEAD
cargo install --locked --path . --debug
```
