### PR TITLE
fix: validate URLs in open_url and report clipboard/open failures

### DIFF
--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -1,4 +1,4 @@
-use crate::ui::renderer::{base64_encode, copy_to_clipboard};
+use crate::ui::renderer::{base64_encode, copy_to_clipboard, is_safe_url};
 
 #[test]
 fn base64_encode_empty() {
@@ -39,12 +39,48 @@ fn base64_encode_long_input() {
 
 #[test]
 fn copy_to_clipboard_does_not_panic() {
-    copy_to_clipboard("test text");
+    // Succeeds via an external tool or the OSC 52 fallback.
+    copy_to_clipboard("test text").expect("copy should succeed");
 }
 
 #[test]
 fn copy_to_clipboard_empty_string() {
-    copy_to_clipboard("");
+    copy_to_clipboard("").expect("copy should succeed");
+}
+
+#[test]
+fn safe_url_accepts_http_and_https() {
+    assert!(is_safe_url("https://example.com"));
+    assert!(is_safe_url("http://example.com/path?q=1#frag"));
+    assert!(is_safe_url("https://user@example.com:8080/x"));
+}
+
+#[test]
+fn safe_url_rejects_non_http_schemes() {
+    assert!(!is_safe_url("file:///etc/passwd"));
+    assert!(!is_safe_url("javascript:alert(1)"));
+    assert!(!is_safe_url("ftp://example.com"));
+    assert!(!is_safe_url("example.com/no-scheme"));
+    assert!(!is_safe_url(""));
+}
+
+#[test]
+fn safe_url_rejects_missing_host() {
+    assert!(!is_safe_url("https://"));
+    assert!(!is_safe_url("http:///path"));
+}
+
+#[test]
+fn safe_url_rejects_whitespace_and_control_chars() {
+    assert!(!is_safe_url("https://example.com/a b"));
+    assert!(!is_safe_url("https://example.com/\nevil"));
+    assert!(!is_safe_url("https://example.com/\x07"));
+}
+
+#[test]
+fn safe_url_rejects_overlong_urls() {
+    let long = format!("https://example.com/{}", "a".repeat(2100));
+    assert!(!is_safe_url(&long));
 }
 
 #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -477,7 +477,10 @@ impl<'a> App<'a> {
                     && let Some(idx) = self.renderer.buffer_line_at_row(row)
                 {
                     if let Some(url) = self.renderer.link_url_at(idx, col) {
-                        renderer_mod::open_url(&url);
+                        if let Err(e) = renderer_mod::open_url(&url) {
+                            self.renderer
+                                .write_line(&format!("cannot open link: {}", e), C_ERROR)?;
+                        }
                     } else {
                         self.renderer.selection_active = true;
                         self.renderer.selection_start = Some(idx);
@@ -497,8 +500,11 @@ impl<'a> App<'a> {
                     if let Some(idx) = self.renderer.buffer_line_at_row(row) {
                         self.renderer.selection_end = Some(idx);
                     }
-                    if let Some(text) = self.renderer.selected_text() {
-                        copy_to_clipboard(&text);
+                    if let Some(text) = self.renderer.selected_text()
+                        && let Err(e) = copy_to_clipboard(&text)
+                    {
+                        self.renderer
+                            .write_line(&format!("copy to clipboard failed: {}", e), C_ERROR)?;
                     }
                     self.renderer.clear_selection();
                 }
@@ -549,8 +555,15 @@ impl<'a> App<'a> {
     async fn handle_key_event(&mut self, key: KeyEvent) -> anyhow::Result<()> {
         if self.renderer.selection_active && key.code == KeyCode::Char('y') {
             if let Some(text) = self.renderer.selected_text() {
-                copy_to_clipboard(&text);
-                self.renderer.write_line("copied selection", Color::Green)?;
+                match copy_to_clipboard(&text) {
+                    Ok(()) => {
+                        self.renderer.write_line("copied selection", Color::Green)?;
+                    }
+                    Err(e) => {
+                        self.renderer
+                            .write_line(&format!("copy to clipboard failed: {}", e), C_ERROR)?;
+                    }
+                }
             }
             self.renderer.clear_selection();
             return Ok(());
@@ -1288,9 +1301,13 @@ impl<'a> App<'a> {
                         match crate::extras::mcp::oauth::begin_login(&server, &url, &settings).await
                         {
                             Ok(login) => {
-                                copy_to_clipboard(&login.auth_url);
+                                let copied = copy_to_clipboard(&login.auth_url).is_ok();
                                 self.renderer.write_line(
-                                    "open this URL to authorize (copied to clipboard):",
+                                    if copied {
+                                        "open this URL to authorize (copied to clipboard):"
+                                    } else {
+                                        "open this URL to authorize (could not copy to clipboard):"
+                                    },
                                     C_AGENT,
                                 )?;
                                 self.renderer.write_line(&login.auth_url, Color::Cyan)?;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1301,26 +1301,64 @@ impl Renderer {
     }
 }
 
-pub fn open_url(url: &str) {
+/// Validate that a URL is safe to hand to the OS opener: an absolute
+/// http(s) URL with a non-empty host, no whitespace or control characters,
+/// and a sane length. Anything else (file:, javascript:, bare paths, ...)
+/// is rejected so a malicious or malformed link cannot reach the shell.
+pub(crate) fn is_safe_url(url: &str) -> bool {
+    let url = url.trim();
+    if url.is_empty() || url.len() > 2048 {
+        return false;
+    }
+    if url.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return false;
+    }
+    let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    else {
+        return false;
+    };
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    !host.is_empty()
+}
+
+/// Open `url` in the system browser. The URL is validated first; the error
+/// describes why nothing was opened (rejected URL or no working opener), so
+/// callers can surface it instead of failing silently.
+pub fn open_url(url: &str) -> anyhow::Result<()> {
+    if !is_safe_url(url) {
+        let preview: String = url.chars().take(80).collect();
+        anyhow::bail!("refusing to open invalid or non-http(s) URL: {}", preview);
+    }
     let openers: &[(&str, &[&str])] = &[
         ("xdg-open", &[url]),
         ("open", &[url]),               // macOS
         ("cmd", &["/c", "start", url]), // Windows
     ];
     for &(cmd, args) in openers {
-        if std::process::Command::new(cmd)
+        let Ok(mut child) = std::process::Command::new(cmd)
             .args(args)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
-            .is_ok()
-        {
-            return;
+        else {
+            continue; // opener not installed
+        };
+        // A spawned opener can still fail (e.g. xdg-open without a display);
+        // honor its exit status and fall through to the next one.
+        if matches!(child.wait(), Ok(status) if status.success()) {
+            return Ok(());
         }
     }
+    anyhow::bail!("no working opener found (tried xdg-open, open, cmd)")
 }
 
-pub fn copy_to_clipboard(text: &str) {
+/// Copy `text` to the system clipboard. Tries external tools (checking
+/// their exit status, so a tool that starts but fails — e.g. xclip without
+/// an X display — falls through) and finally the OSC 52 terminal escape.
+/// Errors only when even the escape cannot be written.
+pub fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
     let cmds: &[(&str, &[&str])] = &[
         ("wl-copy", &[]),
         ("xclip", &["-selection", "clipboard"]),
@@ -1328,17 +1366,25 @@ pub fn copy_to_clipboard(text: &str) {
         ("clip.exe", &[]),
     ];
     for &(cmd, args) in cmds {
-        if let Ok(mut child) = std::process::Command::new(cmd)
+        let Ok(mut child) = std::process::Command::new(cmd)
             .args(args)
             .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .spawn()
-        {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(text.as_bytes());
-                let _ = stdin.flush();
+        else {
+            continue; // tool not installed
+        };
+        let wrote = match child.stdin.take() {
+            Some(mut stdin) => {
+                let ok = stdin.write_all(text.as_bytes()).is_ok();
+                drop(stdin); // close stdin so the tool sees EOF
+                ok
             }
-            let _ = child.wait();
-            return;
+            None => false,
+        };
+        if wrote && matches!(child.wait(), Ok(status) if status.success()) {
+            return Ok(());
         }
     }
 
@@ -1347,8 +1393,9 @@ pub fn copy_to_clipboard(text: &str) {
     // and most other modern terminals. No external tools needed.
     let encoded = base64_encode(text.as_bytes());
     let mut stdout = std::io::stdout().lock();
-    let _ = write!(stdout, "\x1b]52;c;{encoded}\x07");
-    let _ = stdout.flush();
+    write!(stdout, "\x1b]52;c;{encoded}\x07")?;
+    stdout.flush()?;
+    Ok(())
 }
 
 /// Minimal base64 encoder — avoids pulling in a crate just for clipboard support.


### PR DESCRIPTION
Implements item 4 of **Safety and error handling** in #186:

> Validate URLs in `open_url` and report clipboard/open failures to the status line.

## Problems

- `open_url` handed any string straight to `xdg-open`/`open`/`cmd` with no validation, and couldn't report failure: an opener that *spawned* but exited non-zero (e.g. `xdg-open` without a display) counted as success, and with no opener installed, nothing happened at all — silently.
- `copy_to_clipboard` likewise treated a spawned-but-failed tool as success (e.g. `xclip` with no X display), and callers printed success unconditionally: `copied selection` in green, `(copied to clipboard)` during MCP OAuth login.

## Changes

**`src/ui/renderer.rs`**
- New `is_safe_url`: accepts only absolute `http(s)` URLs with a non-empty host, rejects whitespace/control characters, caps length at 2048. This blocks `file://`, `javascript:`, bare paths, and control-char payloads from ever reaching the OS opener.
- `open_url` now returns `anyhow::Result<()>`: bails on rejected URLs (with a preview of the offending string), and honors each opener's **exit status**, falling through to the next one; errors with "no working opener found" when all fail.
- `copy_to_clipboard` now returns `anyhow::Result<()>`: checks tool exit statuses (a tool that starts but fails falls through), then the OSC 52 terminal escape; errors only when even the escape can't be written. Also closes stdin explicitly so tools see EOF.

**Call sites (`src/ui/app.rs`)** — all four report outcomes to the feed:
- Link click: `cannot open link: <reason>` on failure (silent on success, browser opens)
- Mouse-release and `y` selection copy: warning line on failure instead of unconditional green `copied selection`
- MCP OAuth login: message now says `(could not copy to clipboard)` when the copy fails

## Tests

5 new `is_safe_url` tests (accept http/https variants; reject non-http schemes, missing host, whitespace/control chars, overlong URLs); the two existing clipboard tests now assert success.

## Verification

- `cargo fmt` applied; `cargo clippy --all-targets` clean
- `cargo test`: 678 passed · `--no-default-features`: 579 · `--all-features`: 883 — all 0 failed
- `cargo install --path . --debug` succeeds
