### PR TITLE
feat: warn on unknown config keys at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8718,7 +8718,7 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerostack"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -54,6 +54,8 @@ data files.
 
 All config keys are optional. CLI flags and their environment-backed values
 (such as `ZS_PROVIDER` and `ZS_MODEL`) take precedence where both exist.
+Unknown top-level keys (typos, or keys gated behind a cargo feature that is
+not compiled in) produce a warning at startup — they are otherwise ignored.
 
 Example (YAML):
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -337,8 +337,9 @@ pub fn load() -> (Config, bool) {
             );
             std::process::exit(1);
         });
-        match path.extension().and_then(|e| e.to_str()) {
-            Some("toml") => toml::from_str(&content).unwrap_or_else(|e| {
+        let is_toml = path.extension().and_then(|e| e.to_str()) == Some("toml");
+        let cfg: Config = if is_toml {
+            toml::from_str(&content).unwrap_or_else(|e| {
                 eprintln!(
                     "error: {} is not a valid config: {}\n\
                       Fix the file or remove it to use defaults.",
@@ -346,8 +347,9 @@ pub fn load() -> (Config, bool) {
                     e,
                 );
                 std::process::exit(1);
-            }),
-            _ => serde_yaml_ng::from_str(&content).unwrap_or_else(|e| {
+            })
+        } else {
+            serde_yaml_ng::from_str(&content).unwrap_or_else(|e| {
                 eprintln!(
                     "error: {} is not a valid config: {}\n\
                       Fix the file or remove it to use defaults.",
@@ -355,8 +357,23 @@ pub fn load() -> (Config, bool) {
                     e,
                 );
                 std::process::exit(1);
-            }),
+            })
+        };
+        // Best-effort second pass to flag unknown top-level keys (the main
+        // parse silently drops them).
+        let file_value = if is_toml {
+            toml::from_str::<toml::Value>(&content)
+                .ok()
+                .and_then(|v| serde_json::to_value(&v).ok())
+        } else {
+            serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&content)
+                .ok()
+                .and_then(|v| serde_json::to_value(&v).ok())
+        };
+        if let Some(value) = &file_value {
+            warn_unknown_keys(&path.display().to_string(), value, &cfg);
         }
+        cfg
     };
 
     tracing::debug!(
@@ -394,6 +411,9 @@ fn apply_local_override(cfg: &mut Config) {
         );
         std::process::exit(1);
     });
+    let file_value = toml::from_str::<toml::Value>(&content)
+        .ok()
+        .and_then(|v| serde_json::to_value(&v).ok());
     match merge_config_override(cfg, &content) {
         Ok(merged) => {
             tracing::info!(
@@ -404,6 +424,9 @@ fn apply_local_override(cfg: &mut Config) {
                 "note: applied project-local config override from {}",
                 path.display()
             );
+            if let Some(value) = &file_value {
+                warn_unknown_keys(LOCAL_CONFIG_PATH, value, &merged);
+            }
             *cfg = merged;
         }
         Err(e) => {
@@ -447,6 +470,33 @@ fn deep_merge_json(base: &mut serde_json::Value, over: serde_json::Value) {
             }
         }
         (slot, v) => *slot = v,
+    }
+}
+
+/// Top-level keys in a parsed config file that do not map to a known
+/// `Config` field — typos, or keys gated behind a cargo feature that is not
+/// compiled in. The known set comes from serializing `cfg` back to JSON, so
+/// it tracks field renames and needs no manual list.
+pub fn unknown_keys(file: &serde_json::Value, cfg: &Config) -> Vec<String> {
+    let Ok(known) = serde_json::to_value(cfg) else {
+        return Vec::new();
+    };
+    let (Some(file_obj), Some(known_obj)) = (file.as_object(), known.as_object()) else {
+        return Vec::new();
+    };
+    file_obj
+        .keys()
+        .filter(|k| !known_obj.contains_key(*k))
+        .cloned()
+        .collect()
+}
+
+fn warn_unknown_keys(source: &str, file: &serde_json::Value, cfg: &Config) {
+    for key in unknown_keys(file, cfg) {
+        eprintln!(
+            "warning: {}: unknown config key '{}' (typo, or requires a cargo feature not compiled in)",
+            source, key
+        );
     }
 }
 

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -411,6 +411,43 @@ fn config_candidate_priority_toml_yaml_yml_legacy_json() {
 }
 
 use crate::config::merge_config_override;
+use crate::config::unknown_keys;
+
+#[test]
+fn unknown_keys_flags_typo() {
+    let file = serde_json::json!({"model": "m", "modle": "typo"});
+    let cfg: Config = serde_json::from_value(file.clone()).unwrap();
+    assert_eq!(unknown_keys(&file, &cfg), vec!["modle"]);
+}
+
+#[test]
+fn unknown_keys_accepts_valid_keys() {
+    let file = serde_json::json!({
+        "model": "m",
+        "temperature": 0.5,
+        "reserve_tokens": 1024,
+        "retry": {"max_attempts": 5}
+    });
+    let cfg: Config = serde_json::from_value(file.clone()).unwrap();
+    assert!(unknown_keys(&file, &cfg).is_empty());
+}
+
+#[cfg(feature = "mcp")]
+#[test]
+fn unknown_keys_accepts_renamed_keys() {
+    let file = serde_json::json!({
+        "enable-exa-mcp": false,
+        "permission-allow": {"bash": ["ls"]}
+    });
+    let cfg: Config = serde_json::from_value(file.clone()).unwrap();
+    assert!(unknown_keys(&file, &cfg).is_empty());
+}
+
+#[test]
+fn unknown_keys_non_object_file_is_empty() {
+    let file = serde_json::json!(["not", "a", "table"]);
+    assert!(unknown_keys(&file, &Config::default()).is_empty());
+}
 
 #[test]
 fn local_override_replaces_scalar() {


### PR DESCRIPTION
## Problem

`Config` deserialization silently drops unknown top-level keys, so a typo (`modle = "x"`, `temperatur = 0.5`) fails invisibly. With the project-local `.zerostack/config.toml` override (#208) this is worse: a typo'd key merges over nothing and *looks* like it applied.

## Change

After parsing, the loader compares the file's top-level keys against the keys the deserialized `Config` retains when serialized back to JSON (`unknown_keys` in `src/config/load.rs`). Because the known set comes from serialization, field renames (`enable-exa-mcp`, `permission-allow`, …) and future fields need no manual list to maintain.

Unknown keys print a startup warning:

```
warning: /path/config.toml: unknown config key 'modle' (typo, or requires a cargo feature not compiled in)
```

The "feature not compiled in" hint covers the one legitimate false-positive class: keys like `mcp_servers` in a build without the `mcp` feature.

Applied at both parse sites: the global config (TOML path and YAML/JSON path — the second pass is best-effort and never fails the load) and the `.zerostack/config.toml` override (checked against the merged config, so valid keys set only locally are not flagged).

## Tests

4 new tests: typo flagged, valid keys accepted, renamed keys accepted (mcp-gated), non-object file ignored. Smoke-tested end-to-end with `ZS_CONFIG_DIR` + a project-local override — both warnings print as shown above.

## Verification

- `cargo fmt` applied; `cargo clippy --all-targets` clean
- `cargo test`: 691 passed · `--no-default-features`: 582 passed — 0 failed
- `cargo install --path . --debug` succeeds
