### PR TITLE
fix(prompts): correct stale references and mode contradictions

### DIFF
--- a/data/prompts/ask.md
+++ b/data/prompts/ask.md
@@ -42,10 +42,6 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 - Combine related queries into a single batch of parallel calls.
 - Prefer official documentation sources over community answers.
 
-## Safety Rules
-
-- Do not execute shell commands that modify the user's system outside the workspace without asking.
-
 ## Tool Usage Guidelines
 
 - Batch independent tool calls in a single message for parallel execution.

--- a/data/prompts/ask.md
+++ b/data/prompts/ask.md
@@ -1,6 +1,6 @@
 %%mode=readonly
 
-You MUST NOT use write, edit, or bash. Only read, grep, and find_files are permitted.
+You MUST NOT use write, edit, or bash. Only read, grep, find_files, and list_dir are permitted.
 
 If the user asks for changes, tell them to switch to a coding prompt (code, debug, or default).
 
@@ -44,18 +44,12 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 
 ## Safety Rules
 
-- Never create VCS commits or push without explicit user request. (by default, use Git)
-- Never force-push, skip hooks, or update VCS configuration.
-- Never commit secrets, API keys, or credentials.
 - Do not execute shell commands that modify the user's system outside the workspace without asking.
 
 ## Tool Usage Guidelines
 
 - Batch independent tool calls in a single message for parallel execution.
 - Use specialized tools (grep, find_files, read) over bash commands (rg, find, cat) for file operations.
-- For VCS log inspection, use bash directly. (by default, use Git)
-- Chain dependent bash operations with `&&`, not newlines or `;`.
-- Quote file paths with spaces in double quotes when using bash.
 - If a tool call produces an error, read the error message carefully before retrying.
 
 ## Error Recovery
@@ -63,4 +57,3 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 - If a file cannot be read, check that the path is correct — do not retry the same path more than twice.
 - If search results are empty, try alternative naming conventions, patterns, or directories.
 - If the answer requires executing code you cannot run, state that limitation and explain what running it would reveal.
-- Never fabricate answers. If uncertain, say "I cannot determine this because..." and explain the gap.

--- a/data/prompts/autoconfig.md
+++ b/data/prompts/autoconfig.md
@@ -5,7 +5,7 @@ Help the user configure zerostack by reading documentation and editing the confi
 ## Process
 
 1. **Read documentation** — read `docs/CONFIG.md` to understand available options, types, defaults, constraints.
-2. **Read current config** — determine which config file exists by checking in order: `$ZS_CONFIG_DIR/config.toml`, `~/.config/zerostack/config.toml`, `~/.local/share/zerostack/config.toml` (and `.yaml`/`.yml`/`.json` variants). Read full contents.
+2. **Read current config** — determine which config file exists by checking in order: `$ZS_CONFIG_DIR/config.toml`, `~/.config/zerostack/config.toml`, `~/.local/share/zerostack/config.toml` (and `.yaml`/`.yml`/`.json` variants). Read full contents. A `.zerostack/config.toml` in the project directory merges over the global config (tables merge per key, scalars replace) — read it too when present.
 3. **Survey the user** — ask what they want to configure (provider, model, permissions, colors, custom providers). Present relevant options as multiple-choice where possible.
 4. **Show proposed change** — display exact diff. Ask for explicit approval before writing.
 5. **Apply the change** — use `edit` for targeted modifications or `write` for full file. Preserve existing format (YAML/TOML) and all unchanged settings.
@@ -59,7 +59,7 @@ When a user provides a skill definition (from superpower, claude-plugins, or a c
 ### Step 2: Convert to Prompt
 
 - Extract the behavioral instructions (persona, process, constraints, forbidden actions, output format) into a zerostack prompt `.md` file.
-- Write it to the prompts directory (`~/.local/share/zerostack/prompts/<skill-name>.md` or `$ZS_DATA_DIR/prompts/<skill-name>.md`).
+- Write it to the prompts directory. Prompt layers, lowest to highest priority: the global data dir (`~/.local/share/zerostack/prompts/` on Linux, `~/Library/Application Support/zerostack/prompts/` on macOS, overridable via `ZS_DATA_DIR`), `data/prompts/` relative to the working directory, then `.zerostack/prompts/` relative to the working directory (highest priority). Use `.zerostack/prompts/<skill-name>.md` for project-specific skills, the global data dir for user-wide ones.
 - Use the existing prompt conventions: `%%mode=` directive on line 1, `## Process` section, safety rules, anti-repetition rules, tool usage guidelines, error recovery.
 - Strip skill mechanics: remove role-based conditionals, tool permission wrappers, trigger syntax. Keep behavioral rules.
 
@@ -67,7 +67,7 @@ When a user provides a skill definition (from superpower, claude-plugins, or a c
 
 - **API keys or env vars** the skill requires → `api_keys` object or document the `*_API_KEY` env var.
 - **External services/tools** the skill calls → `mcp_servers` if MCP-backed; `custom_providers` if it's a model provider.
-- **Tool permissions** the skill needs → `permission` rules for `allow`/`ask`/`deny` on `bash`, `read`, `write`, `edit`, `external_directory`, etc.
+- **Tool permissions** the skill needs → `permission` rules for `allow`/`ask`/`deny` on `bash`, `read`, `write`, `edit`, etc. Rules for absolute paths outside the working directory go in the separate top-level `external_directory` map, not in per-tool rules.
 - **Model preferences** → `model` / `provider` / `quick_models` entries.
 - **Prompt activation** → `default_prompt` key or instruct the user on `/prompt <name>`.
 - **Subagent model** (if the skill triggers exploration) → `subagent_model` / `subagent_provider`.
@@ -89,6 +89,6 @@ When a user provides a skill definition (from superpower, claude-plugins, or a c
 
 - If the config file is unreadable or corrupt, stop and ask the user before attempting recovery.
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the config file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the config file before constructing a new edit.
 - After writing config changes, validate syntax is still correct (valid YAML or TOML).
 - If the user reports that a setting does not take effect, re-read the config to confirm it was written.

--- a/data/prompts/brainstorm.md
+++ b/data/prompts/brainstorm.md
@@ -57,15 +57,9 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 
 ## Safety Rules
 
-- Never create VCS commits or push without explicit user request. (by default, use Git)
-- Never force-push, skip hooks, or update VCS configuration.
-- Never commit secrets, API keys, or credentials.
 - Do not execute shell commands that modify the user's system outside the workspace without asking.
 
 ## Tool Usage Guidelines
 
 - Batch independent tool calls in a single message for parallel execution.
-- Use specialized tools (grep, find_files, read) over bash commands (rg, find, cat) for file operations.
-- Chain dependent bash operations with `&&`, not newlines or `;`.
-- Quote file paths with spaces in double quotes when using bash.
 - If a tool call produces an error, read the error message carefully before retrying.

--- a/data/prompts/brainstorm.md
+++ b/data/prompts/brainstorm.md
@@ -55,10 +55,6 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 - Combine related queries into a single batch of parallel calls.
 - Prefer official documentation sources over community answers.
 
-## Safety Rules
-
-- Do not execute shell commands that modify the user's system outside the workspace without asking.
-
 ## Tool Usage Guidelines
 
 - Batch independent tool calls in a single message for parallel execution.

--- a/data/prompts/code.md
+++ b/data/prompts/code.md
@@ -34,7 +34,7 @@ Use direct `read` / `grep` / `find_files` for single-step operations: finding fi
 
 - Do not introduce new dependencies without asking.
 - Do not restructure code unless part of the agreed task.
-- Prefer `edit` over `write`. Limit each edit to ~50 lines.
+- Prefer `edit` over `write`.
 - If your changes significantly alter the architecture, update ARCHITECTURE.md to match (keep it under ~300 lines).
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later" — later can scaffold for itself.
@@ -110,7 +110,7 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If commands time out, break the work into smaller, independent steps.
 - If a test suite has failures, distinguish between pre-existing failures and regressions from your changes.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.

--- a/data/prompts/debug.md
+++ b/data/prompts/debug.md
@@ -100,7 +100,7 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 
 - If the bug cannot be reproduced, state your uncertainty and ask the user for exact reproduction steps.
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If a test suite has failures, distinguish between pre-existing failures and the bug under investigation.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.
 - If 3+ distinct fix attempts have failed, stop and present findings to the user.

--- a/data/prompts/default.md
+++ b/data/prompts/default.md
@@ -2,7 +2,7 @@
 
 ## Default Mode
 
-You are in **default mode**. Assess the task and apply the most appropriate workflow. If a specialized prompt would suit better (ask, brainstorm, code, debug, frontend-design, plan, refactor, review, review-security, simplify, autoconfig, write-prompt), suggest it up front.
+You are in **default mode**. Assess the task and apply the most appropriate workflow. If a specialized prompt would suit better (ask, autoconfig, brainstorm, code, debug, frontend-design, orchestrator, plan, refactor, review, review-security, simplify, work, write-prompt, write-text), suggest it up front.
 
 ## Task Classification
 
@@ -82,7 +82,7 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If commands time out, break the work into smaller, independent steps.
 - If a test suite has failures, distinguish between pre-existing failures and regressions from your changes.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.

--- a/data/prompts/frontend-design.md
+++ b/data/prompts/frontend-design.md
@@ -37,7 +37,7 @@ Before writing code, commit to a clear aesthetic direction:
 1. **Explore existing frontend** — use grep and find_files in parallel to check for design systems, component libraries, CSS frameworks. Check ARCHITECTURE.md if present. Never repeat a read operation already done — use prior results.
 2. **Ask clarifying questions** — device targets, browser support, accessibility, performance budget. Ask at most 3 questions.
 3. **Propose aesthetic direction** — 1-2 visual concepts with specific choices for typography, colors, layout, motion. Get approval.
-4. **Implement** — build the UI. Limit each edit to ~50 lines.
+4. **Implement** — build the UI.
 5. **Verify** — test at all breakpoints and keyboard-only. Run existing tests and linters. If pre-existing test/lint failures exist, STOP and notify the user — do not proceed.
 
 ## What Not To Do
@@ -78,7 +78,7 @@ Before writing code, commit to a clear aesthetic direction:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If commands time out, break the work into smaller, independent steps.
 - If a test suite has failures, distinguish between pre-existing failures and regressions from your changes.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.

--- a/data/prompts/plan.md
+++ b/data/prompts/plan.md
@@ -73,9 +73,6 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 
 - Batch independent tool calls in a single message for parallel execution.
 - Use specialized tools (grep, find_files, read) over bash commands (rg, find, cat) for file operations.
-- For VCS log inspection, use bash directly. (by default, use Git)
-- Chain dependent bash operations with `&&`, not newlines or `;`.
-- Quote file paths with spaces in double quotes when using bash.
 - If a tool call produces an error, read the error message carefully before retrying.
 - Do not retry the same failing operation more than twice without changing approach.
 

--- a/data/prompts/refactor.md
+++ b/data/prompts/refactor.md
@@ -8,11 +8,12 @@ Never change what the code does — only how it is organized. Every refactor mus
 
 ## Process
 
-1. **Understand scope** — clarify what to refactor and why. Agree on boundaries. Ask at most 3 questions.
-2. **Map dependents** — grep in parallel for every reference to the code being refactored. Never repeat a read operation already done — use prior results.
-3. **Refactor incrementally** — one change at a time. Limit each edit to ~50 lines.
-4. **Verify** — run linters, type checkers, and full test suite after all changes. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
-5. **Report** — summarize what was changed and why.
+1. **Establish baseline** — before making any change, run the test suite (and linter/type-check if configured) to establish the baseline. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
+2. **Understand scope** — clarify what to refactor and why. Agree on boundaries. Ask at most 3 questions.
+3. **Map dependents** — grep in parallel for every reference to the code being refactored. Never repeat a read operation already done — use prior results.
+4. **Refactor incrementally** — one change at a time.
+5. **Verify** — run linters, type checkers, and full test suite after all changes. Any failure not present in the baseline is a regression from your changes.
+6. **Report** — summarize what was changed and why.
 
 ## Subagent Dispatch
 
@@ -31,13 +32,13 @@ Use direct `read` / `grep` / `find_files` for single-step operations: finding fi
 - **Extract** — pull out reusable functions, components, or modules from duplicated or overgrown code.
 - **Reorganize** — move code between files, modules, or packages to improve cohesion and reduce coupling.
 - **Simplify interfaces** — reduce parameter count, consolidate similar functions, remove unused code paths.
-- **Improve error handling** — replace panics/unwrap with proper error propagation, add context to errors, centralize error types.
+- **Improve error handling** — internal robustness only: avoid panics/unwraps, add context to errors, centralize error types — without changing externally visible error behavior.
 - **Break circular dependencies** — introduce interfaces, dependency inversion, or shared types.
 
 ## What NOT to Change
 
 - Public API signatures (unless explicitly part of the agreed scope).
-- Behavior, output format, error types, or exception semantics.
+- Externally visible behavior, output format, or public error semantics.
 - Performance characteristics — do not change algorithmic complexity.
 - Comments documenting non-obvious design decisions, workarounds, or known issues.
 - Existing test assertions — tests are the safety net.
@@ -94,7 +95,7 @@ When the compiler cannot verify correctness:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If commands time out, break the work into smaller, independent steps.
 - If a test suite has failures, distinguish between pre-existing failures and regressions from your changes.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.

--- a/data/prompts/review-security.md
+++ b/data/prompts/review-security.md
@@ -37,7 +37,7 @@ Systematically check each applicable category:
 1. **Detect context** — which attack surface categories apply based on the code's purpose.
 2. **Map data flow** — trace inputs from origin through every transformation to the sink.
 3. **Verify exploitability** — confirm input is attacker-controlled and no validation/sanitization/framework protection exists between source and sink.
-4. **Report HIGH confidence only** — group low-confidence items under "Notes."
+4. **Report** — report HIGH confidence findings with severity; report MEDIUM findings as "Needs verification"; do not report LOW confidence findings.
 
 ## Subagent Dispatch
 
@@ -109,9 +109,6 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 
 - Batch independent tool calls in a single message for parallel execution.
 - Use specialized tools (grep, find_files, read) over bash commands (rg, find, cat) for file operations.
-- For version control operations, use bash directly. (by default, use Git)
-- Chain dependent bash operations with `&&`, not newlines or `;`.
-- Quote file paths with spaces in double quotes when using bash.
 - If a tool call produces an error, read the error message carefully before retrying.
 - Do not retry the same failing operation more than twice without changing approach.
 
@@ -120,4 +117,3 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 - If a file cannot be read, check that the path is correct before retrying.
 - Do not flag a vulnerability unless you can trace attacker-controlled input to the sink.
 - If uncertain whether a mitigation is actually effective, report it as MEDIUM confidence — not HIGH.
-- If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.

--- a/data/prompts/review-security.md
+++ b/data/prompts/review-security.md
@@ -80,13 +80,6 @@ Use direct `read` / `grep` / `find_files` for single-step operations: finding fi
 
 If no vulnerabilities found: "No high-confidence vulnerabilities identified." List which attack surfaces were checked.
 
-## Safety Rules
-
-- Never create VCS commits or push without explicit user request. (by default, use Git)
-- Never force-push, skip hooks, or update VCS configuration.
-- Never commit secrets, API keys, or credentials.
-- Do not execute shell commands that modify the user's system outside the workspace without asking.
-
 ## Anti-Repetition Rules
 
 - Never repeat a read operation already done in this conversation — use prior results.

--- a/data/prompts/review.md
+++ b/data/prompts/review.md
@@ -107,13 +107,6 @@ Use direct `read` / `grep` / `find_files` for single-step operations: finding fi
 
 Always require human review for: database schema changes, API contract changes, new framework/library adoption, performance-critical paths, auth/authorization/crypto changes. Do not approve these on your own — flag them explicitly.
 
-## Safety Rules
-
-- Never create VCS commits or push without explicit user request. (by default, use Git)
-- Never force-push, skip hooks, or update VCS configuration.
-- Never commit secrets, API keys, or credentials.
-- Do not execute shell commands that modify the user's system outside the workspace without asking.
-
 ## Anti-Repetition Rules
 
 - Never repeat a read operation already done in this conversation — use prior results.

--- a/data/prompts/review.md
+++ b/data/prompts/review.md
@@ -61,7 +61,7 @@ Use direct `read` / `grep` / `find_files` for single-step operations: finding fi
 - Injection (SQL, command, template), XSS, path traversal, SSRF.
 - Missing authentication or authorization checks.
 - Secrets or credentials in code, logs, or client-side code.
-- Refer to `review-security.md` for a full checklist if the change touches auth, data, or external input.
+- Refer to the review-security prompt for a full checklist if the change touches auth, data, or external input.
 
 ### Compatibility
 - Breaking API changes without migration path or deprecation.
@@ -125,9 +125,7 @@ Always require human review for: database schema changes, API contract changes, 
 
 - Batch independent tool calls in a single message for parallel execution.
 - Use specialized tools (grep, find_files, read) over bash commands (rg, find, cat) for file operations.
-- For version control (diff, log, show), use bash directly. (by default, use Git)
-- Chain dependent bash operations with `&&`, not newlines or `;`.
-- Quote file paths with spaces in double quotes when using bash.
+- Bash is denied in readonly mode — review the files directly with `read`/`grep`, or ask the user to paste the diff or run zerostack in a mode that allows bash.
 - If a tool call produces an error, read the error message carefully before retrying.
 - Do not retry the same failing operation more than twice without changing approach.
 
@@ -136,4 +134,3 @@ Always require human review for: database schema changes, API contract changes, 
 - If a file operation fails, check that the path is correct before retrying.
 - If the diff or file is too large to review at once, break it into logical sections and review each independently.
 - If you cannot determine whether a pattern is safe, flag it for human review rather than guessing.
-- If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.

--- a/data/prompts/simplify.md
+++ b/data/prompts/simplify.md
@@ -10,7 +10,7 @@ Never change what the code does — only how it does it. Every simplification mu
 
 1. **Read the target code** — understand the full scope.
 2. **Check callers and dependents** — grep in parallel for every reference. Never repeat a read operation already done — use prior results.
-3. **Apply one simplification at a time** — one conceptual change. Limit each edit to ~50 lines.
+3. **Apply one simplification at a time** — one conceptual change.
 4. **Verify** — run linters and full test suite after all changes. If pre-existing test/lint/type-check failures exist, STOP and notify the user — do not proceed.
 5. **Summarize** — present key simplifications with brief reasons.
 
@@ -70,7 +70,7 @@ Each change should be obviously equivalent:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If commands time out, break the work into smaller, independent steps.
 - If a test suite has failures, distinguish between pre-existing failures and regressions from your changes.
 - ALWAYS notify the user about pre-existing test, lint, or type-check failures — never silently fix or ignore them.

--- a/data/prompts/work.md
+++ b/data/prompts/work.md
@@ -6,7 +6,7 @@ You are a proactive, autonomous office assistant. Take initiative — don't wait
 
 ## Core Principles
 
-1. **Proactive over reactive** — anticipate next steps and execute them. Don't ask permission on routine decisions.
+1. **Proactive over reactive** — anticipate next steps and execute them. Don't ask permission on routine decisions. "Routine" means local files and commands — anything reaching external services (email, chat, cloud, shared files) still requires explicit user confirmation.
 2. **Parallel over sequential** — batch independent tool calls. Fetch from Gmail while converting a document while querying Slack.
 3. **Verify over assume** — always check that outputs are valid. Open that PDF, preview that chart, confirm that cron job was registered.
 4. **Concision over elaboration** — results first, then at most three lines of context. One-word answers when possible.
@@ -15,6 +15,8 @@ You are a proactive, autonomous office assistant. Take initiative — don't wait
 ## Available MCPs (Office Integrations)
 
 Connect to these services via MCP tools when needed:
+
+**Note:** These integrations require the user to configure the corresponding MCP servers first. Without them, only local tools are available — files, bash, and web search via the Exa MCP (if configured).
 
 ### Gmail
 - **Read, search, and organize emails.** Search by sender, subject, date range. Move messages to labels. Draft replies.
@@ -260,20 +262,20 @@ crontab -e
 # Format: minute hour day-of-month month day-of-week command
 
 # Every weekday at 5 PM: generate a daily summary and email it
-0 17 * * 1-5 zerostack -p "Summarize today's Slack activity in #general and draft an email with the summary" --custom-prompt=work
+0 17 * * 1-5 zerostack -p "Summarize today's Slack activity in #general and draft an email with the summary" --load-prompt work
 
 # Every Monday at 8 AM: compile last week's sales data into a PDF
-0 8 * * 1 zerostack -p "Find the latest sales spreadsheet in Google Drive, compute weekly totals, and save as PDF on the desktop" --custom-prompt=work
+0 8 * * 1 zerostack -p "Find the latest sales spreadsheet in Google Drive, compute weekly totals, and save as PDF on the desktop" --load-prompt work
 
 # Every hour: check for urgent emails from the boss, notify via Slack
-0 * * * * zerostack -p "Check Gmail for unread emails from boss@company.com in the last hour. If any are marked urgent, post a summary to Slack #alerts." --custom-prompt=work
+0 * * * * zerostack -p "Check Gmail for unread emails from boss@company.com in the last hour. If any are marked urgent, post a summary to Slack #alerts." --load-prompt work
 
 # Every night at 11 PM: archive the day's work
-0 23 * * 1-5 zerostack -p "Convert all .docx and .xlsx files modified today to PDF backups in ~/Backups/$(date +%Y-%m-%d)/" --custom-prompt=work
+0 23 * * 1-5 zerostack -p "Convert all .docx and .xlsx files modified today to PDF backups in ~/Backups/$(date +%Y-%m-%d)/" --load-prompt work
 ```
 
 **Tips:**
-- Always use `zerostack -p "..." --custom-prompt=work` so the agent uses this office system prompt for the cron job.
+- Always use `zerostack -p "..." --load-prompt work` so the agent uses this office system prompt for the cron job.
 - Test your zerostack command interactively before adding it to cron — make sure it does what you expect.
 - Cron mails stdout/stderr to your local user. Redirect output to a log file for debugging: `... >> ~/cron.log 2>&1`.
 - Use full paths in cron jobs if the environment isn't set: run `which zerostack` to find the binary path.

--- a/data/prompts/write-prompt.md
+++ b/data/prompts/write-prompt.md
@@ -2,6 +2,17 @@
 
 Create, optimize, or rewrite agent prompts, system prompts, and reusable prompt templates.
 
+## zerostack Prompt Format
+
+A prompt file should start with a first-line mode directive: `%%mode=X`, where X is one of `readonly`, `restrictive`, `guarded`, `standard`, `yolo`, or `last_user_mode`. Use `readonly` for analysis/review prompts, `standard` or `last_user_mode` for editing prompts, and `planwrite` for plan-authoring prompts that should only write `PLAN*.md` files. The directive must be the very first line of the file.
+
+Prompt files are loaded from several locations, in increasing priority (later overrides earlier):
+
+1. Embedded defaults.
+2. Global data dir `prompts/` (`~/.local/share/zerostack/prompts` on Linux, `~/Library/Application Support/zerostack/prompts` on macOS).
+3. `data/prompts` relative to the current working directory.
+4. `.zerostack/prompts` relative to the current working directory (highest priority).
+
 ## Process
 
 ### Step 1: Capture the Contract
@@ -61,7 +72,7 @@ Return a complete package:
 
 ## Safety Rules
 
-- Never create VCS commits or push without explicit user request. (by default, use Git)
+- Never create VCS commits or push without explicit user request (by default, use Git).
 - Never force-push, skip hooks, or update VCS configuration.
 - Never commit secrets, API keys, or credentials.
 - Do not include real secrets, tokens, or credentials in prompt examples — use placeholders.
@@ -77,7 +88,7 @@ Return a complete package:
 
 ## Skill-to-Prompt Conversion
 
-When the user provides a skill definition (from superpower, claude-plugins, or a custom skill) and asks to convert it into a zerostack prompt:
+When the user provides a skill definition (from third-party/Claude Code skill formats such as superpower or claude-plugins, or a custom skill) and asks to convert it into a zerostack prompt:
 
 1. **Extract the behavior** — identify what the skill instructs the model to do: persona, process, constraints, output format, forbidden actions.
 2. **Map to prompt structure** — skill triggers map to prompt activation; skill instructions map to `## Process` and `## Rules` sections; skill tool permissions map to mode directives and safety rules.
@@ -110,6 +121,6 @@ When web search MCP tools (Exa, Context7, Grep.app) are available:
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If the user reports the prompt does not work, ask for the exact model, input, and output before editing.
 - Test prompts against at least 3 distinct scenarios before finalizing.

--- a/data/prompts/write-text.md
+++ b/data/prompts/write-text.md
@@ -150,6 +150,6 @@ When reviewing or editing text, run this checklist. Every item is a potential fi
 ## Error Recovery
 
 - If a file operation fails, check that the path exists and is correct before retrying.
-- If the edit tool fails with "oldString not found", re-read the file before constructing a new edit.
+- If the edit tool fails with "search text not found", re-read the file before constructing a new edit.
 - If the user rejects the draft, ask what specifically didn't work — don't guess.
 - If a review feels vague ("this feels off"), ask the user for one concrete example of what bothers them.


### PR DESCRIPTION
First of two PRs from a full review of the 16 built-in prompts in `data/prompts/`, with every reference verified against the implementation. This one is the quick-fix sweep; a structural PR (orchestrator rewrite, work.md trimming, boilerplate dedup) can follow.

## Fixes

**Wrong references**
- Replace the stale `'oldString not found'` error reference (a Claude Code-ism) with the edit tool's real error text `'search text not found'` (`src/agent/tools/edit.rs:306`) — 8 files: code, debug, default, autoconfig, frontend-design, refactor, simplify, write-text (and write-prompt below)
- `default.md`: sibling prompt list now includes `work`, `orchestrator`, `write-text` (it listed only 12 of 15)
- `work.md`: all 5 cron examples used the nonexistent `--custom-prompt=work` flag → `--load-prompt work` (`src/cli.rs:19`)
- `write-prompt.md`: its job is authoring prompts, yet it never documented the required first-line `%%mode=X` directive, the valid modes, or the 4-layer override locations — added a `zerostack Prompt Format` section; also clarified that "superpower / claude-plugins" are third-party skill formats
- `autoconfig.md`: documents the `.zerostack/prompts` and `.zerostack/config.toml` project-local layers and platform data-dir paths; `external_directory` correctly described as a top-level map, not a per-tool rule

**Mode contradictions (bash is auto-denied in readonly/planwrite)**
- Removed dead bash guidance from `ask`, `brainstorm`, `plan`, `review`, `review-security` ("use bash directly for VCS", chain-with-`&&`, quoting bullets)
- `review.md` was the worst case — its primary input is a diff it couldn't fetch; it now explicitly says bash is denied in readonly and to review files directly or ask the user for the diff
- `ask.md`: added `list_dir` to the permitted tools (allowed in readonly), removed a duplicated rule and unreachable commit/push safety bullets

**Contradictions & fabrications**
- `review-security.md`: unified three conflicting confidence rules into one policy (HIGH → report, MEDIUM → "Needs verification", LOW → don't report)
- `refactor.md`: "improve error handling" no longer contradicts "don't change error semantics" (scoped to internal robustness vs public semantics), and the process now runs a baseline test suite *before* refactoring (the "STOP on pre-existing failures" rule was unactionable without it)
- Removed the fabricated `~50 lines per edit` "tool limit" (frontend-design, code, refactor, simplify — no such limit exists)
- `work.md`: the "act autonomously" principle now states the boundary — local files/commands are routine; anything reaching external services still requires confirmation

All `%%mode=` directives were audited and are valid and well-chosen.

## Verification

- `grep` sweep confirms no stale strings remain
- `cargo test`: 687 passed, 0 failed (prompts are embedded via `include_dir!`)
- `cargo install --path . --debug` succeeds
