### PR TITLE
fix: sync Cargo.lock version with Cargo.toml (1.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8718,7 +8718,7 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerostack"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",


### PR DESCRIPTION
The v1.7.2 bump (3d6c343) updated `Cargo.toml`'s version but not `Cargo.lock`, so every `--locked` CI job fails — on main itself and on the merge refs of all open PRs (e.g. #215, #216):

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

This PR is the one-line lock regeneration (zerostack 1.7.1 → 1.7.2), verified with `cargo test --locked` (687 passed).

Note: `scripts/sync-version.sh` syncs the version into packaging files (AUR/conda/Homebrew) but not into `Cargo.lock` — worth adding a lock regeneration step there (or to `just`) so the next bump doesn't hit this.