### PR TITLE
perf: parse markdown only for completed lines while streaming

### DIFF
--- a/src/tests/feed_tests.rs
+++ b/src/tests/feed_tests.rs
@@ -251,3 +251,106 @@ fn generation_not_bumped_by_reads() {
     let _ = feed.block_count();
     assert_eq!(feed.generation(), before);
 }
+
+#[test]
+fn running_agent_block_renders_tail_as_plain_text() {
+    let mut feed = Feed::new();
+    feed.push_streaming_block(BlockStyle::Agent);
+    assert!(feed.append_to_last("hello **wor"));
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    // No markdown parsing while the line is unfinished: markers stay literal.
+    assert_eq!(lines[0].text, "< hello **wor");
+    assert_eq!(lines[0].color, Color::White);
+}
+
+#[test]
+fn running_agent_block_parses_only_completed_lines() {
+    let mut feed = Feed::new();
+    feed.push_streaming_block(BlockStyle::Agent);
+    assert!(feed.append_to_last("first **bold**\nsecond **par"));
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 2);
+    // The completed line is parsed as markdown: bold markers are gone.
+    assert_eq!(lines[0].text, "< first bold");
+    // The unfinished tail line stays plain: markers remain literal.
+    assert_eq!(lines[1].text, "second **par");
+}
+
+#[test]
+fn running_agent_block_appends_grow_tail() {
+    let mut feed = Feed::new();
+    feed.push_streaming_block(BlockStyle::Agent);
+    assert!(feed.append_to_last("hello"));
+    assert!(feed.append_to_last(" world"));
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text, "< hello world");
+}
+
+#[test]
+fn finalize_last_parses_full_text() {
+    let mut feed = Feed::new();
+    feed.push_streaming_block(BlockStyle::Agent);
+    assert!(feed.append_to_last("hello **world**"));
+    feed.finalize_last();
+    let lines = feed.lines(80);
+    assert_eq!(lines.len(), 1);
+    // After finalizing, the former tail line is parsed as markdown.
+    assert_eq!(lines[0].text, "< hello world");
+}
+
+#[test]
+fn finalize_last_bumps_generation_once() {
+    let mut feed = Feed::new();
+    feed.push_streaming_block(BlockStyle::Agent);
+    let before = feed.generation();
+    feed.finalize_last();
+    assert_eq!(feed.generation(), before + 1);
+    // Second call is a no-op: the block is no longer running.
+    feed.finalize_last();
+    assert_eq!(feed.generation(), before + 1);
+}
+
+#[test]
+fn finalize_last_on_complete_block_is_noop() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Agent, "done");
+    let before = feed.generation();
+    feed.finalize_last();
+    assert_eq!(feed.generation(), before);
+}
+
+#[test]
+fn replace_last_invalidates_cached_layout() {
+    let mut feed = Feed::new();
+    feed.push_block(BlockStyle::Agent, "aaaa **old**");
+    let _ = feed.lines(80); // populate the layout cache
+    // Same length, different content: the cached layout must not leak through.
+    feed.replace_last(BlockStyle::Agent, "bbbb **new**");
+    let lines = feed.lines(80);
+    let joined: String = lines
+        .iter()
+        .map(|l| l.text.as_str())
+        .collect::<Vec<_>>()
+        .join("");
+    assert!(joined.contains("new"), "expected new content: {joined}");
+    assert!(!joined.contains("old"), "stale cached content: {joined}");
+}
+
+#[test]
+fn agent_layout_recomputes_on_width_change() {
+    let mut feed = Feed::new();
+    feed.push_block(
+        BlockStyle::Agent,
+        "one two three four five six seven eight nine ten eleven twelve",
+    );
+    let wide = feed.lines(120);
+    let narrow = feed.lines(20);
+    assert!(
+        narrow.len() > wide.len(),
+        "narrow width should wrap into more lines: {} vs {}",
+        narrow.len(),
+        wide.len()
+    );
+}

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -79,22 +79,22 @@ pub async fn handle_agent_event(
                 return Ok(());
             }
 
-            // Throttle markdown re-parsing: only re-parse when the buffer
-            // ends with a newline (markdown structure changes at line
-            // boundaries) or when the buffer is small. This avoids O(n²)
-            // re-parsing on every token. The final parse happens in
-            // handle_agent_done.
+            if run.response_start_block.is_none() {
+                renderer.feed_mut().push_streaming_block(BlockStyle::Agent);
+                run.response_start_block = Some(renderer.feed().block_count() - 1);
+            }
+            // Append the token to the running block: layout renders the
+            // unfinished tail line as plain text and parses markdown only for
+            // completed lines, instead of re-parsing the whole response.
+            renderer.feed_mut().append_to_last(&safe);
+
+            // Throttle repaints: redraw when a line completed (markdown
+            // structure changes at line boundaries) or while the buffer is
+            // small. The final full parse happens in handle_agent_done.
             if run.response_buf.len() >= 200 && !run.response_buf.ends_with('\n') {
                 return Ok(());
             }
 
-            if run.response_start_block.is_none() {
-                renderer.feed_mut().push_block(BlockStyle::Agent, "");
-                run.response_start_block = Some(renderer.feed().block_count() - 1);
-            }
-            renderer
-                .feed_mut()
-                .replace_last(BlockStyle::Agent, run.response_buf.as_str());
             renderer.render_viewport()?;
             run.agent_line_started = true;
         }
@@ -319,11 +319,16 @@ async fn handle_agent_done(
 
     if !run.response_buf.is_empty() {
         if let Some(start) = run.response_start_block {
+            // Drop anything interleaved after the streaming block, then
+            // finalize it: the full response (including the last line) is
+            // parsed as markdown once, here.
             renderer.feed_mut().truncate_blocks(start + 1);
+            renderer.feed_mut().finalize_last();
+        } else {
+            renderer
+                .feed_mut()
+                .push_block(BlockStyle::Agent, run.response_buf.as_str());
         }
-        renderer
-            .feed_mut()
-            .replace_last(BlockStyle::Agent, run.response_buf.as_str());
         renderer.render_viewport()?;
     } else if !run.agent_line_started {
         renderer.feed_mut().push_line(BlockStyle::Agent, "< ");

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use compact_str::CompactString;
 use crossterm::style::Color;
 
@@ -67,6 +69,23 @@ pub fn style_from_color(color: Color) -> BlockStyle {
 pub struct Block {
     pub style: BlockStyle,
     pub text: String,
+    /// True while a producer is still appending to this block (e.g. streaming
+    /// agent tokens). A running agent block parses markdown only for its
+    /// completed lines and renders the unfinished tail line as plain text.
+    running: bool,
+    /// Memoized markdown layout. Interior mutability keeps `Feed::lines` a
+    /// `&self` read; `Feed` mutators that rewrite block text invalidate it.
+    md_cache: RefCell<Option<MdCache>>,
+}
+
+/// Memoized markdown layout of an agent block's completed text at a width.
+#[derive(Clone, Debug)]
+struct MdCache {
+    width: usize,
+    /// Byte length of the parsed prefix: up to the last completed line for
+    /// running blocks, the full text once finalized.
+    parsed_len: usize,
+    lines: Vec<LineEntry>,
 }
 
 impl Block {
@@ -74,6 +93,8 @@ impl Block {
         Self {
             style,
             text: text.into(),
+            running: false,
+            md_cache: RefCell::new(None),
         }
     }
 }
@@ -123,6 +144,31 @@ impl Feed {
         self.blocks.push(Block::new(style, text));
     }
 
+    /// Push an empty block that a producer will append to incrementally
+    /// (e.g. streaming agent tokens). While running, agent blocks parse
+    /// markdown only for completed lines and render the unfinished tail line
+    /// as plain text. Call `finalize_last` when the stream ends.
+    pub fn push_streaming_block(&mut self, style: BlockStyle) {
+        self.generation += 1;
+        let mut block = Block::new(style, "");
+        block.running = true;
+        self.blocks.push(block);
+    }
+
+    /// Mark the last block as complete: its full text (including the former
+    /// tail line) is parsed as markdown on the next layout. No-op when the
+    /// last block is not running.
+    pub fn finalize_last(&mut self) {
+        if let Some(last) = self.blocks.last_mut()
+            && last.running
+        {
+            self.generation += 1;
+            last.running = false;
+            // Force one full re-parse now that the text is complete.
+            *last.md_cache.borrow_mut() = None;
+        }
+    }
+
     pub fn push_line(&mut self, style: BlockStyle, text: impl Into<String>) {
         self.push_block(style, text);
     }
@@ -145,6 +191,8 @@ impl Feed {
         if let Some(last) = self.blocks.last_mut() {
             last.style = style;
             last.text = text.into();
+            last.running = false;
+            *last.md_cache.borrow_mut() = None;
         } else {
             self.blocks.push(Block::new(style, text));
         }
@@ -160,12 +208,15 @@ impl Feed {
     /// The result is a list of `LineEntry` values, one per visible row, that the
     /// renderer can draw directly. Markdown is parsed for agent blocks; all
     /// other blocks are word-wrapped and colored by their semantic role.
+    /// Running agent blocks parse markdown only for their completed lines and
+    /// render the unfinished tail line as plain text; parsed layouts are
+    /// memoized per block so repeated layouts at the same width don't re-parse.
     pub fn lines(&self, width: usize) -> Vec<LineEntry> {
         let mut result = Vec::new();
         for block in &self.blocks {
             match block.style {
                 BlockStyle::Agent => {
-                    let mut styled = markdown_to_styled(&block.text, width);
+                    let mut styled = agent_block_lines(block, width);
                     if !styled.is_empty() {
                         styled[0].text = CompactString::from(format!("< {}", styled[0].text));
                     }
@@ -290,5 +341,64 @@ impl Feed {
         } else {
             Some(result)
         }
+    }
+}
+
+/// Lay out an agent block: markdown for completed lines, plain text for the
+/// unfinished tail line of a still-streaming block.
+///
+/// The markdown parse of the completed prefix is memoized in the block's
+/// `MdCache`. The cache key is `(width, parsed_len)`; this is valid because
+/// block text grows by appends only while running, so an unchanged prefix
+/// length means an unchanged prefix. Mutators that rewrite text
+/// (`replace_last`, `finalize_last`) clear the cache explicitly.
+fn agent_block_lines(block: &Block, width: usize) -> Vec<LineEntry> {
+    // Text parsed as markdown: the whole block once finalized, or only the
+    // completed lines (up to the last newline) while streaming.
+    let completed_len = if block.running {
+        match block.text.rfind('\n') {
+            Some(idx) => idx + 1,
+            None => 0,
+        }
+    } else {
+        block.text.len()
+    };
+
+    let mut lines = match cached_agent_lines(block, width, completed_len) {
+        Some(lines) => lines,
+        None => {
+            let parsed = markdown_to_styled(&block.text[..completed_len], width);
+            *block.md_cache.borrow_mut() = Some(MdCache {
+                width,
+                parsed_len: completed_len,
+                lines: parsed.clone(),
+            });
+            parsed
+        }
+    };
+
+    // The unfinished tail line of a running block is rendered as plain text:
+    // its markdown markers are not parsed until the line completes. This
+    // avoids re-parsing the whole response on every streamed token.
+    if block.running && completed_len < block.text.len() {
+        let tail = block.text[completed_len..].trim_end_matches('\r');
+        if !tail.is_empty() {
+            let color = BlockStyle::Agent.color();
+            for chunk in word_wrap(tail, width) {
+                lines.push(LineEntry { text: chunk, color });
+            }
+        }
+    }
+    lines
+}
+
+/// Return the memoized markdown layout when it matches `(width, parsed_len)`.
+fn cached_agent_lines(block: &Block, width: usize, parsed_len: usize) -> Option<Vec<LineEntry>> {
+    let cache = block.md_cache.borrow();
+    let cache = cache.as_ref()?;
+    if cache.width == width && cache.parsed_len == parsed_len {
+        Some(cache.lines.clone())
+    } else {
+        None
     }
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -35,7 +35,7 @@ fn wrap_urls_osc8(text: &str) -> String {
     result
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LineEntry {
     pub text: CompactString,
     pub color: Color,


### PR DESCRIPTION
Implements item 2 of **Rendering performance** in #186:

> Append streaming tokens to a running line and render the current unfinished line as plain text; parse markdown only for completed lines to avoid O(n²) re-parsing.

## Changes

**`src/ui/feed.rs`**
- `Block` gains a `running` flag and a per-block `MdCache` (memoized markdown layout keyed by `(width, parsed_len)`, via `RefCell` so `Feed::lines` stays a `&self` read).
- New `Feed::push_streaming_block(style)` and `Feed::finalize_last()`; `replace_last` clears the cache and the running flag.
- `Feed::lines` delegates agent blocks to `agent_block_lines`: while running, only text up to the last newline is parsed as markdown; the unfinished tail line is word-wrapped as plain text. Cache validity rests on text growing by appends only while running, so an unchanged prefix length means an unchanged prefix — completed blocks (including all history) now parse once per width instead of on every frame.

**`src/ui/event_handler.rs`**
- `AgentEvent::Token`: creates a streaming block once, then `append_to_last` per token instead of `replace_last` with the whole `response_buf` (no more full-buffer copy per token). The existing repaint throttle (line boundary or small buffer) is unchanged.
- `handle_agent_done`: `truncate_blocks(start + 1)` + `finalize_last()` — the full response, tail line included, is parsed as markdown exactly once.

**Tests** — 8 new cases in `src/tests/feed_tests.rs`: plain-text tail rendering, completed-line-only parsing, incremental append growth, finalize semantics + generation bumps, cache invalidation on same-length `replace_last`, and re-layout on width change.

## Verification

- `cargo fmt` applied
- `cargo test`: 656 passed, 0 failed
- `cargo install --path . --debug` succeeds