### PR TITLE
perf(tui): make Renderer dirty-region aware

### DIFF
--- a/src/tests/feed_tests.rs
+++ b/src/tests/feed_tests.rs
@@ -206,3 +206,48 @@ fn clear_empties_feed() {
     assert!(feed.is_empty());
     assert_eq!(feed.line_count(80), 0);
 }
+
+#[test]
+fn generation_starts_at_zero() {
+    let feed = Feed::new();
+    assert_eq!(feed.generation(), 0);
+}
+
+#[test]
+fn generation_bumps_on_each_mutator() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Plain, "one");
+    assert_eq!(feed.generation(), 1);
+    feed.push_line(BlockStyle::Plain, "two");
+    assert_eq!(feed.generation(), 2);
+    assert!(feed.append_to_last(" more"));
+    assert_eq!(feed.generation(), 3);
+    feed.replace_last(BlockStyle::Agent, "replaced");
+    assert_eq!(feed.generation(), 4);
+    feed.truncate_blocks(1);
+    assert_eq!(feed.generation(), 5);
+    feed.clear();
+    assert_eq!(feed.generation(), 6);
+}
+
+#[test]
+fn generation_not_bumped_by_failed_append() {
+    let mut feed = Feed::new();
+    assert!(!feed.append_to_last("orphan"));
+    assert_eq!(feed.generation(), 0);
+}
+
+#[test]
+fn generation_not_bumped_by_reads() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "one");
+    let before = feed.generation();
+    let _ = feed.lines(80);
+    let _ = feed.line_count(80);
+    let _ = feed.visible_range(80, 0, 10);
+    let _ = feed.line_at_visual_row(80, 0, 10, 0);
+    let _ = feed.selected_text(80, 0, 0);
+    let _ = feed.is_empty();
+    let _ = feed.block_count();
+    assert_eq!(feed.generation(), before);
+}

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -57,3 +57,236 @@ fn chat_margin_reduces_content_width() {
     r.set_chat_margin(0);
     assert_eq!(r.line_width(), full);
 }
+
+mod dirty {
+    use crate::ui::feed::BlockStyle;
+    use crate::ui::renderer::{BottomRedrawPlan, BottomSnapshot, PromptSnapshot, Renderer};
+    use crate::ui::statusline::StatusSpan;
+
+    fn bottom_snapshot() -> BottomSnapshot {
+        BottomSnapshot {
+            cols: 80,
+            rows: 24,
+            statusline_height: 1,
+            input: String::new(),
+            cursor_pos: 0,
+            is_running: false,
+            spinner_frame: 0,
+            input_vscroll_offset: 0,
+            prompt: PromptSnapshot::Input,
+            statusline: vec![vec![StatusSpan::Text {
+                text: "model".to_string(),
+                fg: None,
+                bg: None,
+            }]],
+            scroll_indicator: false,
+            monochrome: false,
+            input_bg: None,
+            status_bg: None,
+        }
+    }
+
+    #[test]
+    fn fresh_renderer_needs_chat_redraw() {
+        let r = Renderer::new().unwrap();
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn chat_clean_after_mark_clean() {
+        let mut r = Renderer::new().unwrap();
+        r.mark_chat_clean();
+        assert!(!r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn feed_mut_mutation_triggers_chat_redraw() {
+        let mut r = Renderer::new().unwrap();
+        r.mark_chat_clean();
+        r.feed_mut().push_block(BlockStyle::Plain, "hello");
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn scroll_triggers_chat_redraw() {
+        let mut r = Renderer::new().unwrap();
+        // Enough lines to overflow the (fallback 80x24) viewport.
+        for i in 0..40 {
+            r.feed_mut()
+                .push_line(BlockStyle::Plain, format!("line {i}"));
+        }
+        r.mark_chat_clean();
+        assert!(!r.chat_needs_redraw());
+        r.scroll_line_up();
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn resize_marks_chat_dirty() {
+        let mut r = Renderer::new().unwrap();
+        r.mark_chat_clean();
+        r.resize();
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn selection_change_triggers_chat_redraw() {
+        let mut r = Renderer::new().unwrap();
+        r.feed_mut().push_line(BlockStyle::Plain, "selectable");
+        r.mark_chat_clean();
+        assert!(!r.chat_needs_redraw());
+        // Selection fields are public and mutated directly by callers.
+        r.selection_active = true;
+        r.selection_start = Some(0);
+        r.selection_end = Some(0);
+        assert!(r.chat_needs_redraw());
+        r.mark_chat_clean();
+        r.clear_selection();
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn invalidate_marks_chat_dirty() {
+        let mut r = Renderer::new().unwrap();
+        r.mark_chat_clean();
+        r.invalidate();
+        assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn bottom_plan_full_when_no_previous() {
+        let next = bottom_snapshot();
+        assert_eq!(
+            Renderer::bottom_redraw_plan(None, &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_skip_when_unchanged() {
+        let prev = bottom_snapshot();
+        let next = bottom_snapshot();
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Skip
+        );
+    }
+
+    #[test]
+    fn bottom_plan_force_full() {
+        let prev = bottom_snapshot();
+        let next = bottom_snapshot();
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, true),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_statusline_only_on_statusline_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.statusline = vec![vec![StatusSpan::Text {
+            text: "other model".to_string(),
+            fg: None,
+            bg: None,
+        }]];
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::StatuslineOnly
+        );
+    }
+
+    #[test]
+    fn bottom_plan_statusline_only_on_scroll_indicator_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.scroll_indicator = true;
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::StatuslineOnly
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_input_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.input = "typed".to_string();
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_cursor_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.cursor_pos = 3;
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_prompt_mode_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.prompt = PromptSnapshot::Chain {
+            question: "continue?".into(),
+            but_mode: false,
+        };
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_geometry_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.rows = 40;
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_spinner_frame_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.is_running = true;
+        next.spinner_frame = 1;
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_on_input_scroll_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.input_vscroll_offset = 1;
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+
+    #[test]
+    fn bottom_plan_full_when_statusline_and_input_change() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.input = "typed".to_string();
+        next.statusline = Vec::new();
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
+    }
+}

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -83,6 +83,10 @@ impl Block {
 #[derive(Clone, Debug, Default)]
 pub struct Feed {
     blocks: Vec<Block>,
+    /// Bumped by every content mutation. The renderer compares generations to
+    /// know whether the chat viewport needs a redraw, which also catches
+    /// mutations made through `Renderer::feed_mut()`.
+    generation: u64,
 }
 
 // Several helpers exist primarily for unit testing layout/scroll math without
@@ -90,10 +94,19 @@ pub struct Feed {
 #[allow(dead_code)]
 impl Feed {
     pub fn new() -> Self {
-        Self { blocks: Vec::new() }
+        Self {
+            blocks: Vec::new(),
+            generation: 0,
+        }
+    }
+
+    /// Monotonic counter bumped on every content mutation.
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn clear(&mut self) {
+        self.generation += 1;
         self.blocks.clear();
     }
 
@@ -106,6 +119,7 @@ impl Feed {
     }
 
     pub fn push_block(&mut self, style: BlockStyle, text: impl Into<String>) {
+        self.generation += 1;
         self.blocks.push(Block::new(style, text));
     }
 
@@ -117,6 +131,7 @@ impl Feed {
     /// empty and there is no block to append to.
     pub fn append_to_last(&mut self, text: impl AsRef<str>) -> bool {
         if let Some(last) = self.blocks.last_mut() {
+            self.generation += 1;
             last.text.push_str(text.as_ref());
             true
         } else {
@@ -126,15 +141,17 @@ impl Feed {
 
     /// Replace the last block, or push a new one if the feed is empty.
     pub fn replace_last(&mut self, style: BlockStyle, text: impl Into<String>) {
+        self.generation += 1;
         if let Some(last) = self.blocks.last_mut() {
             last.style = style;
             last.text = text.into();
         } else {
-            self.push_block(style, text);
+            self.blocks.push(Block::new(style, text));
         }
     }
 
     pub fn truncate_blocks(&mut self, len: usize) {
+        self.generation += 1;
         self.blocks.truncate(len);
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -153,7 +153,14 @@ pub(crate) fn refresh_display(
     let statusline = crate::ui::statusline::build(ui.session, &statusline_ctx);
     renderer.draw_bottom(&input.buffer, input.cursor, &statusline, run.is_running)?;
     if let Some(ref mut picker) = input.picker {
+        let was_active = picker.active();
         picker.draw()?;
+        if was_active {
+            // The picker painted over the chat and bottom regions, which the
+            // dirty-region tracking cannot see; force a full repaint next
+            // frame so a closing picker never leaves remnants behind.
+            renderer.invalidate();
+        }
     }
     Ok(())
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -50,6 +50,68 @@ pub struct ChainPrompt {
     pub question: CompactString,
 }
 
+/// Everything that affects what the chat viewport paints. Compared between
+/// frames to decide whether `render_viewport` can skip drawing.
+#[derive(Clone, PartialEq)]
+struct ChatSnapshot {
+    feed_generation: u64,
+    width: usize,
+    visible_rows: usize,
+    scroll_offset: usize,
+    selection_active: bool,
+    selection_start: Option<usize>,
+    selection_end: Option<usize>,
+    partial: CompactString,
+    partial_style: BlockStyle,
+    chat_bg: Option<Color>,
+    monochrome: bool,
+}
+
+/// Which prompt mode `draw_bottom` paints in the input area.
+#[derive(Clone, PartialEq)]
+pub(crate) enum PromptSnapshot {
+    Input,
+    Permission {
+        tool: CompactString,
+        options: CompactString,
+    },
+    Chain {
+        question: CompactString,
+        but_mode: bool,
+    },
+}
+
+/// Everything `draw_bottom` paints, compared between frames to decide how much
+/// of the bottom region (input area + statusline) needs repainting.
+#[derive(Clone, PartialEq)]
+pub(crate) struct BottomSnapshot {
+    pub(crate) cols: u16,
+    pub(crate) rows: u16,
+    pub(crate) statusline_height: usize,
+    pub(crate) input: String,
+    pub(crate) cursor_pos: usize,
+    pub(crate) is_running: bool,
+    pub(crate) spinner_frame: u8,
+    pub(crate) input_vscroll_offset: usize,
+    pub(crate) prompt: PromptSnapshot,
+    pub(crate) statusline: Vec<Vec<StatusSpan>>,
+    pub(crate) scroll_indicator: bool,
+    pub(crate) monochrome: bool,
+    pub(crate) input_bg: Option<Color>,
+    pub(crate) status_bg: Option<Color>,
+}
+
+/// How much of the bottom region a `draw_bottom` call must repaint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BottomRedrawPlan {
+    /// Nothing changed since the last frame; draw nothing.
+    Skip,
+    /// Only the statusline content changed; redraw just the statusline rows.
+    StatuslineOnly,
+    /// Input area (or the geometry it sits in) changed; full bottom redraw.
+    Full,
+}
+
 pub struct Renderer {
     spinner_frame: u8,
     feed: Feed,
@@ -84,6 +146,15 @@ pub struct Renderer {
     pub permission_prompt: Option<PermissionPrompt>,
     pub chain_prompt: Option<ChainPrompt>,
     pub chain_but_mode: bool,
+    /// Dirty-region tracking: explicit invalidation flags plus snapshots of
+    /// the state recorded after the last successful draw of each region.
+    chat_dirty: bool,
+    last_chat_snapshot: Option<ChatSnapshot>,
+    bottom_dirty: bool,
+    last_bottom_snapshot: Option<BottomSnapshot>,
+    /// Screen position of the input caret after the last full bottom draw;
+    /// `None` when the caret is hidden (permission/chain prompts).
+    bottom_cursor: Option<(u16, u16)>,
 }
 
 impl Renderer {
@@ -117,6 +188,11 @@ impl Renderer {
             permission_prompt: None,
             chain_prompt: None,
             chain_but_mode: false,
+            chat_dirty: true,
+            last_chat_snapshot: None,
+            bottom_dirty: true,
+            last_bottom_snapshot: None,
+            bottom_cursor: None,
         })
     }
 
@@ -205,6 +281,58 @@ impl Renderer {
         &mut self.feed
     }
 
+    /// Snapshot of everything the chat viewport currently paints.
+    fn chat_snapshot(&self) -> ChatSnapshot {
+        ChatSnapshot {
+            feed_generation: self.feed.generation(),
+            width: self.max_line_width(),
+            visible_rows: self.visible_lines(),
+            scroll_offset: self.scroll_offset,
+            selection_active: self.selection_active,
+            selection_start: self.selection_start,
+            selection_end: self.selection_end,
+            partial: self.partial.clone(),
+            partial_style: self.partial_style,
+            chat_bg: self.chat_bg,
+            monochrome: self.monochrome,
+        }
+    }
+
+    /// Whether the chat viewport needs repainting: either a renderer-internal
+    /// mutation marked it dirty, or the tracked state changed since the last
+    /// recorded draw. The state comparison also catches feed mutations made
+    /// through `feed_mut()` and direct writes to the public selection fields.
+    pub fn chat_needs_redraw(&self) -> bool {
+        if self.chat_dirty {
+            return true;
+        }
+        match &self.last_chat_snapshot {
+            Some(prev) => *prev != self.chat_snapshot(),
+            None => true,
+        }
+    }
+
+    /// Record the current chat state as freshly drawn.
+    fn record_chat_drawn(&mut self) {
+        self.last_chat_snapshot = Some(self.chat_snapshot());
+        self.chat_dirty = false;
+    }
+
+    /// Test helper: mark the chat viewport clean without drawing, as if a
+    /// `render_viewport` had just completed.
+    #[cfg(test)]
+    pub fn mark_chat_clean(&mut self) {
+        self.record_chat_drawn();
+    }
+
+    /// Mark both regions dirty, forcing a full repaint on the next frame.
+    /// Used when something painted over the screen outside the tracked paths
+    /// (e.g. an active picker overlay).
+    pub fn invalidate(&mut self) {
+        self.chat_dirty = true;
+        self.bottom_dirty = true;
+    }
+
     pub fn visible_lines(&self) -> usize {
         let (_, rows) = self.terminal_size();
         let input_height = self.prev_input_height.max(1);
@@ -263,6 +391,7 @@ impl Renderer {
     }
 
     pub fn clear_selection(&mut self) {
+        self.chat_dirty = true;
         self.selection_active = false;
         self.selection_start = None;
         self.selection_end = None;
@@ -312,6 +441,7 @@ impl Renderer {
             self.feed
                 .push_block(self.partial_style, self.partial.as_str());
             self.partial.clear();
+            self.chat_dirty = true;
         }
     }
 
@@ -387,12 +517,14 @@ impl Renderer {
         let max_offset = self.buffer_len().saturating_sub(visible);
         if self.scroll_offset < max_offset {
             self.scroll_offset += 1;
+            self.chat_dirty = true;
         }
     }
 
     pub fn scroll_line_down(&mut self) {
         if self.scroll_offset > 0 {
             self.scroll_offset -= 1;
+            self.chat_dirty = true;
         }
     }
 
@@ -400,26 +532,41 @@ impl Renderer {
         let visible = self.visible_lines();
         let page = visible.saturating_sub(2).max(1);
         let max_offset = self.buffer_len().saturating_sub(visible);
-        self.scroll_offset = (self.scroll_offset + page).min(max_offset);
+        let new_offset = (self.scroll_offset + page).min(max_offset);
+        if new_offset != self.scroll_offset {
+            self.scroll_offset = new_offset;
+            self.chat_dirty = true;
+        }
     }
 
     pub fn scroll_page_down(&mut self) {
         let visible = self.visible_lines();
         let page = visible.saturating_sub(2).max(1);
-        if self.scroll_offset <= page {
-            self.scroll_offset = 0;
+        let new_offset = if self.scroll_offset <= page {
+            0
         } else {
-            self.scroll_offset = self.scroll_offset.saturating_sub(page);
+            self.scroll_offset.saturating_sub(page)
+        };
+        if new_offset != self.scroll_offset {
+            self.scroll_offset = new_offset;
+            self.chat_dirty = true;
         }
     }
 
     pub fn scroll_to_top(&mut self) {
         let visible = self.visible_lines();
-        self.scroll_offset = self.buffer_len().saturating_sub(visible);
+        let new_offset = self.buffer_len().saturating_sub(visible);
+        if new_offset != self.scroll_offset {
+            self.scroll_offset = new_offset;
+            self.chat_dirty = true;
+        }
     }
 
     pub fn scroll_to_bottom(&mut self) -> io::Result<()> {
-        self.scroll_offset = 0;
+        if self.scroll_offset != 0 {
+            self.scroll_offset = 0;
+            self.chat_dirty = true;
+        }
         self.sync_to_buffer()
     }
 
@@ -429,6 +576,9 @@ impl Renderer {
     }
 
     pub fn render_viewport(&mut self) -> io::Result<()> {
+        if !self.chat_needs_redraw() {
+            return Ok(());
+        }
         let (cols, _rows) = self.terminal_size();
         let max_width = cols.saturating_sub(1 + self.chat_margin) as usize;
         let visible = self.visible_lines();
@@ -533,6 +683,7 @@ impl Renderer {
         }
 
         stdout.flush()?;
+        self.record_chat_drawn();
         Ok(())
     }
 
@@ -540,6 +691,7 @@ impl Renderer {
         self.commit_partial();
         let style = style_from_color(color);
         self.feed.push_block(style, text);
+        self.chat_dirty = true;
         if self.scroll_offset == 0 {
             self.render_viewport()?;
         }
@@ -566,6 +718,7 @@ impl Renderer {
                 self.partial.push_str(segment);
             }
         }
+        self.chat_dirty = true;
         if self.scroll_offset == 0 {
             self.render_viewport()?;
         }
@@ -573,6 +726,7 @@ impl Renderer {
     }
 
     pub fn clear_content(&mut self) -> io::Result<()> {
+        self.chat_dirty = true;
         self.feed.clear();
         self.partial.clear();
         self.scroll_offset = 0;
@@ -589,6 +743,7 @@ impl Renderer {
     }
 
     pub fn resize(&mut self) {
+        self.chat_dirty = true;
         let visible = self.visible_lines();
         let max_offset = self.buffer_len().saturating_sub(visible);
         if self.scroll_offset > max_offset {
@@ -752,6 +907,97 @@ impl Renderer {
         Ok(())
     }
 
+    /// Snapshot of everything `draw_bottom` would paint for these arguments.
+    fn bottom_snapshot(
+        &self,
+        input_line: &str,
+        cursor_pos: usize,
+        statusline: &[Vec<StatusSpan>],
+        is_running: bool,
+        cols: u16,
+        rows: u16,
+    ) -> BottomSnapshot {
+        let prompt = if let Some(ref pp) = self.permission_prompt {
+            PromptSnapshot::Permission {
+                tool: pp.tool.clone(),
+                options: pp.options.clone(),
+            }
+        } else if let Some(ref cp) = self.chain_prompt {
+            PromptSnapshot::Chain {
+                question: cp.question.clone(),
+                but_mode: self.chain_but_mode,
+            }
+        } else {
+            PromptSnapshot::Input
+        };
+        BottomSnapshot {
+            cols,
+            rows,
+            statusline_height: self.statusline_height,
+            input: input_line.to_string(),
+            cursor_pos,
+            is_running,
+            spinner_frame: self.spinner_frame,
+            input_vscroll_offset: self.input_vscroll_offset,
+            scroll_indicator: matches!(prompt, PromptSnapshot::Input) && self.scroll_offset > 0,
+            prompt,
+            statusline: statusline.to_vec(),
+            monochrome: self.monochrome,
+            input_bg: self.input_bg,
+            status_bg: self.status_bg,
+        }
+    }
+
+    /// Pure redraw decision for the bottom region: compare the state recorded
+    /// after the last draw with the state about to be drawn. When only the
+    /// statusline content (or the scroll indicator painted inside it) differs,
+    /// the input area is untouched and only the statusline rows need a repaint.
+    pub(crate) fn bottom_redraw_plan(
+        prev: Option<&BottomSnapshot>,
+        next: &BottomSnapshot,
+        force_full: bool,
+    ) -> BottomRedrawPlan {
+        if force_full {
+            return BottomRedrawPlan::Full;
+        }
+        let Some(prev) = prev else {
+            return BottomRedrawPlan::Full;
+        };
+        if prev == next {
+            return BottomRedrawPlan::Skip;
+        }
+        let mut status_only = next.clone();
+        status_only.statusline = prev.statusline.clone();
+        status_only.scroll_indicator = prev.scroll_indicator;
+        if status_only == *prev {
+            BottomRedrawPlan::StatuslineOnly
+        } else {
+            BottomRedrawPlan::Full
+        }
+    }
+
+    /// Record the bottom region as freshly drawn.
+    fn record_bottom_drawn(&mut self, snapshot: BottomSnapshot) {
+        self.last_bottom_snapshot = Some(snapshot);
+        self.bottom_dirty = false;
+    }
+
+    /// Re-place the terminal caret where the last full bottom draw left it.
+    /// Needed after a statusline-only redraw, which moves the cursor.
+    fn restore_bottom_cursor(&self) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        match self.bottom_cursor {
+            Some((x, row)) => {
+                stdout.execute(MoveTo(x, row))?;
+                write!(stdout, "{}", Show)?;
+            }
+            None => {
+                write!(stdout, "{}", Hide)?;
+            }
+        }
+        stdout.flush()
+    }
+
     pub fn draw_bottom(
         &mut self,
         input_line: &str,
@@ -760,6 +1006,22 @@ impl Renderer {
         is_running: bool,
     ) -> io::Result<()> {
         let (cols, rows) = crossterm::terminal::size()?;
+        let snapshot =
+            self.bottom_snapshot(input_line, cursor_pos, statusline, is_running, cols, rows);
+        match Self::bottom_redraw_plan(
+            self.last_bottom_snapshot.as_ref(),
+            &snapshot,
+            self.bottom_dirty,
+        ) {
+            BottomRedrawPlan::Skip => return Ok(()),
+            BottomRedrawPlan::StatuslineOnly => {
+                self.draw_statusline(statusline, cols, snapshot.scroll_indicator)?;
+                self.restore_bottom_cursor()?;
+                self.record_bottom_drawn(snapshot);
+                return Ok(());
+            }
+            BottomRedrawPlan::Full => {}
+        }
         let reserve = self.statusline_reserve();
         let mut stdout = io::stdout();
 
@@ -800,6 +1062,8 @@ impl Renderer {
             self.draw_statusline(statusline, cols, false)?;
             write!(stdout, "{}", Hide)?;
             stdout.flush()?;
+            self.bottom_cursor = None;
+            self.record_bottom_drawn(snapshot);
             return Ok(());
         }
 
@@ -846,6 +1110,8 @@ impl Renderer {
             self.draw_statusline(statusline, cols, false)?;
             write!(stdout, "{}", Hide)?;
             stdout.flush()?;
+            self.bottom_cursor = None;
+            self.record_bottom_drawn(snapshot);
             return Ok(());
         }
 
@@ -1023,6 +1289,14 @@ impl Renderer {
         stdout.execute(MoveTo(cursor_x, cursor_row))?;
         write!(stdout, "{}", Show)?;
         stdout.flush()?;
+        self.bottom_cursor = Some((cursor_x, cursor_row));
+        // The draw itself settles `input_vscroll_offset` (cursor follow /
+        // clamping); record the settled value so the next identical frame is
+        // recognized as unchanged. `spinner_frame` deliberately keeps the
+        // pre-draw value so a running spinner still differs next frame.
+        let mut drawn = snapshot;
+        drawn.input_vscroll_offset = self.input_vscroll_offset;
+        self.record_bottom_drawn(drawn);
         Ok(())
     }
 }

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -18,7 +18,7 @@ use crate::ui::utils::parse_color;
 pub const MAX_STATUS_LINES: usize = 3;
 
 /// A drawable statusline piece after items are resolved.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StatusSpan {
     Text {
         text: String,


### PR DESCRIPTION
Implements the first item of the **Rendering performance** section of #186:

> Make Renderer dirty-region aware: track whether the chat buffer, input area, or statusline changed, and redraw only what changed.

## What changed

- **Chat buffer** — `Feed` gains a `generation` counter bumped by every mutator, so mutations through `feed_mut()` are detected without changing its signature. `render_viewport()` returns early when `chat_needs_redraw()` is false (dirty flag + snapshot comparison: generation, width, scroll offset, selection, partial line) and records the snapshot after a successful draw.
- **Input area** — `draw_bottom()` builds a `BottomSnapshot` (buffer, cursor, height, prompt mode, spinner frame, vscroll) and consults the pure `bottom_redraw_plan()`: `Skip` when nothing changed, `StatuslineOnly` when only the statusline differs, `Full` otherwise (the full path is byte-identical to before).
- **Statusline** — `StatusSpan` now derives `PartialEq`, so unchanged statuslines are skipped; a statusline-only change redraws just those rows and restores the caret.
- **Safety valve** — `refresh_display()` calls `renderer.invalidate()` after an active picker draws, since pickers paint over tracked regions; any untracked mutation is also backstopped by the snapshot comparisons, so a missed skip costs a frame, never a stale screen.

All dirty *decisions* are pure functions, so they're unit-tested without a terminal.

## Tests

23 new tests (631 → 643 total after rebase onto `main`, all passing):
- `feed_tests.rs`: generation counter bumps on each mutator, not on reads or failed appends.
- `renderer_tests.rs`: chat dirty tracking (fresh renderer, mark-clean, `feed_mut` mutation, scroll, resize, selection, invalidate) and `bottom_redraw_plan` decisions (skip / statusline-only / full across all snapshot fields).

`cargo fmt`, `cargo test`, and `cargo install --path . --debug` all clean.

Refs #186