### PR TITLE
tui: centralize agent rebuild in one rebuild_agent helper

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -190,27 +190,11 @@ impl<'a> App<'a> {
                     ui.context.reload();
                     apply_current_prompt_mode(ui.context, &ui.permission);
                     #[cfg(feature = "mcp")]
-                    let mcp_ref = ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
-                    let model = ui.client.completion_model(ui.session.model.to_string());
-                    let temperature =
-                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
+                    ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
                     run.agent = Some(
-                        crate::provider::build_agent(
-                            model,
-                            ui.cli,
-                            ui.cfg,
-                            ui.context,
-                            ui.permission.clone(),
-                            ui.ask_tx.clone(),
-                            ui.sandbox.clone(),
-                            slash.reasoning_enabled,
-                            temperature,
-                            extra_body,
-                            #[cfg(feature = "mcp")]
-                            mcp_ref,
-                        )
-                        .await,
+                        ui.agent_build_ctx()
+                            .rebuild_agent(&ui.session.model, slash.reasoning_enabled)
+                            .await,
                     );
                     let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
                 }
@@ -235,27 +219,11 @@ impl<'a> App<'a> {
                     ui.context.reload();
                     apply_current_prompt_mode(ui.context, &ui.permission);
                     #[cfg(feature = "mcp")]
-                    let mcp_ref = ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
-                    let model = ui.client.completion_model(ui.session.model.to_string());
-                    let temperature =
-                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
+                    ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
                     run.agent = Some(
-                        crate::provider::build_agent(
-                            model,
-                            ui.cli,
-                            ui.cfg,
-                            ui.context,
-                            ui.permission.clone(),
-                            ui.ask_tx.clone(),
-                            ui.sandbox.clone(),
-                            slash.reasoning_enabled,
-                            temperature,
-                            extra_body,
-                            #[cfg(feature = "mcp")]
-                            mcp_ref,
-                        )
-                        .await,
+                        ui.agent_build_ctx()
+                            .rebuild_agent(&ui.session.model, slash.reasoning_enabled)
+                            .await,
                     );
                     let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
                 }
@@ -326,24 +294,18 @@ impl<'a> App<'a> {
                     None
                 };
 
-                let model = client_clone.completion_model(session_model.clone());
-                let temperature =
-                    crate::config::resolve_temperature(&cli_clone, &cfg_clone, &session_model);
-                let extra_body = crate::config::resolve_extra_body(&cfg_clone, &session_model);
-                let a = crate::provider::build_agent(
-                    model,
-                    &cli_clone,
-                    &cfg_clone,
-                    &context_clone,
-                    permission_clone,
-                    ask_tx_clone,
-                    sandbox_clone,
-                    reasoning_enabled,
-                    temperature,
-                    extra_body,
+                let a = crate::ui::state::AgentBuildCtx {
+                    cli: &cli_clone,
+                    cfg: &cfg_clone,
+                    context: &context_clone,
+                    client: &client_clone,
+                    permission: &permission_clone,
+                    ask_tx: &ask_tx_clone,
+                    sandbox: &sandbox_clone,
                     #[cfg(feature = "mcp")]
-                    mcp.as_ref(),
-                )
+                    mcp_manager: mcp.as_ref(),
+                }
+                .rebuild_agent(&session_model, reasoning_enabled)
                 .await;
 
                 #[cfg(feature = "mcp")]
@@ -1449,36 +1411,13 @@ impl<'a> App<'a> {
                         self.ui.context.reload();
                         apply_current_prompt_mode(self.ui.context, &self.ui.permission);
                         #[cfg(feature = "mcp")]
-                        let mcp_ref =
-                            ensure_mcp_manager(&mut self.ui.mcp_manager, self.ui.cfg).await;
-                        let model = self
+                        ensure_mcp_manager(&mut self.ui.mcp_manager, self.ui.cfg).await;
+                        let new_agent = self
                             .ui
-                            .client
-                            .completion_model(self.ui.session.model.to_string());
-                        let temperature = crate::config::resolve_temperature(
-                            self.ui.cli,
-                            self.ui.cfg,
-                            &self.ui.session.model,
-                        );
-                        let extra_body =
-                            crate::config::resolve_extra_body(self.ui.cfg, &self.ui.session.model);
-                        self.run.agent = Some(
-                            crate::provider::build_agent(
-                                model,
-                                self.ui.cli,
-                                self.ui.cfg,
-                                self.ui.context,
-                                self.ui.permission.clone(),
-                                self.ui.ask_tx.clone(),
-                                self.ui.sandbox.clone(),
-                                self.slash.reasoning_enabled,
-                                temperature,
-                                extra_body,
-                                #[cfg(feature = "mcp")]
-                                mcp_ref,
-                            )
-                            .await,
-                        );
+                            .agent_build_ctx()
+                            .rebuild_agent(&self.ui.session.model, self.slash.reasoning_enabled)
+                            .await;
+                        self.run.agent = Some(new_agent);
                         render_session(
                             &mut self.renderer,
                             self.ui.session,
@@ -1815,33 +1754,12 @@ impl<'a> App<'a> {
             match (self.ui.mcp_manager.as_mut(), server_cfg) {
                 (Some(mgr), Some(scfg)) => match mgr.reconnect(&server, &scfg).await {
                     Ok(()) => {
-                        let model = self
+                        let new_agent = self
                             .ui
-                            .client
-                            .completion_model(self.ui.session.model.to_string());
-                        let temperature = crate::config::resolve_temperature(
-                            self.ui.cli,
-                            self.ui.cfg,
-                            &self.ui.session.model,
-                        );
-                        let extra_body =
-                            crate::config::resolve_extra_body(self.ui.cfg, &self.ui.session.model);
-                        self.run.agent = Some(
-                            crate::provider::build_agent(
-                                model,
-                                self.ui.cli,
-                                self.ui.cfg,
-                                self.ui.context,
-                                self.ui.permission.clone(),
-                                self.ui.ask_tx.clone(),
-                                self.ui.sandbox.clone(),
-                                self.slash.reasoning_enabled,
-                                temperature,
-                                extra_body,
-                                self.ui.mcp_manager.as_ref(),
-                            )
-                            .await,
-                        );
+                            .agent_build_ctx()
+                            .rebuild_agent(&self.ui.session.model, self.slash.reasoning_enabled)
+                            .await;
+                        self.run.agent = Some(new_agent);
                         self.renderer.write_line(
                             &format!("authorized and connected '{}'", server),
                             C_AGENT,

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -30,27 +30,12 @@ pub async fn ensure_agent(
     if agent.is_some() {
         return;
     }
-    let model = ui.client.completion_model(ui.session.model.to_string());
-    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
     #[cfg(feature = "mcp")]
-    let mcp_ref = crate::ui::ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
+    crate::ui::ensure_mcp_manager(&mut ui.mcp_manager, ui.cfg).await;
     *agent = Some(
-        crate::provider::build_agent(
-            model,
-            ui.cli,
-            ui.cfg,
-            ui.context,
-            ui.permission.clone(),
-            ui.ask_tx.clone(),
-            ui.sandbox.clone(),
-            reasoning_enabled,
-            temperature,
-            extra_body,
-            #[cfg(feature = "mcp")]
-            mcp_ref,
-        )
-        .await,
+        ui.agent_build_ctx()
+            .rebuild_agent(&ui.session.model, reasoning_enabled)
+            .await,
     );
     // Keep the pre-calibration context estimate in sync with the preamble we
     // just built (system prompt + tools + context files).
@@ -486,27 +471,11 @@ async fn handle_agent_done(
             chain.loop_label = None;
         } else {
             let prompt = ls.build_prompt();
-            run.agent = Some({
-                let model = ui.client.completion_model(ui.session.model.to_string());
-                let temperature =
-                    crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-                let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
-                crate::provider::build_agent(
-                    model,
-                    ui.cli,
-                    ui.cfg,
-                    ui.context,
-                    ui.permission.clone(),
-                    ui.ask_tx.clone(),
-                    ui.sandbox.clone(),
-                    true,
-                    temperature,
-                    extra_body,
-                    #[cfg(feature = "mcp")]
-                    ui.mcp_manager.as_ref(),
-                )
-                .await
-            });
+            run.agent = Some(
+                ui.agent_build_ctx()
+                    .rebuild_agent(&ui.session.model, true)
+                    .await,
+            );
             let runner = run
                 .agent
                 .as_ref()
@@ -544,27 +513,11 @@ async fn handle_agent_done(
                 ui.session.working_dir = compact_str::CompactString::new(&main_path);
                 ui.context.reload();
                 apply_current_prompt_mode(ui.context, &ui.permission);
-                run.agent = Some({
-                    let model = ui.client.completion_model(ui.session.model.to_string());
-                    let temperature =
-                        crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-                    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
-                    crate::provider::build_agent(
-                        model,
-                        ui.cli,
-                        ui.cfg,
-                        ui.context,
-                        ui.permission.clone(),
-                        ui.ask_tx.clone(),
-                        ui.sandbox.clone(),
-                        true,
-                        temperature,
-                        extra_body,
-                        #[cfg(feature = "mcp")]
-                        ui.mcp_manager.as_ref(),
-                    )
-                    .await
-                });
+                run.agent = Some(
+                    ui.agent_build_ctx()
+                        .rebuild_agent(&ui.session.model, true)
+                        .await,
+                );
                 crate::ui::events::render_session(
                     renderer, ui.session, ui.cli, ui.cfg, ui.context,
                 )?;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -26,7 +26,7 @@ use crate::session::{MessageRole, Session};
 use crate::ui::events::render_session;
 use crate::ui::input::InputEditor;
 use crate::ui::renderer::Renderer;
-use crate::ui::state::{AgentRunState, ChainState, SlashState, UiContext};
+use crate::ui::state::{AgentBuildCtx, AgentRunState, ChainState, SlashState, UiContext};
 
 pub(crate) const C_AGENT: crossterm::style::Color = crossterm::style::Color::White;
 pub(crate) const C_RESULT: crossterm::style::Color = crossterm::style::Color::DarkGrey;
@@ -55,33 +55,32 @@ pub struct SlashCtx<'a> {
 }
 
 impl SlashCtx<'_> {
+    /// Borrow the pieces [`AgentBuildCtx::rebuild_agent`] needs.
+    fn agent_build_ctx(&self) -> AgentBuildCtx<'_> {
+        AgentBuildCtx {
+            cli: self.cli,
+            cfg: self.cfg,
+            context: self.context,
+            client: self.client,
+            permission: self.permission,
+            ask_tx: self.ask_tx,
+            sandbox: self.sandbox,
+            #[cfg(feature = "mcp")]
+            mcp_manager: self.mcp_manager,
+        }
+    }
+
     pub async fn rebuild_agent(&mut self) {
-        let model = self.client.completion_model(self.session.model.to_string());
-        let temperature =
-            crate::config::resolve_temperature(self.cli, self.cfg, &self.session.model);
-        let extra_body = crate::config::resolve_extra_body(self.cfg, &self.session.model);
         #[cfg(feature = "advisor")]
         {
             crate::extras::advisor::update_client(self.client.clone());
             crate::extras::advisor::set_session_messages(self.session.messages.clone());
         }
-        *self.agent = Some(
-            crate::provider::build_agent(
-                model,
-                self.cli,
-                self.cfg,
-                self.context,
-                self.permission.clone(),
-                self.ask_tx.clone(),
-                self.sandbox.clone(),
-                *self.reasoning_enabled,
-                temperature,
-                extra_body,
-                #[cfg(feature = "mcp")]
-                self.mcp_manager,
-            )
-            .await,
-        );
+        let new_agent = self
+            .agent_build_ctx()
+            .rebuild_agent(&self.session.model, *self.reasoning_enabled)
+            .await;
+        *self.agent = Some(new_agent);
     }
 
     pub async fn rebuild_agent_with_client(
@@ -95,32 +94,16 @@ impl SlashCtx<'_> {
             &self.cfg.custom_providers_map(),
             self.cfg.api_keys.as_ref(),
         )?;
-        let model = self.client.completion_model(self.session.model.to_string());
-        let temperature =
-            crate::config::resolve_temperature(self.cli, self.cfg, &self.session.model);
-        let extra_body = crate::config::resolve_extra_body(self.cfg, &self.session.model);
         #[cfg(feature = "advisor")]
         {
             crate::extras::advisor::update_client(self.client.clone());
             crate::extras::advisor::set_session_messages(self.session.messages.clone());
         }
-        *self.agent = Some(
-            crate::provider::build_agent(
-                model,
-                self.cli,
-                self.cfg,
-                self.context,
-                self.permission.clone(),
-                self.ask_tx.clone(),
-                self.sandbox.clone(),
-                new_reasoning,
-                temperature,
-                extra_body,
-                #[cfg(feature = "mcp")]
-                self.mcp_manager,
-            )
-            .await,
-        );
+        let new_agent = self
+            .agent_build_ctx()
+            .rebuild_agent(&self.session.model, new_reasoning)
+            .await;
+        *self.agent = Some(new_agent);
         Ok(())
     }
 
@@ -165,31 +148,16 @@ impl SlashCtx<'_> {
                 }
             }
         } else {
-            let model = self.client.completion_model(new_model.to_string());
-            let temperature = crate::config::resolve_temperature(self.cli, self.cfg, &new_model);
-            let extra_body = crate::config::resolve_extra_body(self.cfg, &new_model);
             #[cfg(feature = "advisor")]
             {
                 crate::extras::advisor::update_client(self.client.clone());
                 crate::extras::advisor::set_session_messages(self.session.messages.clone());
             }
-            *self.agent = Some(
-                crate::provider::build_agent(
-                    model,
-                    self.cli,
-                    self.cfg,
-                    self.context,
-                    self.permission.clone(),
-                    self.ask_tx.clone(),
-                    self.sandbox.clone(),
-                    *self.reasoning_enabled,
-                    temperature,
-                    extra_body,
-                    #[cfg(feature = "mcp")]
-                    self.mcp_manager,
-                )
-                .await,
-            );
+            let new_agent = self
+                .agent_build_ctx()
+                .rebuild_agent(&new_model, *self.reasoning_enabled)
+                .await;
+            *self.agent = Some(new_agent);
         }
 
         self.session.input_token_cost = qmc.input_token_cost;
@@ -262,30 +230,15 @@ pub(crate) async fn apply_prompt_model(
         }
     }
 
-    let model = ui.client.completion_model(new_model.to_string());
-    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &new_model);
-    let extra_body = crate::config::resolve_extra_body(ui.cfg, &new_model);
     #[cfg(feature = "advisor")]
     {
         crate::extras::advisor::update_client(ui.client.clone());
         crate::extras::advisor::set_session_messages(ui.session.messages.clone());
     }
     *agent = Some(
-        crate::provider::build_agent(
-            model,
-            ui.cli,
-            ui.cfg,
-            ui.context,
-            ui.permission.clone(),
-            ui.ask_tx.clone(),
-            ui.sandbox.clone(),
-            reasoning_enabled,
-            temperature,
-            extra_body,
-            #[cfg(feature = "mcp")]
-            ui.mcp_manager.as_ref(),
-        )
-        .await,
+        ui.agent_build_ctx()
+            .rebuild_agent(&new_model, reasoning_enabled)
+            .await,
     );
 
     ui.session.input_token_cost = qmc.input_token_cost;
@@ -421,25 +374,10 @@ pub async fn handle_compress(
     );
     ui.session.compress(summary, cut_idx, tokens_before);
 
-    let model = ui.client.completion_model(ui.session.model.to_string());
-    let temperature = crate::config::resolve_temperature(ui.cli, ui.cfg, &ui.session.model);
-    let extra_body = crate::config::resolve_extra_body(ui.cfg, &ui.session.model);
     *agent = Some(
-        crate::provider::build_agent(
-            model,
-            ui.cli,
-            ui.cfg,
-            ui.context,
-            ui.permission.clone(),
-            ui.ask_tx.clone(),
-            ui.sandbox.clone(),
-            reasoning_enabled,
-            temperature,
-            extra_body,
-            #[cfg(feature = "mcp")]
-            ui.mcp_manager.as_ref(),
-        )
-        .await,
+        ui.agent_build_ctx()
+            .rebuild_agent(&ui.session.model, reasoning_enabled)
+            .await,
     );
 
     render_session(renderer, ui.session, ui.cli, ui.cfg, ui.context)?;

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -148,26 +148,11 @@ fn lookup_pricing_from_cache(provider: &str, model_id: &str) -> Option<(f64, f64
 
 async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
     let new_model = compact_str::CompactString::new(model_id);
-    let model = ctx.client.completion_model(new_model.to_string());
-    let temperature = crate::config::resolve_temperature(ctx.cli, ctx.cfg, &new_model);
-    let extra_body = crate::config::resolve_extra_body(ctx.cfg, &new_model);
-    *ctx.agent = Some(
-        crate::provider::build_agent(
-            model,
-            ctx.cli,
-            ctx.cfg,
-            ctx.context,
-            ctx.permission.clone(),
-            ctx.ask_tx.clone(),
-            ctx.sandbox.clone(),
-            *ctx.reasoning_enabled,
-            temperature,
-            extra_body,
-            #[cfg(feature = "mcp")]
-            ctx.mcp_manager,
-        )
-        .await,
-    );
+    let new_agent = ctx
+        .agent_build_ctx()
+        .rebuild_agent(&new_model, *ctx.reasoning_enabled)
+        .await;
+    *ctx.agent = Some(new_agent);
     ctx.session.model = new_model.clone();
     ctx.session
         .update_context_window(ctx.cfg.resolve_context_window(
@@ -256,26 +241,11 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
         return Ok(());
     }
     let new_model = compact_str::CompactString::new(parts[1].trim());
-    let model = ctx.client.completion_model(new_model.to_string());
-    let temperature = crate::config::resolve_temperature(ctx.cli, ctx.cfg, &new_model);
-    let extra_body = crate::config::resolve_extra_body(ctx.cfg, &new_model);
-    *ctx.agent = Some(
-        crate::provider::build_agent(
-            model,
-            ctx.cli,
-            ctx.cfg,
-            ctx.context,
-            ctx.permission.clone(),
-            ctx.ask_tx.clone(),
-            ctx.sandbox.clone(),
-            *ctx.reasoning_enabled,
-            temperature,
-            extra_body,
-            #[cfg(feature = "mcp")]
-            ctx.mcp_manager,
-        )
-        .await,
-    );
+    let new_agent = ctx
+        .agent_build_ctx()
+        .rebuild_agent(&new_model, *ctx.reasoning_enabled)
+        .await;
+    *ctx.agent = Some(new_agent);
     ctx.session.model = new_model.clone();
     ctx.session.provider = ctx.cli.resolve_provider(ctx.cfg);
     ctx.session

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -37,6 +37,21 @@ pub(crate) struct UiContext<'a> {
 }
 
 impl<'a> UiContext<'a> {
+    /// Borrow the pieces [`AgentBuildCtx::rebuild_agent`] needs.
+    pub(crate) fn agent_build_ctx(&self) -> AgentBuildCtx<'_> {
+        AgentBuildCtx {
+            cli: self.cli,
+            cfg: self.cfg,
+            context: self.context,
+            client: &self.client,
+            permission: &self.permission,
+            ask_tx: &self.ask_tx,
+            sandbox: &self.sandbox,
+            #[cfg(feature = "mcp")]
+            mcp_manager: self.mcp_manager.as_ref(),
+        }
+    }
+
     /// Composition root: built once in `main` and threaded through the TUI.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -63,6 +78,49 @@ impl<'a> UiContext<'a> {
             #[cfg(feature = "mcp")]
             mcp_manager: None,
         }
+    }
+}
+
+/// Everything needed to (re)build the main agent, borrowed from whichever
+/// state bundle the caller has: [`UiContext`] in the main loop and mid-turn
+/// compaction, `SlashCtx` in slash commands, or owned clones in the startup
+/// prebuild task. Centralizes the per-model resolution (completion model,
+/// temperature, extra_body) and the `build_agent` call itself so every
+/// rebuild path stays in sync.
+pub(crate) struct AgentBuildCtx<'a> {
+    pub cli: &'a Cli,
+    pub cfg: &'a Config,
+    pub context: &'a ContextFiles,
+    pub client: &'a AnyClient,
+    pub permission: &'a Option<PermCheck>,
+    pub ask_tx: &'a Option<AskSender>,
+    pub sandbox: &'a Sandbox,
+    #[cfg(feature = "mcp")]
+    pub mcp_manager: Option<&'a McpClientManager>,
+}
+
+impl AgentBuildCtx<'_> {
+    /// Build the main agent for `model_id` (usually `session.model`; model
+    /// switches pass the not-yet-committed new id).
+    pub(crate) async fn rebuild_agent(&self, model_id: &str, reasoning_enabled: bool) -> AnyAgent {
+        let model = self.client.completion_model(model_id.to_string());
+        let temperature = crate::config::resolve_temperature(self.cli, self.cfg, model_id);
+        let extra_body = crate::config::resolve_extra_body(self.cfg, model_id);
+        crate::provider::build_agent(
+            model,
+            self.cli,
+            self.cfg,
+            self.context,
+            self.permission.clone(),
+            self.ask_tx.clone(),
+            self.sandbox.clone(),
+            reasoning_enabled,
+            temperature,
+            extra_body,
+            #[cfg(feature = "mcp")]
+            self.mcp_manager,
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
Implements item 2 of **Control flow and duplication** from #186:

> Centralize agent rebuild in one `rebuild_agent(session, client, context, ...)` helper used by `start_main_run`, slash commands, and mid-turn compaction.

## What changed

Every main-agent rebuild path hand-rolled the same `completion_model` / `resolve_temperature` / `resolve_extra_body` + `build_agent` preamble (~15 copies across `app`, `event_handler`, and slash commands).

Introduced `AgentBuildCtx` (`src/ui/state.rs`): a borrow bundle of the build inputs with a single `rebuild_agent(model_id, reasoning_enabled)` method, obtainable from `UiContext::agent_build_ctx()` (main loop, mid-turn compaction) and `SlashCtx::agent_build_ctx()` (slash commands), or built from owned clones in the startup prebuild task.

Converted call sites:
- `ensure_agent` — used by `start_main_run`, mid-turn compaction, worktree-merge run
- `handle_compress` — /compress and auto/mid-turn compaction
- `SlashCtx::rebuild_agent` / `rebuild_agent_with_client` / `switch_to_prompt_model`, `apply_prompt_model` — all slash-command rebuilds (/model, /provider, /add, /mode, prompt-model switches, ...)
- /loop respawn and worktree-return respawn (`event_handler.rs`)
- worktree startup (x2), worktree exit, MCP reconnect, background prebuild (`app.rs`)
- `apply_model` / `handle_model` (`slash/providers.rs`)

Net: **−312 / +149 lines**. Out of scope and untouched: subagent and /btw builders, non-TUI one-shot/ACP modes.

## Behavior preserved

- advisor global-state syncs keep their original order at slash sites
- /loop and worktree respawns keep hardcoded `reasoning = true`
- model switches still build against the not-yet-committed model id
- MCP lazy-connect stays at the startup sites

## Verification

- `cargo fmt`
- `cargo test` — 608 passed (default features)
- `cargo test --features advisor,hooks,memory` — 784 passed
- `cargo test --no-default-features` — 510 passed
- `cargo install --path . --debug` OK

Refs #186