### PR TITLE
fix: surface non-fatal errors instead of swallowing them

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -92,8 +92,12 @@ impl ContextFiles {
 }
 
 pub fn load(no_context_files: bool) -> ContextFiles {
-    let _ = prompts::ensure_global();
-    let _ = themes::ensure_global();
+    if let Err(e) = prompts::ensure_global() {
+        tracing::warn!("failed to install default prompts: {e}");
+    }
+    if let Err(e) = themes::ensure_global() {
+        tracing::warn!("failed to install default themes: {e}");
+    }
     let (agents, arch_candidate) = if no_context_files {
         (None, None)
     } else {

--- a/src/extras/archmd/mod.rs
+++ b/src/extras/archmd/mod.rs
@@ -5,7 +5,9 @@ const DIRS_ASKED_FILE: &str = "dirs_asked_architecture.txt";
 
 fn dirs_asked_path() -> PathBuf {
     let dir = crate::session::storage::data_dir();
-    let _ = std::fs::create_dir_all(&dir);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!("archmd: failed to create data dir: {e}");
+    }
     dir.join(DIRS_ASKED_FILE)
 }
 

--- a/src/extras/hooks/subprocess.rs
+++ b/src/extras/hooks/subprocess.rs
@@ -75,7 +75,9 @@ pub(crate) async fn run_hook(
     };
 
     if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(stdin_json).await;
+        if let Err(e) = stdin.write_all(stdin_json).await {
+            tracing::warn!("hooks: failed to write hook stdin: {e}");
+        }
         drop(stdin);
     }
 
@@ -87,11 +89,15 @@ pub(crate) async fn run_hook(
     let run = async {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
-        if let Some(pipe) = stdout_pipe.as_mut() {
-            let _ = pipe.read_to_end(&mut stdout).await;
+        if let Some(pipe) = stdout_pipe.as_mut()
+            && let Err(e) = pipe.read_to_end(&mut stdout).await
+        {
+            tracing::warn!("hooks: failed to read hook stdout (output may be truncated): {e}");
         }
-        if let Some(pipe) = stderr_pipe.as_mut() {
-            let _ = pipe.read_to_end(&mut stderr).await;
+        if let Some(pipe) = stderr_pipe.as_mut()
+            && let Err(e) = pipe.read_to_end(&mut stderr).await
+        {
+            tracing::warn!("hooks: failed to read hook stderr (output may be truncated): {e}");
         }
         let status = child.wait().await;
         (status, stdout, stderr)

--- a/src/extras/hooks/trust.rs
+++ b/src/extras/hooks/trust.rs
@@ -41,10 +41,15 @@ pub(crate) fn save_trust_store(path: &Path, trusted: &HashSet<String>) {
     let Ok(json) = serde_json::to_string_pretty(trusted) else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!("hooks: failed to create trust store directory: {e}");
+        return;
     }
-    let _ = std::fs::write(path, json);
+    if let Err(e) = std::fs::write(path, json) {
+        tracing::warn!("hooks: failed to save trust store (trust decisions won't persist): {e}");
+    }
 }
 
 fn global_settings_path() -> PathBuf {

--- a/src/extras/mcp/oauth.rs
+++ b/src/extras/mcp/oauth.rs
@@ -97,7 +97,9 @@ impl FileCredentialStore {
 #[cfg(unix)]
 fn set_owner_only(f: &std::fs::File) {
     use std::os::unix::fs::PermissionsExt;
-    let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+    if let Err(e) = f.set_permissions(std::fs::Permissions::from_mode(0o600)) {
+        tracing::warn!("mcp oauth: failed to set 0600 permissions on token file: {e}");
+    }
 }
 
 #[cfg(not(unix))]

--- a/src/extras/memory/mod.rs
+++ b/src/extras/memory/mod.rs
@@ -959,7 +959,9 @@ pub fn compaction_heading(count: Option<usize>) -> String {
 /// rather than depending on the model to write it. `count` is the number of
 /// messages this compaction summarized (Session's `first_kept_index`).
 pub fn flush_compaction_summary(mem: &Mem, summary: &str, count: Option<usize>) {
-    let _ = mem.append_daily(&compaction_heading(count), summary);
+    if let Err(e) = mem.append_daily(&compaction_heading(count), summary) {
+        tracing::warn!("memory: failed to persist compaction summary: {e}");
+    }
 }
 
 /// Effective compaction reserve including the injected memory block, which the

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -167,7 +167,12 @@ impl Sandbox {
         cmd.arg(cwd.as_os_str());
         // Bind ~/.cache (or $XDG_CACHE_HOME) as writable after "/" bind
         if let Some(cache_dir) = dirs::cache_dir() {
-            let _ = std::fs::create_dir_all(&cache_dir);
+            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+                tracing::warn!(
+                    "sandbox: failed to create cache dir {}: {e}",
+                    cache_dir.display()
+                );
+            }
             cmd.arg("--bind");
             cmd.arg(cache_dir.as_os_str());
             cmd.arg(cache_dir.as_os_str());

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -17,6 +17,25 @@ use crate::session::SessionMessage;
 
 // ── Helper functions ─────────────────────────────────────────────────────
 
+/// Regenerate embedded prompts/themes, printing the actual outcome instead
+/// of claiming success on failure. Returns true when regeneration succeeded.
+fn regen_resource(regen: fn() -> anyhow::Result<()>, what: &str, suffix: &str) -> bool {
+    match regen() {
+        Ok(()) => {
+            eprintln!("{} regenerated{}.", what, suffix);
+            true
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: failed to regenerate {}: {}",
+                what.to_lowercase(),
+                e
+            );
+            false
+        }
+    }
+}
+
 fn resolve_mode(cli: &Cli, cfg: &Config) -> SecurityMode {
     if cli.yolo || cfg.yolo.unwrap_or(false) {
         SecurityMode::Yolo
@@ -489,25 +508,20 @@ impl Startup {
 
             match self.cfg.resolve_auto_update_prompts() {
                 Some(true) => {
-                    let _ = context::prompts::regen();
-                    eprintln!("Prompts regenerated.");
-                    regenerated = true;
+                    regenerated |= regen_resource(context::prompts::regen, "Prompts", "");
                 }
                 Some(false) => { /* skip: user explicitly denied */ }
                 None => {
                     if !prompts_dir.exists() {
-                        let _ = context::prompts::regen();
-                        eprintln!("Prompts regenerated (first launch).");
-                        regenerated = true;
+                        regenerated |=
+                            regen_resource(context::prompts::regen, "Prompts", " (first launch)");
                     } else {
                         let mut input = String::new();
                         eprint!("Regenerate prompts? [y/N] ");
                         let _ = std::io::Write::flush(&mut std::io::stderr());
                         std::io::stdin().read_line(&mut input)?;
                         if matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
-                            let _ = context::prompts::regen();
-                            eprintln!("Prompts regenerated.");
-                            regenerated = true;
+                            regenerated |= regen_resource(context::prompts::regen, "Prompts", "");
                         }
                     }
                 }
@@ -515,25 +529,20 @@ impl Startup {
 
             match self.cfg.resolve_auto_update_themes() {
                 Some(true) => {
-                    let _ = context::themes::regen();
-                    eprintln!("Themes regenerated.");
-                    regenerated = true;
+                    regenerated |= regen_resource(context::themes::regen, "Themes", "");
                 }
                 Some(false) => { /* skip: user explicitly denied */ }
                 None => {
                     if !themes_dir.exists() {
-                        let _ = context::themes::regen();
-                        eprintln!("Themes regenerated (first launch).");
-                        regenerated = true;
+                        regenerated |=
+                            regen_resource(context::themes::regen, "Themes", " (first launch)");
                     } else {
                         let mut input = String::new();
                         eprint!("Regenerate themes? [y/N] ");
                         let _ = std::io::Write::flush(&mut std::io::stderr());
                         std::io::stdin().read_line(&mut input)?;
                         if matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
-                            let _ = context::themes::regen();
-                            eprintln!("Themes regenerated.");
-                            regenerated = true;
+                            regenerated |= regen_resource(context::themes::regen, "Themes", "");
                         }
                     }
                 }
@@ -801,12 +810,14 @@ impl Startup {
                     session.add_message(MessageRole::User, &msg);
                     session.add_message(MessageRole::Assistant, &result);
                     session::storage::save_session(&session)?;
-                    let _ = session::chat_history::append_entry(
+                    if let Err(e) = session::chat_history::append_entry(
                         &session::chat_history::ChatHistoryEntry {
                             content: msg,
                             timestamp: session.updated_at.clone(),
                         },
-                    );
+                    ) {
+                        eprintln!("warning: failed to append chat history entry: {}", e);
+                    }
                 }
             } else {
                 eprintln!("error: empty command after '!'");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -154,10 +154,14 @@ impl<'a> App<'a> {
         if ui.cfg.resolve_always_show_welcome() || !marker_path.exists() {
             crate::ui::events::show_welcome(&mut renderer)?;
             if !ui.cfg.resolve_always_show_welcome() {
-                if let Some(dir) = marker_path.parent() {
-                    let _ = std::fs::create_dir_all(dir);
+                if let Some(dir) = marker_path.parent()
+                    && let Err(e) = std::fs::create_dir_all(dir)
+                {
+                    tracing::warn!("failed to create data dir for welcome marker: {e}");
                 }
-                let _ = std::fs::write(&marker_path, "");
+                if let Err(e) = std::fs::write(&marker_path, "") {
+                    tracing::warn!("failed to write welcome marker (welcome will show again): {e}");
+                }
             }
         }
         refresh_display(
@@ -196,7 +200,11 @@ impl<'a> App<'a> {
                             .rebuild_agent(&ui.session.model, slash.reasoning_enabled)
                             .await,
                     );
-                    let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
+                    if let Err(e) =
+                        render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context)
+                    {
+                        tracing::warn!("failed to re-render session after worktree switch: {e}");
+                    }
                 }
                 Err(e) => {
                     let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
@@ -225,7 +233,11 @@ impl<'a> App<'a> {
                             .rebuild_agent(&ui.session.model, slash.reasoning_enabled)
                             .await,
                     );
-                    let _ = render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context);
+                    if let Err(e) =
+                        render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context)
+                    {
+                        tracing::warn!("failed to re-render session after worktree switch: {e}");
+                    }
                 }
                 Err(e) => {
                     let _ = renderer.write_line(&format!("worktree failed: {}", e), C_ERROR);
@@ -600,8 +612,13 @@ impl<'a> App<'a> {
                     if let Some(text) = text {
                         self.input.load_text(&text);
                     }
-                    if !self.ui.cli.no_session {
-                        let _ = crate::session::storage::save_session(self.ui.session);
+                    if !self.ui.cli.no_session
+                        && let Err(e) = crate::session::storage::save_session(self.ui.session)
+                    {
+                        self.renderer.write_line(
+                            &format!("warning: failed to save session: {}", e),
+                            C_ERROR,
+                        )?;
                     }
                     render_session(
                         &mut self.renderer,

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -453,14 +453,19 @@ async fn handle_agent_done(
         };
         ls.last_run_output = validation_output.clone();
 
-        let _ = crate::extras::r#loop::transcript::save_iteration(
+        if let Err(e) = crate::extras::r#loop::transcript::save_iteration(
             &ui.session.id,
             ls.iteration,
             &ls.build_prompt(),
             &response,
             validation_output.as_deref(),
             &summary,
-        );
+        ) {
+            renderer.write_line(
+                &format!("warning: failed to save loop transcript: {}", e),
+                C_ERROR,
+            )?;
+        }
 
         ls.iteration += 1;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -563,13 +563,15 @@ pub(crate) async fn start_main_run(
     run.pending_send = Some(text.to_string());
     #[cfg(feature = "advisor")]
     crate::extras::advisor::set_session_messages(ui.session.messages.clone());
-    if !ui.cli.no_session {
-        let _ = crate::session::chat_history::append_entry(
+    if !ui.cli.no_session
+        && let Err(e) = crate::session::chat_history::append_entry(
             &crate::session::chat_history::ChatHistoryEntry {
                 content: text.to_string(),
                 timestamp: ui.session.updated_at.clone(),
             },
-        );
+        )
+    {
+        tracing::warn!("failed to append chat history entry: {e}");
     }
 }
 

--- a/src/ui/permission_handler.rs
+++ b/src/ui/permission_handler.rs
@@ -6,7 +6,7 @@ use crate::ui::renderer::Renderer;
 use crate::ui::state::{AgentRunState, UiContext};
 use crate::ui::utils::suggest_pattern;
 
-use super::C_PERM;
+use super::{C_ERROR, C_PERM};
 
 pub async fn handle_permission_request(
     ask_req: crate::permission::ask::AskRequest,
@@ -78,8 +78,10 @@ pub async fn handle_permission_request(
                 tool: ask_req.tool.clone(),
                 pattern: pattern.into(),
             });
-        if !ui.cli.no_session {
-            let _ = crate::session::storage::save_session(ui.session);
+        if !ui.cli.no_session
+            && let Err(e) = crate::session::storage::save_session(ui.session)
+        {
+            renderer.write_line(&format!("warning: failed to save session: {}", e), C_ERROR)?;
         }
     }
 

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -125,7 +125,12 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
             write_ok(ctx.renderer, "no active theme to clear");
         } else {
             ctx.context.current_theme_name = None;
-            let _ = storage::save_theme_name(None);
+            if let Err(e) = storage::save_theme_name(None) {
+                write_error(
+                    ctx.renderer,
+                    format!("warning: theme choice not saved: {}", e),
+                );
+            }
             if let Some(colors) = &ctx.cfg.colors {
                 let chat_bg = colors
                     .chat_background
@@ -148,7 +153,12 @@ async fn handle_theme(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
         let name = parts[1].trim();
         if let Some(content) = ctx.context.themes.get(name) {
             ctx.context.current_theme_name = Some(name.to_string());
-            let _ = storage::save_theme_name(Some(name));
+            if let Err(e) = storage::save_theme_name(Some(name)) {
+                write_error(
+                    ctx.renderer,
+                    format!("warning: theme choice not saved: {}", e),
+                );
+            }
             crate::context::themes::apply(content, ctx.renderer);
             write_ok(ctx.renderer, format!("active theme: {}", name));
         } else {

--- a/src/ui/slash/memory.rs
+++ b/src/ui/slash/memory.rs
@@ -192,10 +192,19 @@ fn handle_write(parts: &[&str], ctx: &mut SlashCtx<'_>) {
 fn handle_editor(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     let mem = Mem::open();
     let path = mem.memory_md();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        write_error(ctx.renderer, format!("cannot create memory dir: {e}"));
+        return Ok(());
     }
-    let _ = std::fs::write(&path, "");
+    if let Err(e) = std::fs::write(&path, "") {
+        write_error(
+            ctx.renderer,
+            format!("cannot prepare {}: {e}", path.display()),
+        );
+        return Ok(());
+    }
     write_ok(
         ctx.renderer,
         format!("opening {} in editor...", path.display()),


### PR DESCRIPTION
Implements item 3 of **Safety and error handling** in #186:

> Surface non-fatal errors visibly instead of `let _ = ...` swallowing them.

## Approach

Swept all ~280 `let _ =` sites and classified them. Most are legitimate best-effort operations (temp-file cleanup, cwd/terminal restore, shutdown-path channel sends, fire-and-forget outputs) and are deliberately untouched. The ones whose failure a user would actually care about now surface the error, in three tiers:

**Feed warnings (renderer at hand)**
- Session saves after a permission "allow always" decision (the old code printed "saved to session" even when the save failed) and after `/rewind`
- Theme-name persistence in `/theme` and `/theme default`
- `/memory editor` file preparation (now reports and aborts instead of opening a broken path)
- Loop transcript saves (`--loop`)

**Honest startup output**
- The prompts/themes regen flow printed `"Prompts regenerated."` **unconditionally** — a regen failure now prints a warning, and the success message only appears on success (via a small `regen_resource` helper)

**`tracing::warn!` (library/headless code)**
- Chat-history appends (TUI run + print mode — print mode uses `eprintln` to match its other diagnostics)
- Memory compaction-summary flush (data loss was invisible)
- MCP OAuth token file `0600` permission failure (security-relevant)
- Hooks trust-store save (trust decisions silently not persisting)
- Hook subprocess stdin/pipe I/O failures
- Default prompt/theme installation (`ensure_global`), archmd data dir, sandbox cache dir, welcome marker, session re-render after worktree switch

## Notable find

The `SessionStart`/`SessionEnd` hook dispatch sites *look* like error swallows but aren't: `dispatch()` returns an informational `Decision`, not a `Result` — the doc comment already states the decision is intentionally ignored. Left as-is (verified with `--all-features`, which is the only combo that compiles the hooks code).

## Verification

- `cargo fmt` applied
- `cargo test`: 673 passed · `--no-default-features`: 574 passed · `--all-features`: 878 passed — all 0 failed
- `cargo install --path . --debug` succeeds
