### PR TITLE
fix: honor resumed history and fail closed on Ask in headless mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,18 @@ agent-client-protocol = { version = "1.0.1", optional = true }
 blocking = { version = "1", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 
+[dev-dependencies]
+# Adds rig-core's `test_utils` module (scripted `CompletionModel` test
+# doubles) for the fake-model carrier under `src/tests/fake_model.rs`. The
+# edition-2024 resolver keeps dev-dependency features out of non-test builds,
+# so the release binary never compiles `test-utils`. Tradeoff: the normal dep
+# above requests `rmcp` and this one adds `test-utils`, so `cargo build`
+# (rig[rmcp]) and a following `cargo test` (rig[rmcp+test-utils]) ask for
+# different feature sets and rig is recompiled between them. That is the
+# accepted cost of a test-only feature; folding `test-utils` into the release
+# dep to skip the rebuild would instead ship dead test code in the binary.
+rig = { version = "0.40", features = ["test-utils"] }
+
 [profile.dev]
 opt-level = 1
 debug = false

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -581,6 +581,11 @@ pub async fn run_print<M>(
     prompt: &str,
     pure_stdout: bool,
     retry_config: &RetryConfig,
+    // Prior turns from a resumed session (e.g. `--continue`), converted via
+    // `convert_history`. Fed to the initial `stream_chat` call below and
+    // seeded into `retry_history` for the hooks `Stop`-continuation retry,
+    // mirroring `spawn_agent`. Empty for a fresh session.
+    history: Vec<Message>,
     // `--loop` iteration/active state, for the `Stop` hook envelope's
     // `loop_iteration`/`loop_active` fields; see `runner::spawn_agent`.
     // `None` for plain `-p` one-shot runs.
@@ -592,13 +597,14 @@ where
 {
     let mut stream = retry::retry_stream_chat(retry_config, || {
         let p = prompt.to_string();
-        async move { agent.stream_chat(p, Vec::<Message>::new()).await }
+        let h = history.clone();
+        async move { agent.stream_chat(p, h).await }
     })
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     #[cfg(feature = "hooks")]
-    let retry_history: Vec<Message> = Vec::new();
+    let retry_history: Vec<Message> = history;
     #[cfg(feature = "hooks")]
     let mut tool_interactions: Vec<Message> = Vec::new();
     let mut full_response = String::new();

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -715,8 +715,11 @@ where
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("Error: {}", e);
-                    break;
+                    // Propagate the stream failure instead of returning `Ok`
+                    // with a truncated/empty response: dispatch must exit
+                    // non-zero and must never persist an empty assistant turn
+                    // (which would then be replayed as history on `--continue`).
+                    return Err(anyhow::anyhow!("{e}"));
                 }
             }
         }
@@ -726,7 +729,10 @@ where
             let injected_prompt = next_instruction
                 .take()
                 .unwrap_or_else(|| prompt.to_string());
-            full_response.clear();
+            // Keep the text already streamed to stdout this turn: the caller
+            // persists the returned string as the assistant message, so
+            // clearing it here would drop turn-1 output the user already saw
+            // and desync the saved transcript from the terminal.
             stream = continue_prompt_injector(
                 agent,
                 &injected_prompt,

--- a/src/extras/hooks/mod.rs
+++ b/src/extras/hooks/mod.rs
@@ -88,6 +88,13 @@ pub(crate) fn get_dispatcher() -> Option<std::sync::Arc<dispatcher::HookDispatch
     DISPATCHER.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
 
+/// Test-only: clears the process-global dispatcher so a test that installed one
+/// via [`init_dispatcher`] can't leak it into other tests sharing the binary.
+#[cfg(test)]
+pub(crate) fn reset_dispatcher() {
+    *DISPATCHER.lock().unwrap_or_else(|e| e.into_inner()) = None;
+}
+
 /// Wraps `tools` with the process-global dispatcher's guard rail, or returns
 /// them unchanged when no hooks are configured. The single weave point shared
 /// by the main-agent and subagent builders (design D5).

--- a/src/extras/loop/headless.rs
+++ b/src/extras/loop/headless.rs
@@ -64,6 +64,12 @@ pub(crate) async fn run_headless_loop(
                 &iteration_prompt,
                 cli.pure_stdout,
                 &cfg.retry,
+                // TODO(loop-history): the loop threads context only through the
+                // plan/summary state folded into `iteration_prompt`, so every
+                // iteration sends empty history. Making `--loop --continue`
+                // meaningful needs the loop to carry a real `Session`, a
+                // separate change.
+                Vec::new(),
                 #[cfg(feature = "hooks")]
                 Some(crate::extras::hooks::LoopInfo {
                     iteration: state.iteration,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -595,6 +595,9 @@ impl AnyAgent {
         prompt: &str,
         pure_stdout: bool,
         retry_config: &RetryConfig,
+        // Prior turns from a resumed session; see `runner::run_print`. Empty
+        // for a fresh session.
+        history: Vec<Message>,
         // `--loop` iteration/active state; see `runner::run_print`. `None`
         // for plain `-p` one-shot runs.
         #[cfg(feature = "hooks")] loop_info: Option<LoopInfo>,
@@ -606,6 +609,7 @@ impl AnyAgent {
                     prompt,
                     pure_stdout,
                     retry_config,
+                    history,
                     #[cfg(feature = "hooks")]
                     loop_info,
                 )
@@ -618,6 +622,7 @@ impl AnyAgent {
                         prompt,
                         pure_stdout,
                         retry_config,
+                        history,
                         #[cfg(feature = "hooks")]
                         loop_info,
                     )
@@ -629,6 +634,7 @@ impl AnyAgent {
                         prompt,
                         pure_stdout,
                         retry_config,
+                        history,
                         #[cfg(feature = "hooks")]
                         loop_info,
                     )
@@ -641,6 +647,7 @@ impl AnyAgent {
                     prompt,
                     pure_stdout,
                     retry_config,
+                    history,
                     #[cfg(feature = "hooks")]
                     loop_info,
                 )
@@ -652,6 +659,7 @@ impl AnyAgent {
                     prompt,
                     pure_stdout,
                     retry_config,
+                    history,
                     #[cfg(feature = "hooks")]
                     loop_info,
                 )
@@ -663,6 +671,7 @@ impl AnyAgent {
                     prompt,
                     pure_stdout,
                     retry_config,
+                    history,
                     #[cfg(feature = "hooks")]
                     loop_info,
                 )

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -823,7 +823,10 @@ impl Startup {
                 &self.cfg,
                 &self.context,
                 self.permission,
-                self.ask_tx,
+                // Non-interactive dispatch never keeps the ask channel: with
+                // no one draining it, an `Ask` verdict must fail closed as a
+                // denial rather than block forever. See `handle_ask_inner`.
+                None,
                 self.sandbox.clone(),
                 true,
                 temperature,
@@ -915,7 +918,9 @@ impl Startup {
             &self.cfg,
             &self.context,
             self.permission,
-            self.ask_tx,
+            // Non-interactive dispatch never keeps the ask channel; see the
+            // matching note in `dispatch_print`.
+            None,
             self.sandbox.clone(),
             true,
             temperature,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -845,11 +845,13 @@ impl Startup {
             if let Some(ss) = self.status_signals.as_ref() {
                 ss.send_start();
             }
+            let history = crate::agent::runner::convert_history(&self.session);
             let response_result = agent
                 .run_print(
                     &msg,
                     self.cli.pure_stdout,
                     &self.cfg.retry,
+                    history,
                     #[cfg(feature = "hooks")]
                     None,
                 )

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -1506,3 +1506,25 @@ fn standard_respects_config_allow_over_cwd_auto_allow() {
         CheckResult::Allowed,
     ));
 }
+
+// --- check_perm non-interactive Ask denial (guards headless dispatch) ---
+
+#[tokio::test]
+async fn check_perm_denies_non_interactively_when_ask_tx_is_none_and_verdict_is_ask() {
+    // Guarded mode with no matching rule asks for non-read tools (see
+    // guarded_asks_for_write_and_bash above), so this checker's verdict for
+    // "write" is CheckResult::Ask.
+    let checker = make_checker(SecurityMode::Guarded);
+    let perm: Option<crate::permission::checker::PermCheck> =
+        Some(std::sync::Arc::new(std::sync::Mutex::new(checker)));
+    let ask_tx: Option<crate::permission::ask::AskSender> = None;
+
+    let result = crate::agent::tools::check_perm(&perm, &ask_tx, "write", "/etc/passwd").await;
+
+    match result {
+        Err(crate::agent::tools::ToolError::Msg(msg)) => {
+            assert_eq!(msg, "Permission denied (non-interactive mode)");
+        }
+        other => panic!("expected non-interactive Ask denial error, got {:?}", other),
+    }
+}

--- a/src/tests/convert_history_tests.rs
+++ b/src/tests/convert_history_tests.rs
@@ -1,0 +1,64 @@
+//! Unit tests for `convert_history`'s assembly of a resumed session's prior
+//! turns into the `rig::completion::Message` history handed to the model.
+
+use rig::completion::Message;
+
+use crate::agent::runner::convert_history;
+use crate::session::{MessageRole, Session};
+
+fn sample_session() -> Session {
+    Session::new("anthropic", "claude-test", 200_000, "")
+}
+
+#[test]
+fn uncompacted_session_gives_full_tail_in_order_no_summary() {
+    let mut session = sample_session();
+    session.add_message(MessageRole::User, "hello");
+    session.add_message(MessageRole::Assistant, "hi there");
+    session.add_message(MessageRole::User, "how are you");
+
+    let history = convert_history(&session);
+
+    assert_eq!(
+        history,
+        vec![
+            Message::user("hello"),
+            Message::assistant("hi there"),
+            Message::user("how are you"),
+        ]
+    );
+}
+
+#[test]
+fn compacted_session_gives_summary_as_assistant_then_kept_tail() {
+    let mut session = sample_session();
+    session.add_message(MessageRole::User, "old question");
+    session.add_message(MessageRole::Assistant, "old answer");
+    session.add_message(MessageRole::User, "kept question");
+    session.add_message(MessageRole::Assistant, "kept answer");
+
+    // Summarize the first two messages, keeping the last two.
+    session.compress("did some prior work".to_string(), 2, 100);
+
+    let history = convert_history(&session);
+
+    assert_eq!(
+        history,
+        vec![
+            Message::assistant(
+                "[Recap of my prior work in this conversation]\ndid some prior work"
+            ),
+            Message::user("kept question"),
+            Message::assistant("kept answer"),
+        ]
+    );
+}
+
+#[test]
+fn empty_session_gives_empty_vec() {
+    let session = sample_session();
+
+    let history = convert_history(&session);
+
+    assert_eq!(history, Vec::<Message>::new());
+}

--- a/src/tests/fake_model.rs
+++ b/src/tests/fake_model.rs
@@ -1,0 +1,136 @@
+//! Shared test-only fake `CompletionModel` carrier for headless-dispatch e2e
+//! tests (`run_print` over `Agent<FakeModel>`).
+//!
+//! Rig 0.40 ships exactly the scripted-streaming test double this change
+//! needs (`rig::test_utils::MockCompletionModel`): a cloneable
+//! `CompletionModel` with scripted streaming turns, a `GetTokenUsage`
+//! response, and per-request capture (`requests()` returns the
+//! `CompletionRequest`s it received, each carrying the `chat_history` the
+//! caller sent). This module wraps it rather than hand-rolling the
+//! `CompletionModel` impl, and adds only the thin, task-specific API this
+//! change's tests need on top: scripting plain text turns, and reading back
+//! the history a given turn received.
+//!
+//! Tool-call scripting is deliberately not wrapped here: `MockStreamEvent`
+//! (also re-exported by rig) already supports it directly
+//! (`MockStreamEvent::tool_call(..)`), so section 2's e2e can reach for that
+//! itself when it needs it, without this module growing an API no current
+//! caller exercises.
+
+use rig::completion::Message;
+pub use rig::test_utils::{MockCompletionModel, MockStreamEvent};
+
+/// The fake `CompletionModel` carrier. Build with [`text_turns`] (or
+/// [`text_chunks`] for the common single-turn case), pass into
+/// `AgentBuilder::new(model).build()`, then inspect what it received via
+/// [`history_at`].
+pub type FakeModel = MockCompletionModel;
+
+/// Script a fake model with one streaming turn per element of `turns`, each
+/// yielding its plain-text chunks in order and ending in a default (zero)
+/// usage final response. Turn N is consumed by the (N+1)th call the agent
+/// makes to the model (e.g. turn 0 by the initial `stream_chat`, turn 1 by a
+/// hooks `Stop`-continuation retry).
+pub fn text_turns<I, J, S>(turns: I) -> FakeModel
+where
+    I: IntoIterator<Item = J>,
+    J: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let scripted: Vec<Vec<MockStreamEvent>> = turns
+        .into_iter()
+        .map(|chunks| {
+            chunks
+                .into_iter()
+                .map(|c| MockStreamEvent::text(c.into()))
+                .chain(std::iter::once(
+                    MockStreamEvent::final_response_with_default_usage(),
+                ))
+                .collect()
+        })
+        .collect();
+    MockCompletionModel::from_stream_turns(scripted)
+}
+
+/// Script a fake model with a single streaming turn yielding `chunks` in
+/// order.
+pub fn text_chunks<I, S>(chunks: I) -> FakeModel
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    text_turns([chunks])
+}
+
+/// The chat history the model actually received on request `turn` (0-based),
+/// with the trailing prompt message dropped: `CompletionRequest::chat_history`
+/// always ends with the prompt (rig's documented invariant), so this returns
+/// exactly the history the caller passed in alongside that prompt.
+pub fn history_at(model: &FakeModel, turn: usize) -> Vec<Message> {
+    let requests = model.requests();
+    let request = requests.get(turn).unwrap_or_else(|| {
+        panic!(
+            "model was called only {} time(s); no request captured at turn {turn} \
+             (did the expected continuation not fire?)",
+            requests.len()
+        )
+    });
+    let mut messages: Vec<Message> = request.chat_history.clone().into_iter().collect();
+    messages.pop();
+    messages
+}
+
+#[tokio::test]
+async fn run_print_returns_scripted_text() {
+    // Under `--features hooks`, `run_print` reaches the process-global Stop
+    // dispatcher; serialize against the tests that install one so a leaked
+    // hook can't force an unscripted continuation here. No-op otherwise.
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = dispatcher_guard::acquire();
+
+    let model = text_chunks(["hello, ", "world"]);
+    let agent = rig::agent::AgentBuilder::new(model).build();
+
+    let (response, _usage) = crate::agent::runner::run_print(
+        &agent,
+        "hi",
+        false,
+        &crate::retry::RetryConfig::default(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await
+    .expect("run_print should succeed against the fake model");
+
+    assert_eq!(response, "hello, world");
+}
+
+/// Serializes tests that touch the process-global hook dispatcher and clears
+/// it when the guard drops. `run_print`'s `Stop` path reads a process-wide
+/// dispatcher (`extras::hooks::DISPATCHER`), so a test that installs one via
+/// `init_dispatcher` would otherwise leak that hook into any other `run_print`
+/// test running concurrently in the same binary. Every `run_print` test holds
+/// this guard for the duration of its call, so at most one such test runs at a
+/// time and the dispatcher is always reset afterwards.
+#[cfg(feature = "hooks")]
+pub(crate) mod dispatcher_guard {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    /// Held for the lifetime of a dispatcher-touching test; resets the
+    /// process-global dispatcher on drop.
+    pub(crate) struct DispatcherGuard(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+    /// Acquire exclusive access to the process-global hook dispatcher.
+    pub(crate) fn acquire() -> DispatcherGuard {
+        let lock = LOCK.get_or_init(|| Mutex::new(()));
+        DispatcherGuard(lock.lock().unwrap_or_else(|e| e.into_inner()))
+    }
+
+    impl Drop for DispatcherGuard {
+        fn drop(&mut self) {
+            crate::extras::hooks::reset_dispatcher();
+        }
+    }
+}

--- a/src/tests/fake_model.rs
+++ b/src/tests/fake_model.rs
@@ -96,6 +96,7 @@ async fn run_print_returns_scripted_text() {
         "hi",
         false,
         &crate::retry::RetryConfig::default(),
+        Vec::new(),
         #[cfg(feature = "hooks")]
         None,
     )

--- a/src/tests/headless_ask_tests.rs
+++ b/src/tests/headless_ask_tests.rs
@@ -1,0 +1,146 @@
+//! e2e proof that a headless (`-p`, non-interactive) run whose permission
+//! checker resolves `Ask` fails closed instead of hanging.
+//!
+//! Before this section's fix, `dispatch_print`/`dispatch_loop` handed the
+//! live `ask_tx` sender to the agent even in non-interactive mode, so a tool
+//! whose permission check resolves `Ask` would send an `AskRequest` down a
+//! channel nobody drains and then block forever awaiting a reply that never
+//! comes (`src/agent/tools/mod.rs::handle_ask_inner`). This test scripts that
+//! exact shape at the `run_print` boundary: a `WriteTool` wired with a
+//! `Guarded`-mode checker (which asks for an external-path write) and a live
+//! ask-channel sender whose receiver is kept alive but never polled, mirroring
+//! the pre-fix headless dispatch. Section 6.2 makes the production fix
+//! (non-interactive dispatch hands the agent `None` for the ask sender); this
+//! test exercises that fixed behavior by passing `None`, exactly as production
+//! now does for non-interactive runs.
+//!
+//! Rig's multi-turn agent loop treats a tool's `Err` as ordinary tool-result
+//! content fed back to the model for the next turn (not a terminating
+//! error), so proving "denied, not hung" at this boundary means driving the
+//! agent through a second turn and inspecting what the model was actually
+//! shown, rather than asserting `run_print` itself returns `Err`.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rig::agent::AgentBuilder;
+use rig::completion::Message;
+use rig::message::{ToolResultContent, UserContent};
+
+use crate::agent::runner::run_print;
+use crate::agent::tools::WriteTool;
+use crate::permission::checker::PermissionChecker;
+use crate::permission::{PermissionConfigs, SecurityMode};
+use crate::retry::RetryConfig;
+use crate::tests::fake_model::{MockCompletionModel, MockStreamEvent};
+
+fn guarded_checker() -> PermissionChecker {
+    PermissionChecker::new(
+        &PermissionConfigs::default(),
+        SecurityMode::Guarded,
+        Some(std::path::PathBuf::from("/home/user/project")),
+        Some(vec![
+            "guarded".to_string(),
+            "standard".to_string(),
+            "yolo".to_string(),
+        ]),
+    )
+}
+
+// The model calls `write` on turn 0, then (given the tool's denial fed back
+// as ordinary tool-result content) produces a plain text reply on turn 1.
+// `default_max_turns(2)` is needed because rig's implicit per-agent budget is
+// one model call total; without it, driving a second turn hits
+// `PromptError::MaxTurnsError` regardless of how the tool call resolved,
+// which would prove nothing about the ask-channel fix.
+fn write_tool_call_model() -> MockCompletionModel {
+    MockCompletionModel::from_stream_turns(vec![
+        vec![
+            MockStreamEvent::tool_call(
+                "call-1",
+                "write",
+                serde_json::json!({"path": "/etc/passwd", "content": "x"}),
+            ),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("acknowledged".to_string()),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ])
+}
+
+// 6.1/6.3: before the 6.2 fix, `dispatch_print`/`dispatch_loop` handed the
+// live `ask_tx` sender straight to the agent regardless of interactivity
+// (`build_permission_checker` populates it for any run that has a
+// permission checker at all), so a `-p` run whose checker resolves `Ask`
+// would hang forever awaiting a reply nobody sends. The fix makes headless
+// dispatch hand the agent `None` for the ask sender; this test passes `None`,
+// exactly as production now does for a non-interactive (`-p`) run.
+#[tokio::test]
+async fn headless_ask_denies_instead_of_hanging() {
+    // Under `--features hooks`, `run_print` consults the process-global Stop
+    // dispatcher; serialize against the test that installs one. No-op otherwise.
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+
+    let model = write_tool_call_model();
+    let permission = Some(Arc::new(Mutex::new(guarded_checker())));
+
+    // Production hands non-interactive dispatch `None` for the ask channel
+    // (see `dispatch_print`/`dispatch_loop`); with no sender, an `Ask` verdict
+    // must fail closed instead of hanging on a channel nobody drains.
+    let ask_tx: Option<crate::permission::ask::AskSender> = None;
+    let write_tool = WriteTool::new(permission, ask_tx, None);
+
+    let agent = AgentBuilder::new(model.clone())
+        .tool(write_tool)
+        .default_max_turns(2)
+        .build();
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        run_print(
+            &agent,
+            "please write to /etc/passwd",
+            false,
+            &RetryConfig::default(),
+            Vec::new(),
+            #[cfg(feature = "hooks")]
+            None,
+        ),
+    )
+    .await
+    .expect("run_print must complete within the timeout instead of hanging on an unserviced ask channel")
+    .expect("run_print should complete once the tool's denial is fed back to the model as an ordinary turn");
+
+    // The second call's chat history is what the model was actually shown
+    // after the tool ran; its trailing message (the "prompt" for this turn,
+    // per rig's `CompletionRequest` invariant) is the tool's own result, and
+    // it must carry the non-interactive denial, proving the tool failed
+    // closed rather than silently succeeding or hanging.
+    let second_call_history: Vec<Message> = model.requests()[1]
+        .chat_history
+        .clone()
+        .into_iter()
+        .collect();
+    let saw_denial = second_call_history.iter().any(|message| match message {
+        Message::User { content } => content.iter().any(|item| match item {
+            UserContent::ToolResult(tool_result) => {
+                tool_result.content.iter().any(|part| match part {
+                    ToolResultContent::Text(text) => text
+                        .text
+                        .contains("Permission denied (non-interactive mode)"),
+                    _ => false,
+                })
+            }
+            _ => false,
+        }),
+        _ => false,
+    });
+    assert!(
+        saw_denial,
+        "expected the tool result fed back to the model on the second turn to \
+         contain the non-interactive denial message, history: {second_call_history:?}"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -65,6 +65,8 @@ mod provider_tests;
 #[cfg(test)]
 mod renderer_tests;
 #[cfg(test)]
+mod resumed_history_tests;
+#[cfg(test)]
 mod session_storage_tests;
 #[cfg(test)]
 mod session_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,6 +32,8 @@ mod fake_model;
 mod feed_tests;
 #[cfg(test)]
 mod grep_tests;
+#[cfg(test)]
+mod headless_ask_tests;
 #[cfg(all(test, feature = "hooks"))]
 mod hooks;
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,6 +21,8 @@ mod checker_tests;
 #[cfg(test)]
 mod config_tests;
 #[cfg(test)]
+mod convert_history_tests;
+#[cfg(test)]
 mod crc_tests;
 #[cfg(test)]
 mod edit_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -25,6 +25,8 @@ mod crc_tests;
 #[cfg(test)]
 mod edit_tests;
 #[cfg(test)]
+mod fake_model;
+#[cfg(test)]
 mod feed_tests;
 #[cfg(test)]
 mod grep_tests;

--- a/src/tests/resumed_history_tests.rs
+++ b/src/tests/resumed_history_tests.rs
@@ -1,0 +1,53 @@
+//! e2e proof that a resumed session's prior messages reach the model.
+//!
+//! Exercises the `-p --continue` code path at the boundary `run_print` and
+//! the fake model carrier share: a `Session` seeded with prior turns is
+//! converted via `convert_history` (the same conversion `dispatch_print`
+//! uses) and threaded through `run_print`, then the carrier's captured
+//! request history is asserted to match. Section 4 extends this same test
+//! with persistence and hooks-continuation assertions; keep additions here
+//! easy to layer on top rather than rewriting the scaffolding.
+
+use rig::agent::AgentBuilder;
+
+use crate::agent::runner::{convert_history, run_print};
+use crate::retry::RetryConfig;
+use crate::session::{MessageRole, Session};
+use crate::tests::fake_model::{history_at, text_chunks};
+
+fn resumed_session() -> Session {
+    let mut session = Session::new("anthropic", "claude-test", 200_000, "");
+    session.add_message(MessageRole::User, "what's the plan");
+    session.add_message(MessageRole::Assistant, "ship section 3");
+    session
+}
+
+#[tokio::test]
+async fn resumed_session_history_reaches_model_initial_turn() {
+    let session = resumed_session();
+    let expected_history = convert_history(&session);
+
+    let model = text_chunks(["got it"]);
+    let agent = AgentBuilder::new(model.clone()).build();
+
+    // Mirrors `dispatch_print`'s own `convert_history(&self.session)` call:
+    // this is the `-p --continue` code path being exercised end to end.
+    let (_response, _usage) = run_print(
+        &agent,
+        "continue",
+        false,
+        &RetryConfig::default(),
+        expected_history.clone(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await
+    .expect("run_print should succeed against the fake model");
+
+    let observed_history = history_at(&model, 0);
+    assert_eq!(
+        observed_history, expected_history,
+        "run_print must forward the resumed session's prior messages to the \
+         model as history on the initial stream_chat call"
+    );
+}

--- a/src/tests/resumed_history_tests.rs
+++ b/src/tests/resumed_history_tests.rs
@@ -4,15 +4,16 @@
 //! the fake model carrier share: a `Session` seeded with prior turns is
 //! converted via `convert_history` (the same conversion `dispatch_print`
 //! uses) and threaded through `run_print`, then the carrier's captured
-//! request history is asserted to match. Section 4 extends this same test
-//! with persistence and hooks-continuation assertions; keep additions here
-//! easy to layer on top rather than rewriting the scaffolding.
+//! request history is asserted to match. A hooks-continuation variant (4.2)
+//! extends this to prove the resumed history survives a `Stop`-forced retry.
 
 use rig::agent::AgentBuilder;
 
 use crate::agent::runner::{convert_history, run_print};
 use crate::retry::RetryConfig;
 use crate::session::{MessageRole, Session};
+#[cfg(feature = "hooks")]
+use crate::tests::fake_model::text_turns;
 use crate::tests::fake_model::{history_at, text_chunks};
 
 fn resumed_session() -> Session {
@@ -29,6 +30,11 @@ async fn resumed_session_history_reaches_model_initial_turn() {
 
     let model = text_chunks(["got it"]);
     let agent = AgentBuilder::new(model.clone()).build();
+
+    // Under `--features hooks`, `run_print` consults the process-global Stop
+    // dispatcher; serialize against the test that installs one. No-op otherwise.
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
 
     // Mirrors `dispatch_print`'s own `convert_history(&self.session)` call:
     // this is the `-p --continue` code path being exercised end to end.
@@ -49,5 +55,89 @@ async fn resumed_session_history_reaches_model_initial_turn() {
         observed_history, expected_history,
         "run_print must forward the resumed session's prior messages to the \
          model as history on the initial stream_chat call"
+    );
+}
+
+// 4.2: a `Stop` hook forcing a continuation must still see the resumed
+// history. `run_print`'s `Stop`-continuation path (`src/agent/runner.rs`,
+// ~line 692) calls the production `dispatch_stop`, which reads the
+// process-global hook dispatcher; this test installs one so the real wiring
+// (not a test-only substitute) is exercised end to end.
+#[cfg(feature = "hooks")]
+#[tokio::test]
+async fn resumed_session_history_survives_stop_hook_continuation() {
+    use std::collections::HashMap;
+
+    use crate::extras::hooks::dispatcher::HookDispatcher;
+    use crate::extras::hooks::init_dispatcher;
+    use crate::extras::hooks::settings::{HookGroup, HookHandler, HooksConfig};
+
+    // Installs a process-global Stop hook below; the guard serializes against
+    // other `run_print` tests and clears the dispatcher when it drops, so the
+    // hook can't leak into them.
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+
+    let session = resumed_session();
+    let expected_history = convert_history(&session);
+
+    // Script two turns: the first ends with the `Stop` hook below forcing a
+    // continuation (guarding the `retry_history` seed wired in 3.2); the
+    // second is the real final answer released after the hook stands down.
+    let model = text_turns([["partial answer"], ["final answer"]]);
+    let agent = AgentBuilder::new(model.clone()).build();
+
+    // Blocks exactly once: the envelope's `stop_hook_active` is `false` on
+    // the first `Stop` dispatch, so the hook forces a continuation; on the
+    // retry it is `true`, the condition misses, and the hook emits no
+    // decision, releasing the final response.
+    let handler = HookHandler {
+        kind: "command".to_string(),
+        command: Some(
+            r#"if grep -q '"stop_hook_active":false'; then echo '{"decision":"block","reason":"resume once more"}'; fi"#
+                .to_string(),
+        ),
+        args: None,
+        timeout: Some(5),
+        is_async: false,
+        condition: None,
+        once: false,
+    };
+    let mut config: HooksConfig = HashMap::new();
+    config.insert(
+        "Stop".to_string(),
+        vec![HookGroup {
+            matcher: None,
+            hooks: vec![handler],
+        }],
+    );
+    init_dispatcher(HookDispatcher::from_config(&config).unwrap());
+
+    let (response, _usage) = run_print(
+        &agent,
+        "continue",
+        false,
+        &RetryConfig::default(),
+        expected_history.clone(),
+        None,
+    )
+    .await
+    .expect("run_print should succeed against the fake model");
+
+    assert_eq!(
+        response, "partial answerfinal answer",
+        "the Stop-forced continuation must run to completion and the returned \
+         response must keep both turns' text (the first turn was already \
+         streamed to stdout), not just the second turn's"
+    );
+
+    // Guards the `retry_history` seed (runner.rs ~601, consumed by the
+    // `Stop`-continuation retry ~727): the resumed session's prior messages
+    // must still be present in the history the SECOND request received.
+    let second_request_history = history_at(&model, 1);
+    assert!(
+        second_request_history.starts_with(&expected_history),
+        "the Stop-hook continuation retry must still carry the resumed \
+         session's prior messages as history, not just the first turn's \
+         tool interactions"
     );
 }


### PR DESCRIPTION
## Summary

Two headless-mode dispatch bugs. A resumed session (`-p --continue` / `-p --session`) sent the model an empty history, dropping all prior context, and a tool whose permission check resolves to `Ask` hung forever because the non-interactive path had no one to answer the prompt. This wires the real conversation history into headless dispatch and makes an `Ask` verdict fail closed as a denial. The production change is 48 lines (+48 / -7); the remaining ~520 lines are tests.

## Motivation

`zerostack -p --continue "..."` is the scripted / CI entry point, and before this it silently discarded the resumed session's messages: the model answered as if the conversation had no past, so `--continue` and `--session` were effectively broken for the headless path (interactive mode was unaffected, it already threaded history). Separately, any tool call that hit an `Ask` permission verdict in `-p` mode blocked on a reply channel nobody drains, so the process hung instead of terminating, which is unusable in automation. Both are dispatch-wiring gaps: the interactive path already did the right thing, the headless path was never wired to match.

## Design decisions

- Reuse `convert_history` verbatim rather than a headless-specific assembly. `dispatch_print` computes the exact history the interactive path builds (compaction summary plus kept tail, or the full tail), so resumed headless context matches interactive byte for byte and there is no second code path to keep in sync. One `self.session` covers both `--continue` and `--session`.
- Fail closed by handing the agent `None` for the ask sender, not by a runtime interactivity check. Both headless dispatchers (`dispatch_print`, `dispatch_loop`) are unconditionally non-interactive, so they pass a literal `None`; `check_perm`'s existing `None` branch then denies an `Ask` immediately (`"Permission denied (non-interactive mode)"`) with no `.await`. Subagents spawned mid-run inherit that `None`, so the deny holds transitively. Interactive dispatch is untouched and still prompts.
- `history: Vec<Message>` is threaded by value through `run_print` and every provider variant, mirroring the existing `loop_info` threading rather than inventing a new shape. It feeds both model-call sites: the initial `stream_chat` and the `retry_history` seed consumed by the hooks `Stop`-continuation, so a forced continuation still carries the resumed context.
- `--loop` history is deliberately out of scope (a Non-Goal in the design), marked with a `// TODO(loop-history)` in `headless.rs`. `--loop` keeps sending empty history; that is intentional, not an oversight.

## Testing

- The production change is +48 / -7; tests are +520. New coverage: a shared fake `CompletionModel` carrier (wraps rig 0.40's `MockCompletionModel` rather than hand-rolling one), `convert_history` assembly units (three cases), a resumed-history e2e (history reaches the model on the initial call and survives a hooks `Stop`-continuation retry), a headless `Ask` fail-closed e2e (denies within a timeout instead of hanging), and a `check_perm` non-interactive-deny unit contract. Full suite green: `cargo test --all-features`, 878 passed.
- Runtime verification (manual, passed): drove the real binary against a mock provider and confirmed from the logged request body that `-p --continue` sends the resumed session's prior messages, and that a headless `Ask` is denied immediately with `"Permission denied (non-interactive mode)"` rather than hanging. This exercises the two production dispatch lines that the unit/e2e tests reach only at the `run_print` boundary.
- vibe-diff: pass (`cargo test --features hooks`, 782 tests); flagged an early loop-history scope creep that was then reverted (TODO marker restored), plus risks recorded in Notes below.
- cross-check: not run.
- verify: passed (runtime, drove `-p` resumed-history and headless `Ask` fail-closed; no JSON artifact retained).

## Reviewing

- Start with the two production hunks that are the actual fix: `src/startup.rs` (both dispatch sites) and `src/agent/runner.rs` (`run_print` gains `history` and feeds both call sites). Everything in `src/provider.rs` is mechanical six-variant threading.
- `src/agent/runner.rs` also carries two intentional persist-path fixes (see Notes); they are a separate commit, `fix(runner): harden the print stream/continuation persist path`.
- The bulk of the diff, `src/tests/*`, is test infrastructure and can be read last; `fake_model.rs` is the reusable carrier the e2e tests build on.

## Notes

- Known coverage gap (accepted): the two production dispatch lines (`convert_history(&self.session)` and the `ask_tx` to `None` substitution) are exercised at the `run_print` boundary by tests plus the manual runtime verification above, but not by an automated test that drives `dispatch_print` / `dispatch_loop` directly. Doing so would require a fakeable `AnyAgent` (a test-only enum variant in production), which was rejected as production-polluting. A refactor that dropped either line would still pass CI; the runtime verification is the guard.
- Two intentional behavior changes in `runner.rs` (their own commit): first, a mid-stream error now propagates as `Err` (non-zero exit) instead of printing and returning a truncated `Ok`, so a failed `-p` run no longer persists an empty or partial assistant turn that would replay on the next `--continue`; second, the `full_response.clear()` before the `Stop`-continuation injector was dropped, so a forced continuation persists both turns' text as one assistant message (concatenated with no separator, matching what streamed to stdout). The first is a user-visible exit-code change for `-p` on transient stream failures.
- The `convert_history` N+2 no-duplication invariant is not asserted by a test. It holds by construction (`dispatch_print` does exactly two `add_message` calls and never re-appends the loaded history) but lives at the dispatch layer the tests do not drive, so it is documented rather than asserted.
- Scan and review nits (not actioned): the `Stop`-hook e2e scripts a `grep` / sh hook command that would not run on Windows, consistent with the suite's existing unix-only tests (CI is ubuntu and macOS). The `rig` `test-utils` dev-dependency is unconditional, so CI compiles rig twice (once for the release binary without it, once for tests with it), accepted as simpler than a dedicated test feature. The `#[allow(dead_code)]` in `fake_model.rs` is on a `MutexGuard` field held only for its `Drop` / RAII effect.
