### PR TITLE
perf: pre-wrap feed layout so scroll/selection reuse visual rows

### DIFF
--- a/src/tests/feed_tests.rs
+++ b/src/tests/feed_tests.rs
@@ -354,3 +354,32 @@ fn agent_layout_recomputes_on_width_change() {
         wide.len()
     );
 }
+
+#[test]
+fn scroll_and_selection_queries_reuse_prewrapped_rows() {
+    let mut feed = Feed::new();
+    feed.push_line(BlockStyle::Plain, "hello");
+    let _ = feed.lines(80);
+    let _ = feed.line_count(80);
+    let _ = feed.visible_range(80, 0, 10);
+    let _ = feed.selected_text(80, 0, 0);
+    let _ = feed.line_at_visual_row(80, 0, 10, 9);
+    assert_eq!(
+        feed.layout_computes(),
+        1,
+        "scroll/selection queries should reuse the pre-wrapped rows"
+    );
+
+    feed.push_line(BlockStyle::Plain, "world");
+    let _ = feed.lines(80);
+    assert_eq!(feed.layout_computes(), 2, "mutation should invalidate");
+
+    let _ = feed.lines(40);
+    assert_eq!(feed.layout_computes(), 3, "resize should invalidate");
+
+    // Alternating back to a previously seen width still re-lays out once
+    // (single-slot cache), then reuses.
+    let _ = feed.lines(80);
+    let _ = feed.lines(80);
+    assert_eq!(feed.layout_computes(), 4);
+}

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -108,6 +108,23 @@ pub struct Feed {
     /// know whether the chat viewport needs a redraw, which also catches
     /// mutations made through `Renderer::feed_mut()`.
     generation: u64,
+    /// Pre-wrapped visual rows for the last requested width. Scroll and
+    /// selection queries reuse these rows instead of re-laying out the whole
+    /// feed each time; invalidated by any content mutation (generation bump)
+    /// or a width change.
+    layout_cache: RefCell<Option<LayoutCache>>,
+    /// Number of full layout passes; test-only proof that queries reuse the
+    /// pre-wrapped rows.
+    #[cfg(test)]
+    layout_computes: std::cell::Cell<usize>,
+}
+
+/// Memoized layout of the whole feed at a viewport width and generation.
+#[derive(Clone, Debug)]
+struct LayoutCache {
+    width: usize,
+    generation: u64,
+    lines: Vec<LineEntry>,
 }
 
 // Several helpers exist primarily for unit testing layout/scroll math without
@@ -118,6 +135,9 @@ impl Feed {
         Self {
             blocks: Vec::new(),
             generation: 0,
+            layout_cache: RefCell::new(None),
+            #[cfg(test)]
+            layout_computes: std::cell::Cell::new(0),
         }
     }
 
@@ -211,7 +231,40 @@ impl Feed {
     /// Running agent blocks parse markdown only for their completed lines and
     /// render the unfinished tail line as plain text; parsed layouts are
     /// memoized per block so repeated layouts at the same width don't re-parse.
+    ///
+    /// The laid-out rows are pre-wrapped and memoized per `(width,
+    /// generation)`, so scroll and selection queries (`line_count`,
+    /// `visible_range`, `line_at_visual_row`, `selected_text`) operate on the
+    /// cached visual rows instead of re-laying out the feed on every call.
     pub fn lines(&self, width: usize) -> Vec<LineEntry> {
+        {
+            let cache = self.layout_cache.borrow();
+            if let Some(c) = cache.as_ref()
+                && c.width == width
+                && c.generation == self.generation
+            {
+                return c.lines.clone();
+            }
+        }
+        let lines = self.compute_lines(width);
+        #[cfg(test)]
+        self.layout_computes.set(self.layout_computes.get() + 1);
+        *self.layout_cache.borrow_mut() = Some(LayoutCache {
+            width,
+            generation: self.generation,
+            lines: lines.clone(),
+        });
+        lines
+    }
+
+    /// Number of full layout passes so far (test-only).
+    #[cfg(test)]
+    pub(crate) fn layout_computes(&self) -> usize {
+        self.layout_computes.get()
+    }
+
+    /// Lay out every block at `width`. Called by `lines` on a cache miss.
+    fn compute_lines(&self, width: usize) -> Vec<LineEntry> {
         let mut result = Vec::new();
         for block in &self.blocks {
             match block.style {


### PR DESCRIPTION
Implements item 3 of **Rendering performance** in #186:

> Pre-wrap the feed to viewport width so selection and scroll operate on visual rows instead of logical lines.

## Problem

`Feed::lines(width)` re-laid out every block on each call, and every scroll/selection query went through it: `line_count`, `visible_range`, `selected_text`, and `line_at_visual_row` (which calls it **twice** — once via `line_count`, once directly). A single scroll step or selection drag therefore re-wrapped the whole feed several times per event.

## Change

`Feed` gains a single-slot `LayoutCache { width, generation, lines }`:

- `lines(width)` recomputes only when the width changed (resize) or the generation bumped (any content mutation — the same counter the renderer already uses for dirty-region redraws); otherwise it returns the cached visual rows.
- All scroll/selection queries now operate on those pre-wrapped rows by construction, since they all funnel through `lines(width)`.
- Composes with the per-block markdown cache from #207: during streaming the generation bumps per token (rows stay correct), while each re-layout stays cheap.

## Tests

New `scroll_and_selection_queries_reuse_prewrapped_rows` uses a test-only `layout_computes()` counter to prove the five query methods share a single layout pass, and that mutation / resize invalidate the cache correctly.

## Verification

- `cargo fmt` applied
- `cargo test`: 657 passed, 0 failed
- `cargo install --path . --debug` succeeds