### PR TITLE
tui: extract apply_prompt_mode helper for prompt selection

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -55,6 +55,8 @@ mod paste_burst_tests;
 #[cfg(test)]
 mod picker_tests;
 #[cfg(test)]
+mod prompt_mode_tests;
+#[cfg(test)]
 mod provider_tests;
 #[cfg(test)]
 mod renderer_tests;

--- a/src/tests/prompt_mode_tests.rs
+++ b/src/tests/prompt_mode_tests.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::context::ContextFiles;
+use crate::permission::checker::{PermCheck, PermissionChecker};
+use crate::permission::{PermissionConfigs, SecurityMode};
+use crate::ui::{PromptModeOutcome, apply_prompt_mode};
+
+fn make_context(prompts: &[(&str, &str)]) -> ContextFiles {
+    ContextFiles {
+        agents: None,
+        prompts: prompts
+            .iter()
+            .map(|(name, content)| (name.to_string(), content.to_string()))
+            .collect::<HashMap<_, _>>(),
+        current_prompt: None,
+        current_prompt_name: None,
+        themes: HashMap::new(),
+        current_theme_name: None,
+        extra_files: Vec::new(),
+        one_shot_restore: None,
+        chain_declined: Vec::new(),
+        #[cfg(feature = "memory")]
+        memory: None,
+        #[cfg(feature = "archmd")]
+        architecture: None,
+    }
+}
+
+fn make_perm(mode: SecurityMode) -> PermCheck {
+    Arc::new(Mutex::new(PermissionChecker::new(
+        &PermissionConfigs::default(),
+        mode,
+        None,
+        None,
+    )))
+}
+
+fn current_mode(perm: &PermCheck) -> SecurityMode {
+    perm.lock().unwrap_or_else(|e| e.into_inner()).mode()
+}
+
+#[test]
+fn prompt_without_directive_keeps_content_and_mode_untouched() {
+    let mut context = make_context(&[("code", "You are a coder.")]);
+    let perm = make_perm(SecurityMode::Standard);
+
+    let outcome = apply_prompt_mode("code", &mut context, &Some(perm.clone()));
+
+    assert_eq!(outcome, PromptModeOutcome::None);
+    assert_eq!(context.current_prompt.as_deref(), Some("You are a coder."));
+    assert_eq!(context.current_prompt_name.as_deref(), Some("code"));
+    assert_eq!(current_mode(&perm), SecurityMode::Standard);
+}
+
+#[test]
+fn mode_directive_is_stripped_and_applied() {
+    let mut context = make_context(&[("review", "%%mode=readonly\nReview the code.")]);
+    let perm = make_perm(SecurityMode::Standard);
+
+    let outcome = apply_prompt_mode("review", &mut context, &Some(perm.clone()));
+
+    assert_eq!(outcome, PromptModeOutcome::Applied(SecurityMode::ReadOnly));
+    assert_eq!(context.current_prompt.as_deref(), Some("Review the code."));
+    assert_eq!(context.current_prompt_name.as_deref(), Some("review"));
+    assert_eq!(current_mode(&perm), SecurityMode::ReadOnly);
+}
+
+#[test]
+fn last_user_mode_restores_the_user_selected_mode() {
+    let mut context = make_context(&[
+        ("review", "%%mode=readonly\nReview the code."),
+        ("code", "%%mode=last_user_mode\nYou are a coder."),
+    ]);
+    let perm = make_perm(SecurityMode::Guarded);
+
+    // A prompt-imposed mode must not clobber the user-selected mode...
+    apply_prompt_mode("review", &mut context, &Some(perm.clone()));
+    assert_eq!(current_mode(&perm), SecurityMode::ReadOnly);
+
+    // ...so a `last_user_mode` prompt restores it afterwards.
+    let outcome = apply_prompt_mode("code", &mut context, &Some(perm.clone()));
+
+    assert_eq!(outcome, PromptModeOutcome::RestoredUserMode);
+    assert_eq!(current_mode(&perm), SecurityMode::Guarded);
+    assert_eq!(context.current_prompt.as_deref(), Some("You are a coder."));
+    assert_eq!(context.current_prompt_name.as_deref(), Some("code"));
+}
+
+#[test]
+fn unknown_prompt_is_a_noop() {
+    let mut context = make_context(&[("code", "You are a coder.")]);
+    let perm = make_perm(SecurityMode::Standard);
+
+    let outcome = apply_prompt_mode("missing", &mut context, &Some(perm.clone()));
+
+    assert_eq!(outcome, PromptModeOutcome::None);
+    assert!(context.current_prompt.is_none());
+    assert!(context.current_prompt_name.is_none());
+    assert_eq!(current_mode(&perm), SecurityMode::Standard);
+}
+
+#[test]
+fn unrecognized_mode_strips_directive_but_keeps_current_mode() {
+    let mut context = make_context(&[("weird", "%%mode=bogus\nBody.")]);
+    let perm = make_perm(SecurityMode::Standard);
+
+    let outcome = apply_prompt_mode("weird", &mut context, &Some(perm.clone()));
+
+    assert_eq!(outcome, PromptModeOutcome::None);
+    assert_eq!(context.current_prompt.as_deref(), Some("Body."));
+    assert_eq!(context.current_prompt_name.as_deref(), Some("weird"));
+    assert_eq!(current_mode(&perm), SecurityMode::Standard);
+}
+
+#[test]
+fn without_permission_checker_prompt_is_still_selected() {
+    let mut context = make_context(&[("review", "%%mode=readonly\nReview the code.")]);
+
+    let outcome = apply_prompt_mode("review", &mut context, &None);
+
+    assert_eq!(outcome, PromptModeOutcome::None);
+    assert_eq!(context.current_prompt.as_deref(), Some("Review the code."));
+    assert_eq!(context.current_prompt_name.as_deref(), Some("review"));
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -35,7 +35,7 @@ use super::handle_human_handoff;
 #[cfg(feature = "git-worktree")]
 use super::spawn_merge_agent;
 use super::{
-    C_AGENT, C_BTW, C_ERROR, C_TOOL, PrebuildPayload, classify_submission,
+    C_AGENT, C_BTW, C_ERROR, C_TOOL, PrebuildPayload, apply_prompt_mode, classify_submission,
     mid_turn_compact_and_respawn, refresh_display, spawn_event_thread, start_main_run,
     stop_turn_context_exhausted,
 };
@@ -982,30 +982,7 @@ impl<'a> App<'a> {
         extra: Option<&str>,
     ) -> anyhow::Result<()> {
         let next_name = phase.next_prompt_name();
-        if let Some(content) = self.ui.context.prompts.get(next_name).cloned() {
-            let (mode_directive_str, clean_content) =
-                crate::permission::parse_prompt_mode(&content);
-            let mode_directive = mode_directive_str.map(|s| s.to_string());
-            self.ui.context.current_prompt = Some(if mode_directive.is_some() {
-                clean_content.to_string()
-            } else {
-                content
-            });
-            self.ui.context.current_prompt_name = Some(next_name.to_string());
-            if let Some(ref mode_str) = mode_directive {
-                if mode_str == "last_user_mode"
-                    && let Some(perm) = &self.ui.permission
-                {
-                    let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-                    guard.restore_user_mode();
-                } else if let Some(mode) = crate::permission::SecurityMode::from_str(mode_str)
-                    && let Some(perm) = &self.ui.permission
-                {
-                    let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-                    guard.set_prompt_mode(mode);
-                }
-            }
-        }
+        apply_prompt_mode(next_name, self.ui.context, &self.ui.permission);
         apply_prompt_model(
             next_name,
             &mut self.ui,
@@ -1059,10 +1036,7 @@ impl<'a> App<'a> {
             let msg = msg.trim();
             if !prompt_name.is_empty() && self.ui.context.prompts.contains_key(prompt_name) {
                 self.chain.dot_prompt_restore = self.ui.context.current_prompt_name.clone();
-                if let Some(content) = self.ui.context.prompts.get(prompt_name).cloned() {
-                    self.apply_prompt_from_content(&content, prompt_name)
-                        .await?;
-                }
+                apply_prompt_mode(prompt_name, self.ui.context, &self.ui.permission);
                 apply_prompt_model(
                     prompt_name,
                     &mut self.ui,
@@ -1083,10 +1057,7 @@ impl<'a> App<'a> {
 
         let prompt_name = after_dot.trim();
         if self.ui.context.prompts.contains_key(prompt_name) {
-            if let Some(content) = self.ui.context.prompts.get(prompt_name).cloned() {
-                self.apply_prompt_from_content(&content, prompt_name)
-                    .await?;
-            }
+            apply_prompt_mode(prompt_name, self.ui.context, &self.ui.permission);
             apply_prompt_model(
                 prompt_name,
                 &mut self.ui,
@@ -1105,32 +1076,6 @@ impl<'a> App<'a> {
                 .write_line(&format!("error: unknown prompt '{}'", prompt_name), C_ERROR)?;
             Ok(true)
         }
-    }
-
-    async fn apply_prompt_from_content(
-        &mut self,
-        content: &str,
-        prompt_name: &str,
-    ) -> anyhow::Result<()> {
-        let (mode_directive_str, clean_content) = crate::permission::parse_prompt_mode(content);
-        let mode_directive = mode_directive_str.map(|s| s.to_string());
-        self.ui.context.current_prompt = Some(if mode_directive.is_some() {
-            clean_content.to_string()
-        } else {
-            content.to_string()
-        });
-        self.ui.context.current_prompt_name = Some(prompt_name.to_string());
-        if let Some(ref mode_str) = mode_directive
-            && let Some(perm) = &self.ui.permission
-        {
-            let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-            if mode_str == "last_user_mode" {
-                guard.restore_user_mode();
-            } else if let Some(mode) = crate::permission::SecurityMode::from_str(mode_str) {
-                guard.set_prompt_mode(mode);
-            }
-        }
-        Ok(())
     }
 
     fn run_queue_command(&mut self, arg: &str) -> anyhow::Result<()> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,16 +25,13 @@ use tokio::sync::mpsc;
 
 #[cfg(feature = "mcp")]
 use crate::config::Config;
-#[cfg(feature = "git-worktree")]
 use crate::context::ContextFiles;
 use crate::event::UserEvent;
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::McpClientManager;
-#[cfg(feature = "git-worktree")]
-use crate::permission;
 use crate::permission::ask::AskReceiver;
-#[cfg(feature = "git-worktree")]
 use crate::permission::checker::PermCheck;
+use crate::permission::{self, SecurityMode};
 use crate::provider::AnyAgent;
 use crate::session::{MessageRole, Session};
 use crate::ui::event_handler::ensure_agent;
@@ -47,6 +44,61 @@ use crate::ui::slash::handle_compress;
 use crate::ui::state::MergeRequest;
 use crate::ui::state::{AgentRunState, BtwStats, ChainState, SlashState, UiContext};
 
+/// What [`apply_prompt_mode`] did with the prompt's `%%mode=` directive, so
+/// callers can report the change without re-parsing the prompt.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum PromptModeOutcome {
+    /// No directive, an unrecognized mode name, or no permission checker.
+    None,
+    /// `%%mode=last_user_mode`: the user-selected mode was restored.
+    RestoredUserMode,
+    /// `%%mode=<mode>`: the given security mode was applied.
+    Applied(SecurityMode),
+}
+
+/// Select prompt `name` as the current prompt and apply its `%%mode=`
+/// directive (if any) to the permission checker. The directive line is
+/// stripped from the stored prompt content. Unknown prompt names are a no-op.
+pub(crate) fn apply_prompt_mode(
+    name: &str,
+    context: &mut ContextFiles,
+    permission: &Option<PermCheck>,
+) -> PromptModeOutcome {
+    let Some(content) = context.prompts.get(name) else {
+        return PromptModeOutcome::None;
+    };
+    let (mode_directive, clean_content) = permission::parse_prompt_mode(content);
+    context.current_prompt = Some(if mode_directive.is_some() {
+        clean_content.to_string()
+    } else {
+        content.clone()
+    });
+    context.current_prompt_name = Some(name.to_string());
+    apply_mode_directive(mode_directive, permission)
+}
+
+/// Apply an already-parsed `%%mode=` directive to the permission checker.
+fn apply_mode_directive(
+    mode_directive: Option<&str>,
+    permission: &Option<PermCheck>,
+) -> PromptModeOutcome {
+    let (Some(mode_str), Some(perm)) = (mode_directive, permission) else {
+        return PromptModeOutcome::None;
+    };
+    let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
+    if mode_str == "last_user_mode" {
+        guard.restore_user_mode();
+        PromptModeOutcome::RestoredUserMode
+    } else if let Some(mode) = SecurityMode::from_str(mode_str) {
+        guard.set_prompt_mode(mode);
+        PromptModeOutcome::Applied(mode)
+    } else {
+        PromptModeOutcome::None
+    }
+}
+
+/// Re-apply the current prompt's `%%mode=` directive after a context reload
+/// (which restores the raw, unstripped prompt content from disk).
 #[cfg(feature = "git-worktree")]
 pub(crate) fn apply_current_prompt_mode(
     context: &mut ContextFiles,
@@ -59,16 +111,7 @@ pub(crate) fn apply_current_prompt_mode(
     if mode_directive.is_some() {
         context.current_prompt = Some(clean_content.to_string());
     }
-    let Some(mode_str) = mode_directive else {
-        return;
-    };
-    let Some(perm) = permission else { return };
-    let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-    if mode_str == "last_user_mode" {
-        guard.restore_user_mode();
-    } else if let Some(mode) = permission::SecurityMode::from_str(mode_str) {
-        guard.set_prompt_mode(mode);
-    }
+    apply_mode_directive(mode_directive, permission);
 }
 
 pub(super) const C_AGENT: Color = Color::White;

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -1,7 +1,7 @@
 use crate::context;
-use crate::permission::{self, SecurityMode};
 use crate::session::storage;
 use crate::ui::slash::{SlashCtx, write_error, write_ok, write_result};
+use crate::ui::{PromptModeOutcome, apply_prompt_mode};
 
 pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     match parts[0] {
@@ -61,20 +61,10 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
         }
     } else {
         let name = parts[1].trim();
-        if let Some(content) = ctx.context.prompts.get(name) {
-            let (mode_directive, clean_content) = permission::parse_prompt_mode(content);
-            ctx.context.current_prompt = Some(if mode_directive.is_some() {
-                clean_content.to_string()
-            } else {
-                content.clone()
-            });
-            ctx.context.current_prompt_name = Some(name.to_string());
-            if let Some(mode_str) = mode_directive {
-                if mode_str == "last_user_mode" {
+        if ctx.context.prompts.contains_key(name) {
+            match apply_prompt_mode(name, ctx.context, ctx.permission) {
+                PromptModeOutcome::RestoredUserMode => {
                     if let Some(perm) = ctx.permission {
-                        perm.lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .restore_user_mode();
                         let current = perm
                             .lock()
                             .unwrap_or_else(|e| e.into_inner())
@@ -82,17 +72,14 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
                             .to_string();
                         write_ok(ctx.renderer, format!("restored user mode: {}", current));
                     }
-                } else if let Some(mode) = SecurityMode::from_str(mode_str)
-                    && let Some(perm) = ctx.permission
-                {
-                    perm.lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .set_prompt_mode(mode);
+                }
+                PromptModeOutcome::Applied(mode) => {
                     write_ok(
                         ctx.renderer,
                         format!("security mode: {} (from prompt)", mode),
                     );
                 }
+                PromptModeOutcome::None => {}
             }
             let model_switched = ctx.switch_to_prompt_model(name).await;
             if !model_switched {

--- a/src/ui/slash/review.rs
+++ b/src/ui/slash/review.rs
@@ -1,5 +1,5 @@
-use crate::permission::{self, SecurityMode};
 use crate::session::MessageRole;
+use crate::ui::apply_prompt_mode;
 use crate::ui::slash::{SlashCtx, write_error, write_ok};
 
 fn is_session_empty(ctx: &SlashCtx<'_>) -> bool {
@@ -59,29 +59,7 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
     ctx.context.one_shot_restore = ctx.context.current_prompt_name.clone();
 
     // Switch to review prompt
-    if let Some(content) = ctx.context.prompts.get("review").cloned() {
-        let (mode_directive_str, clean_content) = permission::parse_prompt_mode(&content);
-        let mode_directive = mode_directive_str.map(|s| s.to_string());
-        ctx.context.current_prompt = Some(if mode_directive.is_some() {
-            clean_content.to_string()
-        } else {
-            content
-        });
-        ctx.context.current_prompt_name = Some("review".to_string());
-        if let Some(ref mode_str) = mode_directive {
-            if mode_str == "last_user_mode" {
-                if let Some(perm) = ctx.permission {
-                    let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-                    guard.restore_user_mode();
-                }
-            } else if let Some(mode) = SecurityMode::from_str(mode_str)
-                && let Some(perm) = ctx.permission
-            {
-                let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-                guard.set_prompt_mode(mode);
-            }
-        }
-    }
+    apply_prompt_mode("review", ctx.context, ctx.permission);
 
     let model_switched = ctx.switch_to_prompt_model("review").await;
     if !model_switched {


### PR DESCRIPTION
Implements item 3 of **Control flow and duplication** from #186: *Extract a single `apply_prompt_mode(name, context, permission)` helper to replace the duplicated prompt-mode blocks.*

## Changes

- New `apply_prompt_mode(name, context, permission)` helper in `src/ui/mod.rs`: selects the prompt by name, strips its `%%mode=` directive from the stored content, and applies the directive to the permission checker (`last_user_mode` restores the user-selected mode).
- The helper returns a new `PromptModeOutcome` enum (`None` / `RestoredUserMode` / `Applied(mode)`) so `/prompt` keeps its exact user-facing feedback without re-parsing the prompt.
- Replaced the four duplicated blocks:
  - `/prompt <name>` in `src/ui/slash/content.rs`
  - `/review` in `src/ui/slash/review.rs`
  - chain transitions (`run_chain_transition`) in `src/ui/app.rs`
  - dot commands in `src/ui/app.rs` (the `apply_prompt_from_content` method is gone)
- `apply_current_prompt_mode` (worktree reload path) now shares the same inner `apply_mode_directive` logic instead of its own copy.

No behavior change intended: same stripping rules, same mode semantics, same `/prompt` messages.

## Tests

- New `src/tests/prompt_mode_tests.rs` (6 tests): no-directive passthrough, directive strip + mode applied, `last_user_mode` restore (incl. `user_mode` not clobbered by prompt modes), unknown prompt no-op, unrecognized mode name, and no-permission-checker path.
- `cargo fmt`, full `cargo test` (614 passed), and `cargo install --path . --debug` all green.

## Follow-up note (out of scope here)

`src/main.rs:754-772` tries to apply the `%%mode=` directive at startup by re-parsing `context.current_prompt` — but the directive was already stripped when the prompt was stored (`src/main.rs:659-664`), so the default prompt's mode is never actually applied at startup (e.g. `default_prompt = "plan"` does not enable `planwrite`). This contradicts `docs/CONFIG.md`'s `default_prompt` description. I left it untouched to keep this PR a pure refactor; happy to send a follow-up PR fixing startup mode application using this helper.