### PR TITLE
feat: project-local config override via .zerostack/config.toml

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -12,6 +12,27 @@ at any priority, a default `config.toml` is created in the lowest-priority
 directory (`~/.local/share/zerostack/`). On macOS the XDG config path above
 resolves to `~/Library/Application Support/zerostack/`.
 
+**Project-local override**: if `.zerostack/config.toml` exists in the
+current working directory, it is merged over the global config at startup.
+Any subset of keys may be set — tables (e.g. `mcp_servers`, `quick_models`,
+`api_keys`) merge per key, scalars and arrays replace the global value, and
+keys absent from the local file keep their global values. A startup note is
+printed whenever an override is applied.
+
+```toml
+# .zerostack/config.toml
+model = "anthropic/claude-sonnet-4-5"
+show_reasoning = true
+
+[mcp_servers.local-fs]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+```
+
+The local file is trusted exactly like the global config — it can enable
+`yolo`/`accept-all`, add permission rules, or spawn MCP server processes —
+so review `.zerostack/config.toml` when working in untrusted checkouts.
+
 Prompts and themes are loaded from multiple sources, with later sources
 overriding earlier ones for same-named files:
 
@@ -696,7 +717,9 @@ permission-regex:
 ```
 
 When compiled with MCP support, `mcp_servers` accepts command-based and URL-based
-servers:
+servers. Servers can also be added per project via `.zerostack/config.toml`
+(see *Project-local override* above); project servers merge with — and can
+override — global ones by name.
 
 ```json
 {

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -366,10 +366,88 @@ pub fn load() -> (Config, bool) {
         cfg.custom_providers.as_ref().map(|m| m.len()).unwrap_or(0),
     );
 
+    apply_local_override(&mut cfg);
+
     #[cfg(feature = "mcp")]
     inject_mcp_defaults(&mut cfg);
 
     (cfg, is_first_startup)
+}
+
+/// Project-local config override, resolved relative to the CWD at startup.
+pub const LOCAL_CONFIG_PATH: &str = ".zerostack/config.toml";
+
+/// Merge `.zerostack/config.toml` over the global config when it exists.
+/// The local file is trusted exactly like the global one — it can set any
+/// key, including `yolo` or permission rules — so a startup note is printed
+/// whenever an override is applied.
+fn apply_local_override(cfg: &mut Config) {
+    let path = std::path::Path::new(LOCAL_CONFIG_PATH);
+    if !path.exists() {
+        return;
+    }
+    let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!(
+            "error: failed to read project config ({}): {}",
+            path.display(),
+            e,
+        );
+        std::process::exit(1);
+    });
+    match merge_config_override(cfg, &content) {
+        Ok(merged) => {
+            tracing::info!(
+                "applied project-local config override from {}",
+                path.display()
+            );
+            eprintln!(
+                "note: applied project-local config override from {}",
+                path.display()
+            );
+            *cfg = merged;
+        }
+        Err(e) => {
+            eprintln!(
+                "error: {} is not a valid config: {}\n\
+                 Fix the file or remove it to use defaults.",
+                path.display(),
+                e,
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Merge a project-local TOML config fragment over `base`: keys present in
+/// `local_toml` win, tables (`quick_models`, `mcp_servers`, ...) merge per
+/// key, scalars and arrays replace, and absent keys keep the base value.
+pub fn merge_config_override(base: &Config, local_toml: &str) -> Result<Config, String> {
+    let local: toml::Value = toml::from_str(local_toml).map_err(|e| e.to_string())?;
+    let local_json = serde_json::to_value(&local).map_err(|e| e.to_string())?;
+    // `Config` skips `None` fields when serializing, so the base JSON holds
+    // exactly the keys that are set and the local JSON exactly the keys the
+    // project file sets.
+    let mut base_json = serde_json::to_value(base).map_err(|e| e.to_string())?;
+    deep_merge_json(&mut base_json, local_json);
+    serde_json::from_value(base_json).map_err(|e| e.to_string())
+}
+
+/// Deep-merge `over` into `base`: objects merge recursively per key, any
+/// other value replaces.
+fn deep_merge_json(base: &mut serde_json::Value, over: serde_json::Value) {
+    match (base, over) {
+        (serde_json::Value::Object(b), serde_json::Value::Object(o)) => {
+            for (k, v) in o {
+                match b.get_mut(&k) {
+                    Some(existing) => deep_merge_json(existing, v),
+                    None => {
+                        b.insert(k, v);
+                    }
+                }
+            }
+        }
+        (slot, v) => *slot = v,
+    }
 }
 
 #[cfg(feature = "mcp")]

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -409,3 +409,129 @@ fn config_candidate_priority_toml_yaml_yml_legacy_json() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+use crate::config::merge_config_override;
+
+#[test]
+fn local_override_replaces_scalar() {
+    let base = Config {
+        model: Some(CompactString::new("global-model")),
+        ..Config::default()
+    };
+    let merged = merge_config_override(&base, "model = \"local-model\"").unwrap();
+    assert_eq!(merged.model.as_deref(), Some("local-model"));
+}
+
+#[test]
+fn local_override_keeps_unset_keys() {
+    let base = Config {
+        model: Some(CompactString::new("global-model")),
+        temperature: Some(0.7),
+        ..Config::default()
+    };
+    let merged = merge_config_override(&base, "temperature = 0.2").unwrap();
+    assert_eq!(merged.model.as_deref(), Some("global-model"));
+    assert_eq!(merged.temperature, Some(0.2));
+}
+
+#[test]
+fn local_override_merges_maps_per_key() {
+    let mut keys = HashMap::new();
+    keys.insert("openai".to_string(), "sk-global".to_string());
+    keys.insert("gemini".to_string(), "gm-global".to_string());
+    let base = Config {
+        api_keys: Some(keys),
+        ..Config::default()
+    };
+    let local = r#"
+[api_keys]
+gemini = "gm-local"
+anthropic = "sk-ant-local"
+"#;
+    let merged = merge_config_override(&base, local).unwrap();
+    let keys = merged.api_keys.unwrap();
+    // Untouched key kept, existing key replaced, new key added.
+    assert_eq!(keys.get("openai").map(String::as_str), Some("sk-global"));
+    assert_eq!(keys.get("gemini").map(String::as_str), Some("gm-local"));
+    assert_eq!(
+        keys.get("anthropic").map(String::as_str),
+        Some("sk-ant-local")
+    );
+}
+
+#[test]
+fn local_override_arrays_replace() {
+    let base = Config {
+        permission_modes: Some(vec!["a".to_string(), "b".to_string()]),
+        ..Config::default()
+    };
+    let merged = merge_config_override(&base, "permission-modes = [\"c\"]").unwrap();
+    assert_eq!(merged.permission_modes, Some(vec!["c".to_string()]));
+}
+
+#[test]
+fn local_override_partial_retry() {
+    // `retry` is a non-Option struct: a local `[retry]` table must merge per
+    // key over the (default-filled) base rather than replace it wholesale.
+    let base = Config::default();
+    let merged = merge_config_override(&base, "[retry]\nmax_attempts = 9").unwrap();
+    assert_eq!(merged.retry.max_attempts, 9);
+    assert_eq!(merged.retry.initial_backoff_ms, 500);
+    assert_eq!(merged.retry.max_backoff_ms, 10_000);
+}
+
+#[test]
+fn local_override_empty_keeps_base() {
+    let base = Config {
+        model: Some(CompactString::new("global-model")),
+        ..Config::default()
+    };
+    let merged = merge_config_override(&base, "").unwrap();
+    assert_eq!(merged.model.as_deref(), Some("global-model"));
+}
+
+#[test]
+fn local_override_invalid_toml_errors() {
+    assert!(merge_config_override(&Config::default(), "not [valid").is_err());
+}
+
+#[test]
+fn local_override_wrong_type_errors() {
+    let err = merge_config_override(&Config::default(), "max_tokens = \"lots\"").unwrap_err();
+    assert!(!err.is_empty());
+}
+
+#[cfg(feature = "mcp")]
+#[test]
+fn local_override_merges_mcp_servers() {
+    use crate::extras::mcp::config::McpServerConfig;
+    let mut servers = HashMap::new();
+    servers.insert(
+        "global-srv".to_string(),
+        McpServerConfig::Url {
+            url: "https://global.example.com/mcp".to_string(),
+            headers: HashMap::new(),
+            oauth: None,
+        },
+    );
+    let base = Config {
+        mcp_servers: Some(servers),
+        ..Config::default()
+    };
+    let local = r#"
+[mcp_servers.local-fs]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+"#;
+    let merged = merge_config_override(&base, local).unwrap();
+    let servers = merged.mcp_servers.unwrap();
+    assert_eq!(servers.len(), 2);
+    assert!(matches!(
+        servers.get("global-srv"),
+        Some(McpServerConfig::Url { .. })
+    ));
+    assert!(matches!(
+        servers.get("local-fs"),
+        Some(McpServerConfig::Command { .. })
+    ));
+}


### PR DESCRIPTION
## Motivation

The goal is **more flexibility in how zerostack is configured per project**. Today all config (including `mcp_servers`) lives in a single global file, so anything project-specific — the prime example being **per-project MCP servers** — has to be registered globally, leaking across every other project. Prompts and themes already have a project-local tier (`prompts/`, `.zerostack/prompts/` relative to CWD); this PR extends the same idea to the config itself, rather than special-casing MCP alone.

## What it does

If `.zerostack/config.toml` exists in the current working directory at startup, it is merged over the global config. Any subset of keys may be set:

```toml
# .zerostack/config.toml
model = "anthropic/claude-sonnet-4-5"
show_reasoning = true

[mcp_servers.local-fs]
command = "npx"
args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
```

**Merge semantics**: tables (`mcp_servers`, `quick_models`, `api_keys`, …) merge **per key** (local wins on conflicts, global-only keys kept), scalars and arrays **replace**, absent keys keep global values. `[retry]` merges per key as well.

## Implementation

- `merge_config_override` (`src/config/load.rs`): parses the local TOML to a value and deep-merges it over the *serialized* global config. Because `Config` skips `None` fields on serialization, the merge automatically covers every present and future key — no per-field list to maintain, and no changes to the `Config` struct.
- Hooked into `load()` before `inject_mcp_defaults`, so local `enable-*-mcp` flags and explicit `mcp_servers` interact correctly with the recommended-server defaults.
- A startup note (`note: applied project-local config override from ...`) is printed whenever an override applies: the local file is as trusted as the global config — it can enable `yolo`, add permission rules, or spawn MCP server processes — so silent application would be a footgun when cloning untrusted repos. This trust consideration is documented in `docs/CONFIG.md`.
- Invalid local TOML / wrong types abort with the same "fix the file or remove it" error style as the global config.

## Tests & docs

- 9 new tests in `src/tests/config_tests.rs`: scalar replace, unset keys kept, per-key map merge, array replace, partial `[retry]` merge, empty/invalid/wrong-type input, MCP server merge.
- `docs/CONFIG.md`: new *Project-local override* section + a pointer from the MCP servers section.
- Full suite: 657 passed, 0 failed. Smoke-tested end-to-end from a temp CWD (startup note prints, config loads).

Note: the suite has a pre-existing flaky test (`track_read_duplicate_returns_blocking_message`) that races on the global `deny_repeated_reads` flag under parallelism — unrelated to this PR, but worth a follow-up fix.