### PR TITLE
fix: apply the default prompt's %%mode= directive at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -751,7 +751,9 @@ async fn run() -> anyhow::Result<()> {
         }
     }
 
-    // Apply mode from prompt %%mode= directive (if any)
+    // Apply mode from prompt %%mode= directive (if any). Read the directive
+    // from the raw prompt content: `context.current_prompt` has already been
+    // stripped of it (and had capabilities appended).
     if let Some(perm) = &permission {
         let allowlist: Vec<(String, String)> = session
             .permission_allowlist
@@ -760,14 +762,11 @@ async fn run() -> anyhow::Result<()> {
             .collect();
         let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
         guard.load_session_allowlist(&allowlist);
-        if let Some(current_prompt) = &context.current_prompt {
-            let (mode_directive, _) = crate::permission::parse_prompt_mode(current_prompt);
-            if let Some(mode_str) = mode_directive
-                && mode_str != "last_user_mode"
-                && let Some(mode) = SecurityMode::from_str(mode_str)
-            {
-                guard.set_prompt_mode(mode);
-            }
+        if let Some(name) = &context.current_prompt_name
+            && let Some(mode) =
+                crate::permission::resolve_startup_prompt_mode(&context.prompts, name)
+        {
+            guard.set_prompt_mode(mode);
         }
     }
 
@@ -936,15 +935,6 @@ async fn run() -> anyhow::Result<()> {
             #[cfg(feature = "hooks")]
             crate::extras::hooks::dispatch_session_end("exit").await;
             return result;
-        }
-
-        if !cli.resolve_no_tools(&cfg)
-            && let Some(perm) = &permission
-        {
-            let mode = resolve_mode(&cli, &cfg);
-            perm.lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .set_mode(mode);
         }
 
         let initial_msg = cli.message.join(" ");

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -121,6 +121,24 @@ pub fn parse_prompt_mode(content: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// Resolve the security mode requested by prompt `name`'s `%%mode=`
+/// directive, reading the raw (unstripped) prompt content from `prompts`.
+/// Returns `None` when the prompt is unknown, has no directive, names an
+/// unknown mode, or uses `last_user_mode` (meaningless at startup: the
+/// current mode already is the user's mode).
+pub fn resolve_startup_prompt_mode(
+    prompts: &HashMap<String, String>,
+    name: &str,
+) -> Option<SecurityMode> {
+    let content = prompts.get(name)?;
+    let (mode_directive, _) = parse_prompt_mode(content);
+    let mode_str = mode_directive?;
+    if mode_str == "last_user_mode" {
+        return None;
+    }
+    SecurityMode::from_str(mode_str)
+}
+
 /// Auto-deny regex patterns that are always active regardless of config.
 /// These are appended to the end of each relevant tool's rules, so they
 /// take precedence over user-configured allow/ask entries.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -70,6 +70,8 @@ mod singleflight_tests;
 mod slash_add_tests;
 #[cfg(test)]
 mod slash_init_tests;
+#[cfg(test)]
+mod startup_prompt_mode_tests;
 #[cfg(all(test, unix))]
 mod status_signals_tests;
 #[cfg(test)]

--- a/src/tests/startup_prompt_mode_tests.rs
+++ b/src/tests/startup_prompt_mode_tests.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use crate::permission::{SecurityMode, resolve_startup_prompt_mode};
+
+fn prompts(entries: &[(&str, &str)]) -> HashMap<String, String> {
+    entries
+        .iter()
+        .map(|(name, content)| (name.to_string(), content.to_string()))
+        .collect()
+}
+
+#[test]
+fn mode_directive_resolves_to_security_mode() {
+    let map = prompts(&[
+        ("review", "%%mode=readonly\nReview the code."),
+        ("plan", "%%mode=planwrite\nPlan the work."),
+    ]);
+
+    assert_eq!(
+        resolve_startup_prompt_mode(&map, "review"),
+        Some(SecurityMode::ReadOnly)
+    );
+    assert_eq!(
+        resolve_startup_prompt_mode(&map, "plan"),
+        Some(SecurityMode::PlanWrite)
+    );
+}
+
+#[test]
+fn last_user_mode_yields_none_at_startup() {
+    let map = prompts(&[("code", "%%mode=last_user_mode\nYou are a coder.")]);
+
+    assert_eq!(resolve_startup_prompt_mode(&map, "code"), None);
+}
+
+#[test]
+fn prompt_without_directive_yields_none() {
+    let map = prompts(&[("code", "You are a coder.")]);
+
+    assert_eq!(resolve_startup_prompt_mode(&map, "code"), None);
+}
+
+#[test]
+fn unknown_prompt_yields_none() {
+    let map = prompts(&[("code", "%%mode=readonly\nYou are a coder.")]);
+
+    assert_eq!(resolve_startup_prompt_mode(&map, "missing"), None);
+}
+
+#[test]
+fn unrecognized_mode_name_yields_none() {
+    let map = prompts(&[("weird", "%%mode=bogus\nBody.")]);
+
+    assert_eq!(resolve_startup_prompt_mode(&map, "weird"), None);
+}
+
+#[test]
+fn directive_is_only_read_from_the_first_line() {
+    let map = prompts(&[("code", "You are a coder.\n%%mode=readonly")]);
+
+    assert_eq!(resolve_startup_prompt_mode(&map, "code"), None);
+}


### PR DESCRIPTION
Follow-up to a latent bug spotted while working on #186 (mentioned in #202).

## Bug

The startup mode-application block in `src/main.rs` re-parsed `context.current_prompt` for a `%%mode=` directive — but the directive had already been **stripped** when the prompt content was stored (`src/main.rs` prompt-resolution blocks), so the parse never found anything and the default prompt's mode was **never applied at startup**. Example: `default_prompt = "plan"` (`%%mode=planwrite`) started the TUI in the CLI/config mode instead of `planwrite`, contradicting the documented `default_prompt` behavior in `docs/CONFIG.md`.

There was a second, latent obstacle: right before `ui::run_interactive`, the checker's mode was unconditionally reset to the CLI/config mode (`set_mode(resolve_mode(...))`). That reset is a no-op today (nothing can change the mode before it, since the apply block is dead), but it would stomp the prompt-applied mode once the apply block works.

## Fix

- New `permission::resolve_startup_prompt_mode(prompts, name)` helper (next to `parse_prompt_mode`): reads the directive from the **raw** prompt content looked up by name, returns `None` for missing prompts/directives, unknown mode names, and `last_user_mode` (meaningless at startup — the current mode already is the user's mode).
- The apply block now uses it via `context.current_prompt_name`.
- Removed the pre-TUI mode reset. The CLI/config mode remains the checker's **user mode** (set at construction), so `%%mode=last_user_mode` prompts still restore it — same semantics as `/prompt` at runtime.

## Tests

- New `src/tests/startup_prompt_mode_tests.rs` (6 tests): directive resolution, `last_user_mode` → `None`, no directive, unknown prompt, unrecognized mode name, directive-not-on-first-line.
- `cargo fmt`, full `cargo test` (614 passed), `cargo install --path . --debug` all green.

Note: independent of #202 (touches disjoint files); either merge order works.