### PR TITLE
feat(ui): sort prompt list alphabetically and show each prompt's source

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -93,7 +93,7 @@ starting a session or making a model call. See
 
 | Command | Description |
 | ------- | ----------- |
-| `/prompt` | List available prompts. |
+| `/prompt` | List available prompts, sorted alphabetically, each tagged with its source (`built-in`, `global`, `local`). The `/prompt` and `.` pickers show the same tags. |
 | `/prompt <name>` | Activate a named prompt. Also applies `%%mode=` from the prompt file if present (see below). |
 | `/prompt default` | Clear the active prompt. |
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -17,14 +17,14 @@ overriding earlier ones for same-named files:
 
 **Prompts** (priority low to high):
 1. Embedded at compile time
-2. `~/.local/share/zerostack/prompts/` (global, user-level)
-3. `prompts/` (project-local, relative to CWD)
+2. `$ZS_DATA_DIR/prompts/`, defaulting to `~/.local/share/zerostack/prompts/` (global, user-level)
+3. `data/prompts/` (project-local, relative to CWD)
 4. `.zerostack/prompts/` (project-level config, highest priority)
 
 **Themes** (priority low to high):
 1. Embedded at compile time
-2. `~/.local/share/zerostack/themes/` (global, user-level)
-3. `themes/` (project-local, relative to CWD)
+2. `$ZS_DATA_DIR/themes/`, defaulting to `~/.local/share/zerostack/themes/` (global, user-level)
+3. `data/themes/` (project-local, relative to CWD)
 
 If `ZS_CONFIG_DIR` is set, it overrides the data directory for the config file
 location only (prompts and themes still use `ZS_DATA_DIR` / the default data

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -57,6 +57,7 @@ pub(crate) fn copy_embedded_to(embedded: &Dir, dest: &Path) -> anyhow::Result<()
 pub struct ContextFiles {
     pub agents: Option<String>,
     pub prompts: HashMap<String, String>,
+    pub prompt_sources: HashMap<String, prompts::PromptSource>,
     pub current_prompt: Option<String>,
     pub current_prompt_name: Option<String>,
     pub themes: HashMap<String, String>,
@@ -78,7 +79,9 @@ impl ContextFiles {
         {
             self.architecture = walk_context_files().1;
         }
-        self.prompts = prompts::load();
+        let (prompt_map, prompt_sources) = prompts::load_with_sources();
+        self.prompts = prompt_map;
+        self.prompt_sources = prompt_sources;
         if let Some(name) = &self.current_prompt_name {
             self.current_prompt = self.prompts.get(name).cloned();
         }
@@ -103,7 +106,7 @@ pub fn load(no_context_files: bool) -> ContextFiles {
     let architecture = arch_candidate;
     #[cfg(not(feature = "archmd"))]
     let _ = arch_candidate;
-    let prompt_map = prompts::load();
+    let (prompt_map, prompt_sources) = prompts::load_with_sources();
     let theme_map = themes::load();
     let theme_name = crate::session::storage::load_theme_name();
     #[cfg(feature = "memory")]
@@ -111,6 +114,7 @@ pub fn load(no_context_files: bool) -> ContextFiles {
     ContextFiles {
         agents,
         prompts: prompt_map,
+        prompt_sources,
         current_prompt: None,
         current_prompt_name: None,
         themes: theme_map,

--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -5,6 +5,33 @@ use include_dir::{Dir, include_dir};
 
 static EMBEDDED: Dir = include_dir!("$CARGO_MANIFEST_DIR/data/prompts");
 
+/// Which source a prompt was loaded from. Later sources override earlier
+/// ones for same-named prompts, so each prompt's source is the
+/// highest-priority location that defines it (see `load_with_sources`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptSource {
+    /// Compiled into the binary (`data/prompts` at build time).
+    Embedded,
+    /// User-level data dir (`~/.local/share/zerostack/prompts/`).
+    Global,
+    /// Project-local `data/prompts/`, relative to the CWD.
+    DataDir,
+    /// Project-level `.zerostack/prompts/` (highest priority).
+    Project,
+}
+
+impl PromptSource {
+    /// Short tag shown next to the prompt name in pickers and `/prompt`.
+    /// Both project-level sources display as `local`.
+    pub fn label(&self) -> &'static str {
+        match self {
+            PromptSource::Embedded => "built-in",
+            PromptSource::Global => "global",
+            PromptSource::DataDir | PromptSource::Project => "local",
+        }
+    }
+}
+
 pub fn global_dir() -> PathBuf {
     crate::session::storage::data_dir().join("prompts")
 }
@@ -13,23 +40,32 @@ pub fn zerostack_dir() -> PathBuf {
     PathBuf::from(".zerostack/prompts")
 }
 
-pub fn load() -> HashMap<String, String> {
+/// Load all prompts together with the source each one came from. Sources are
+/// scanned in priority order (low to high); a later source overrides both the
+/// content and the provenance of a same-named prompt. Within the embedded
+/// set, the first file with a given name wins.
+pub fn load_with_sources() -> (HashMap<String, String>, HashMap<String, PromptSource>) {
     let mut prompts: HashMap<String, String> = HashMap::new();
+    let mut sources: HashMap<String, PromptSource> = HashMap::new();
 
     for (name, content) in crate::context::load_embedded_files(&EMBEDDED, "md") {
-        prompts.entry(name).or_insert(content);
+        prompts.entry(name.clone()).or_insert(content);
+        sources.entry(name).or_insert(PromptSource::Embedded);
     }
     for (name, content) in crate::context::load_dir_files(&global_dir(), "md") {
+        sources.insert(name.clone(), PromptSource::Global);
         prompts.insert(name, content);
     }
     for (name, content) in crate::context::load_dir_files(&PathBuf::from("data/prompts"), "md") {
+        sources.insert(name.clone(), PromptSource::DataDir);
         prompts.insert(name, content);
     }
     for (name, content) in crate::context::load_dir_files(&zerostack_dir(), "md") {
+        sources.insert(name.clone(), PromptSource::Project);
         prompts.insert(name, content);
     }
 
-    prompts
+    (prompts, sources)
 }
 
 pub fn ensure_global() -> anyhow::Result<()> {
@@ -96,7 +132,7 @@ mod tests {
         let dir = zerostack_dir();
         write_prompt(&dir, "myproject", "# My Project Prompt");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert!(prompts.contains_key("myproject"));
         assert_eq!(prompts["myproject"], "# My Project Prompt");
     }
@@ -109,7 +145,7 @@ mod tests {
         write_prompt(&prompts_dir, "code", "from prompts/");
         write_prompt(&zs_dir, "code", "from .zerostack/prompts/");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert_eq!(prompts["code"], "from .zerostack/prompts/");
     }
 
@@ -121,7 +157,7 @@ mod tests {
         write_prompt(&global, "code", "from global/");
         write_prompt(&zs_dir, "code", "from .zerostack/");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert_eq!(prompts["code"], "from .zerostack/");
     }
 
@@ -131,7 +167,7 @@ mod tests {
         let zs_dir = zerostack_dir();
         write_prompt(&zs_dir, "code", "from .zerostack/");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert_eq!(prompts["code"], "from .zerostack/");
     }
 
@@ -143,7 +179,7 @@ mod tests {
         write_prompt(&global, "custom", "from global/");
         write_prompt(&prompts_dir, "custom", "from prompts/");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert_eq!(prompts["custom"], "from prompts/");
     }
 
@@ -159,7 +195,7 @@ mod tests {
         write_prompt(&zs_dir, "custom", "from .zerostack/");
         write_prompt(&zs_dir, "code", "from .zerostack/code");
 
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert_eq!(prompts["code"], "from .zerostack/code");
         assert_eq!(prompts["custom"], "from .zerostack/");
         assert!(prompts.contains_key("ask"));
@@ -168,9 +204,59 @@ mod tests {
     #[test]
     fn test_zerostack_dir_missing_is_ok() {
         let _td = TestDir::new();
-        let prompts = load();
+        let prompts = load_with_sources().0;
         assert!(prompts.contains_key("code"));
         assert!(prompts.contains_key("ask"));
         assert!(prompts.contains_key("default"));
+    }
+
+    #[test]
+    fn test_source_labels() {
+        assert_eq!(PromptSource::Embedded.label(), "built-in");
+        assert_eq!(PromptSource::Global.label(), "global");
+        assert_eq!(PromptSource::DataDir.label(), "local");
+        assert_eq!(PromptSource::Project.label(), "local");
+    }
+
+    #[test]
+    fn test_embedded_prompt_source() {
+        let _td = TestDir::new();
+        let (_, sources) = load_with_sources();
+        assert_eq!(sources.get("code"), Some(&PromptSource::Embedded));
+    }
+
+    #[test]
+    fn test_global_override_source() {
+        let _td = TestDir::new();
+        write_prompt(&global_dir(), "code", "from global/");
+        let (prompts, sources) = load_with_sources();
+        assert_eq!(prompts["code"], "from global/");
+        assert_eq!(sources.get("code"), Some(&PromptSource::Global));
+    }
+
+    #[test]
+    fn test_data_dir_override_source() {
+        let _td = TestDir::new();
+        write_prompt(&PathBuf::from("data/prompts"), "code", "from data/");
+        let (_, sources) = load_with_sources();
+        assert_eq!(sources.get("code"), Some(&PromptSource::DataDir));
+    }
+
+    #[test]
+    fn test_project_override_source() {
+        let _td = TestDir::new();
+        write_prompt(&zerostack_dir(), "code", "from .zerostack/");
+        let (_, sources) = load_with_sources();
+        assert_eq!(sources.get("code"), Some(&PromptSource::Project));
+    }
+
+    #[test]
+    fn test_source_tracks_winning_override() {
+        let _td = TestDir::new();
+        write_prompt(&global_dir(), "mixed", "from global/");
+        write_prompt(&zerostack_dir(), "mixed", "from .zerostack/");
+        let (prompts, sources) = load_with_sources();
+        assert_eq!(prompts["mixed"], "from .zerostack/");
+        assert_eq!(sources.get("mixed"), Some(&PromptSource::Project));
     }
 }

--- a/src/tests/picker_tests.rs
+++ b/src/tests/picker_tests.rs
@@ -299,6 +299,28 @@ fn test_static_commands_prepopulated() {
     assert!(picker.matches.contains(&"/model".to_string()));
 }
 
+#[test]
+fn test_list_picker_annotations_not_in_filter_or_selection() {
+    let mut picker = ListPicker::new();
+    picker.set_items(vec!["alpha".to_string(), "beta".to_string()]);
+    picker.set_annotations(std::collections::HashMap::from([
+        ("alpha".to_string(), "built-in".to_string()),
+        ("beta".to_string(), ".zerostack".to_string()),
+    ]));
+    picker.activate();
+
+    // Selection returns the bare name, never the decorated display string.
+    assert_eq!(picker.selected_name(), Some("alpha"));
+
+    // Filtering matches item names only: the annotation text is not searched.
+    picker.char_input('z');
+    assert!(picker.matches.is_empty());
+
+    picker.backspace();
+    picker.char_input('a');
+    assert_eq!(picker.matches, vec!["alpha", "beta"]);
+}
+
 // ── walk_files tests ────────────────────────────────────────────────
 
 use std::fs;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -166,7 +166,16 @@ impl<'a> App<'a> {
 
         let mut input = InputEditor::new();
         input.set_monochrome(cli.no_color);
-        input.set_prompt_names(context.prompts.keys().cloned().collect());
+        let mut prompt_names: Vec<String> = context.prompts.keys().cloned().collect();
+        prompt_names.sort();
+        input.set_prompt_names(prompt_names);
+        input.set_prompt_sources(
+            context
+                .prompt_sources
+                .iter()
+                .map(|(name, src)| (name.clone(), src.label().to_string()))
+                .collect(),
+        );
         input.set_theme_names(context.themes.keys().cloned().collect());
         if let Some(editor) = &cfg.editor {
             input.set_editor(editor.clone());

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -9,6 +9,7 @@ pub use pickers::Picker;
 
 use compact_str::CompactString;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::collections::HashMap;
 use std::io::Write;
 
 use crate::ui::pickers::file::FilePicker;
@@ -27,6 +28,9 @@ pub struct InputEditor {
     pub picker: Option<Picker>,
     monochrome: bool,
     prompt_names: Vec<String>,
+    /// Provenance label per prompt name, drawn in the prompt pickers (never
+    /// part of filtering or selection).
+    prompt_sources: HashMap<String, String>,
     theme_names: Vec<String>,
     quick_model_names: Vec<String>,
     live_model_names: Vec<String>,
@@ -48,6 +52,7 @@ impl InputEditor {
             picker: None,
             monochrome: false,
             prompt_names: Vec::new(),
+            prompt_sources: HashMap::new(),
             theme_names: Vec::new(),
             quick_model_names: Vec::new(),
             live_model_names: Vec::new(),
@@ -117,6 +122,10 @@ impl InputEditor {
 
     pub fn set_prompt_names(&mut self, names: Vec<String>) {
         self.prompt_names = names;
+    }
+
+    pub fn set_prompt_sources(&mut self, sources: HashMap<String, String>) {
+        self.prompt_sources = sources;
     }
 
     pub fn set_theme_names(&mut self, names: Vec<String>) {
@@ -198,6 +207,7 @@ impl InputEditor {
         picker.set_monochrome(self.monochrome);
         if !self.prompt_names.is_empty() {
             picker.set_items(self.prompt_names.clone());
+            picker.set_annotations(self.prompt_sources.clone());
         }
         picker.activate();
         self.picker = Some(Picker::Prefixed(picker, "/prompt "));
@@ -208,6 +218,7 @@ impl InputEditor {
         picker.set_monochrome(self.monochrome);
         if !self.prompt_names.is_empty() {
             picker.set_items(self.prompt_names.clone());
+            picker.set_annotations(self.prompt_sources.clone());
         }
         picker.activate();
         self.picker = Some(Picker::Prefixed(picker, "."));

--- a/src/ui/input/pickers.rs
+++ b/src/ui/input/pickers.rs
@@ -64,6 +64,7 @@ impl InputEditor {
             Some(Picker::Command(p)) => {
                 let ctx = handlers::CommandPickerCtx {
                     prompt_names: &self.prompt_names,
+                    prompt_sources: &self.prompt_sources,
                     theme_names: &self.theme_names,
                     quick_model_names: &self.quick_model_names,
                     live_model_names: &self.live_model_names,

--- a/src/ui/pickers/handlers.rs
+++ b/src/ui/pickers/handlers.rs
@@ -1,5 +1,6 @@
 use compact_str::CompactString;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::collections::HashMap;
 
 use super::file::FilePicker;
 use super::list::ListPicker;
@@ -110,6 +111,7 @@ pub fn handle_file_key(
 
 pub struct CommandPickerCtx<'a> {
     pub prompt_names: &'a [String],
+    pub prompt_sources: &'a HashMap<String, String>,
     pub theme_names: &'a [String],
     pub quick_model_names: &'a [String],
     pub live_model_names: &'a [String],
@@ -232,6 +234,7 @@ pub fn handle_command_key(
                     picker.deactivate();
                     let mut pp = ListPicker::new();
                     pp.set_items(ctx.prompt_names.to_vec());
+                    pp.set_annotations(ctx.prompt_sources.clone());
                     pp.activate();
                     return (true, Some(Picker::Prefixed(pp, "/prompt ")));
                 }

--- a/src/ui/pickers/list.rs
+++ b/src/ui/pickers/list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::draw_picker_list;
 
 /// Slash commands that are always available, regardless of which optional
@@ -96,6 +98,11 @@ pub struct ListPicker {
     pub matches: Vec<String>,
     pub selected: usize,
     items: Vec<String>,
+    /// Optional per-item tag drawn after the item name in parentheses (e.g. a
+    /// provenance label). Never part of filtering or selection: the query
+    /// matches against item names only and `selected_name` returns the bare
+    /// name.
+    annotations: HashMap<String, String>,
     monochrome: bool,
 }
 
@@ -108,6 +115,7 @@ impl ListPicker {
             matches: Vec::new(),
             selected: 0,
             items: Vec::new(),
+            annotations: HashMap::new(),
             monochrome: false,
         }
     }
@@ -124,6 +132,10 @@ impl ListPicker {
 
     pub fn set_items(&mut self, items: Vec<String>) {
         self.items = items;
+    }
+
+    pub fn set_annotations(&mut self, annotations: HashMap<String, String>) {
+        self.annotations = annotations;
     }
 
     pub fn activate(&mut self) {
@@ -201,12 +213,23 @@ impl ListPicker {
         if !self.active {
             return Ok(());
         }
-        draw_picker_list(
-            &self.matches,
-            self.selected,
-            self.monochrome,
-            empty_message,
-            4,
-        )
+        if self.annotations.is_empty() {
+            return draw_picker_list(
+                &self.matches,
+                self.selected,
+                self.monochrome,
+                empty_message,
+                4,
+            );
+        }
+        let display: Vec<String> = self
+            .matches
+            .iter()
+            .map(|m| match self.annotations.get(m) {
+                Some(tag) => format!("{} ({})", m, tag),
+                None => m.clone(),
+            })
+            .collect();
+        draw_picker_list(&display, self.selected, self.monochrome, empty_message, 4)
     }
 }

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -16,6 +16,10 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
 async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     let mut sorted: Vec<&String> = ctx.context.prompts.keys().collect();
     sorted.sort();
+    let tagged = |name: &String| match ctx.context.prompt_sources.get(name) {
+        Some(src) => format!("  {} ({})", name, src.label()),
+        None => format!("  {}", name),
+    };
     if parts.len() < 2 {
         if sorted.is_empty() {
             write_ok(ctx.renderer, "no prompts available");
@@ -30,7 +34,7 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
                 format!("available prompts (current: {}):", current),
             );
             for name in &sorted {
-                write_result(ctx.renderer, format!("  {}", name));
+                write_result(ctx.renderer, tagged(name));
             }
             write_result(ctx.renderer, "usage: /prompt <name>  |  /prompt default");
         }
@@ -104,7 +108,7 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
             if !sorted.is_empty() {
                 write_ok(ctx.renderer, "available prompts:");
                 for p in &sorted {
-                    write_result(ctx.renderer, format!("  {}", p));
+                    write_result(ctx.renderer, tagged(p));
                 }
             }
         }
@@ -180,7 +184,20 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
 async fn handle_regen_prompts(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     match context::prompts::regen() {
         Ok(()) => {
-            ctx.context.prompts = context::prompts::load();
+            let (prompts, sources) = context::prompts::load_with_sources();
+            ctx.context.prompts = prompts;
+            ctx.context.prompt_sources = sources;
+            // Keep the prompt pickers in sync with the regenerated set.
+            let mut names: Vec<String> = ctx.context.prompts.keys().cloned().collect();
+            names.sort();
+            ctx.input.set_prompt_names(names);
+            ctx.input.set_prompt_sources(
+                ctx.context
+                    .prompt_sources
+                    .iter()
+                    .map(|(name, src)| (name.clone(), src.label().to_string()))
+                    .collect(),
+            );
             write_ok(ctx.renderer, "default prompts regenerated");
         }
         Err(e) => {


### PR DESCRIPTION
## Problem

`/prompt` listed prompts in HashMap iteration order in the pickers, with no hint about where each prompt came from — which matters since prompts can live in up to four places (built-in, global data dir, `data/prompts/`, `.zerostack/prompts/`, later overriding earlier).

## Changes

- **Sorted alphabetically** — the `/prompt` picker, the `.` dot picker, and the `/prompt` command-picker branch now list prompts sorted (the bare `/prompt` text listing already was).
- **Source tags** — every entry shows its provenance in parentheses: `code (built-in)`, `myprompt (global)`, `x (local)`. The two project-level sources (`data/prompts/`, `.zerostack/prompts/`) both display as `local`.

Implementation:

- `context::prompts`: new `PromptSource` enum + `load_with_sources()` tracking which highest-priority location each prompt came from; replaces the old `load()` (no remaining callers). Stored as `ContextFiles.prompt_sources`; `/regen-prompts` refreshes it and the picker state.
- `ListPicker` gained optional per-item **annotations**: drawn as `name (source)` but never part of filtering or selection — typing `local` won't match every local prompt, and selecting an entry still runs `/prompt <name>` with the bare name.
- Docs: `COMMANDS.md` `/prompt` entry updated; `CONFIG.md` source lists corrected to the actual post-`214a1b3` paths (`data/prompts/`, `data/themes/`, `$ZS_DATA_DIR` defaults).

## Verification

- `cargo fmt --check` ✅
- `cargo test --locked` ✅ (610 passed, incl. 7 new: 6 provenance + 1 picker-annotation)
- `cargo test --locked --no-default-features` ✅ (512 passed)
- `cargo test --locked --all-features` ✅ (814 passed)
- `cargo clippy --locked --no-default-features -- -D warnings` ✅
- `cargo clippy --locked --all-features -- -D warnings` ✅
- `cargo install --locked --path . --debug` ✅
