### PR TITLE
feat: integrate rtk output-filtering proxy into bash tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ pdf = ["multimodal", "rig/pdf"]
 advisor = []
 hooks = []
 lsp = ["dep:lsp-types"]
+rtk = []
 
 [dependencies]
 rig = { version = "0.40", features = ["rmcp"] }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1144,6 +1144,41 @@ Behavior notes:
 - Post-edit diagnostics are capped (errors first, ~20 lines); nothing is
   appended when the file is clean.
 
+## rtk output filtering
+
+zerostack can route bash commands through [rtk](https://github.com/rtk-ai/rtk),
+an external CLI proxy that filters and compresses command output before it
+reaches the model context (e.g. tests report failures only, `git status`
+returns a compact summary). rtk claims up to 90% reduction of bash output
+tokens.
+
+When enabled, every `bash` tool command is passed through `rtk rewrite` before
+execution. rtk decides which commands have a compact equivalent — unsupported
+commands run unchanged. Permission checks always run against the original
+command, so existing permission patterns keep working. The integration is
+fail-open: if the binary is missing, times out, or errors, the original
+command runs unfiltered.
+
+### TOML
+
+```toml
+[rtk]
+enabled = true
+# path = "rtk"    # rtk binary; default resolves `rtk` via PATH
+```
+
+### YAML
+
+```yaml
+rtk:
+  enabled: true
+  path: rtk
+```
+
+When active, a short note is appended to the system prompt telling the model
+that bash output is compacted and that rtk writes full raw output to a tee log
+on failure.
+
 ## Logging
 
 zerostack uses the `tracing` framework for structured logging. By default, only

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1152,6 +1152,9 @@ reaches the model context (e.g. tests report failures only, `git status`
 returns a compact summary). rtk claims up to 90% reduction of bash output
 tokens.
 
+This integration is behind the non-default `rtk` Cargo feature — build with
+`--features rtk` to enable it.
+
 When enabled, every `bash` tool command is passed through `rtk rewrite` before
 execution. rtk decides which commands have a compact equivalent — unsupported
 commands run unchanged. Permission checks always run against the original

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -191,11 +191,20 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         })
     };
 
+    let rtk = if cli.resolve_no_tools(cfg) {
+        None
+    } else {
+        crate::extras::rtk::Rtk::detect(cfg.resolve_rtk()).await
+    };
+
     #[cfg_attr(not(feature = "lsp"), allow(unused_mut))]
     let mut preamble = build_preamble(context, reasoning_enabled);
     #[cfg(feature = "lsp")]
     if lsp_manager.is_some() {
         preamble.push_str(crate::agent::prompt::LSP_PROMPT);
+    }
+    if rtk.is_some() {
+        preamble.push_str(crate::agent::prompt::RTK_PROMPT);
     }
 
     let mut builder = AgentBuilder::new(model).preamble(&preamble);
@@ -244,6 +253,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 sandbox.clone(),
                 max_bash_output_lines,
+                rtk,
             )),
             Box::new(tools::GrepTool::new(
                 permission.clone(),

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -191,18 +191,20 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         })
     };
 
+    #[cfg(feature = "rtk")]
     let rtk = if cli.resolve_no_tools(cfg) {
         None
     } else {
         crate::extras::rtk::Rtk::detect(cfg.resolve_rtk()).await
     };
 
-    #[cfg_attr(not(feature = "lsp"), allow(unused_mut))]
+    #[cfg_attr(not(any(feature = "lsp", feature = "rtk")), allow(unused_mut))]
     let mut preamble = build_preamble(context, reasoning_enabled);
     #[cfg(feature = "lsp")]
     if lsp_manager.is_some() {
         preamble.push_str(crate::agent::prompt::LSP_PROMPT);
     }
+    #[cfg(feature = "rtk")]
     if rtk.is_some() {
         preamble.push_str(crate::agent::prompt::RTK_PROMPT);
     }
@@ -253,6 +255,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 sandbox.clone(),
                 max_bash_output_lines,
+                #[cfg(feature = "rtk")]
                 rtk,
             )),
             Box::new(tools::GrepTool::new(

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -50,6 +50,18 @@ to run a manual typecheck just to confirm. Use the lsp_diagnostics tool to \
 query a file before editing it, or to list diagnostics across the project. \
 Files with no server configured simply return no diagnostics.";
 
+/// Appended to the preamble when the rtk output-filtering proxy is active
+/// (`[rtk] enabled = true` and the binary detected). Tells the model why bash
+/// output looks compact and where the full output goes on failure.
+pub const RTK_PROMPT: &str = "\n\n## rtk output filtering\n\
+Bash commands are automatically rewritten through rtk, an output-filtering proxy: \
+supported commands (git, cargo, test runners, ls, grep, ...) return compact output \
+— e.g. tests report failures only, git operations a one-line confirmation. \
+Trust the compact output; do not re-run a command just because it looks short. \
+On failure rtk may print the path to a tee log with the full raw output — read \
+that file when you need the details. Never prefix commands with `rtk` yourself; \
+rewriting is automatic.";
+
 pub const COMPACTION_PROMPT: &str = "\
 You are a conversation summarizer for a coding session. Distill the following conversation into a concise summary.
 

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -53,6 +53,7 @@ Files with no server configured simply return no diagnostics.";
 /// Appended to the preamble when the rtk output-filtering proxy is active
 /// (`[rtk] enabled = true` and the binary detected). Tells the model why bash
 /// output looks compact and where the full output goes on failure.
+#[cfg(feature = "rtk")]
 pub const RTK_PROMPT: &str = "\n\n## rtk output filtering\n\
 Bash commands are automatically rewritten through rtk, an output-filtering proxy: \
 supported commands (git, cargo, test runners, ls, grep, ...) return compact output \

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -2,6 +2,7 @@ use rig::tool::Tool;
 use tokio::time::{Duration, timeout};
 
 use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm};
+use crate::extras::rtk::Rtk;
 use crate::extras::truncate::head_lines;
 use crate::sandbox::Sandbox;
 
@@ -83,6 +84,9 @@ pub struct BashTool {
     /// `None` = no truncation (matches the historical behaviour). `Some(n)`
     /// = head-only truncation after `n` lines with a recovery hint.
     pub max_output_lines: Option<u64>,
+    /// When `Some`, commands are rewritten through `rtk rewrite` before
+    /// execution so supported commands return compact output.
+    pub rtk: Option<Rtk>,
 }
 
 impl BashTool {
@@ -91,12 +95,14 @@ impl BashTool {
         ask_tx: Option<AskSender>,
         sandbox: Sandbox,
         max_output_lines: Option<u64>,
+        rtk: Option<Rtk>,
     ) -> Self {
         BashTool {
             permission,
             ask_tx,
             sandbox,
             max_output_lines,
+            rtk,
         }
     }
 }
@@ -139,10 +145,24 @@ impl Tool for BashTool {
             }
         }
 
+        // Permissions were checked against the original command; rtk only
+        // wraps it in `rtk ...` calls, so the rewritten form needs no
+        // re-check. Fail-open: any rewrite problem runs the original.
+        let command = match &self.rtk {
+            Some(rtk) => match rtk.rewrite(&args.command).await {
+                Some(rewritten) if rewritten != args.command => {
+                    tracing::debug!("rtk rewrite: {:?} -> {:?}", args.command, rewritten);
+                    rewritten
+                }
+                _ => args.command.clone(),
+            },
+            None => args.command.clone(),
+        };
+
         let output = if let Some(secs) = args.timeout {
             match timeout(
                 Duration::from_millis(secs),
-                self.sandbox.output_command(&args.command),
+                self.sandbox.output_command(&command),
             )
             .await
             {
@@ -154,7 +174,7 @@ impl Tool for BashTool {
                 }
             }
         } else {
-            self.sandbox.output_command(&args.command).await
+            self.sandbox.output_command(&command).await
         }?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -2,6 +2,7 @@ use rig::tool::Tool;
 use tokio::time::{Duration, timeout};
 
 use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm};
+#[cfg(feature = "rtk")]
 use crate::extras::rtk::Rtk;
 use crate::extras::truncate::head_lines;
 use crate::sandbox::Sandbox;
@@ -86,6 +87,7 @@ pub struct BashTool {
     pub max_output_lines: Option<u64>,
     /// When `Some`, commands are rewritten through `rtk rewrite` before
     /// execution so supported commands return compact output.
+    #[cfg(feature = "rtk")]
     pub rtk: Option<Rtk>,
 }
 
@@ -95,13 +97,14 @@ impl BashTool {
         ask_tx: Option<AskSender>,
         sandbox: Sandbox,
         max_output_lines: Option<u64>,
-        rtk: Option<Rtk>,
+        #[cfg(feature = "rtk")] rtk: Option<Rtk>,
     ) -> Self {
         BashTool {
             permission,
             ask_tx,
             sandbox,
             max_output_lines,
+            #[cfg(feature = "rtk")]
             rtk,
         }
     }
@@ -148,6 +151,7 @@ impl Tool for BashTool {
         // Permissions were checked against the original command; rtk only
         // wraps it in `rtk ...` calls, so the rewritten form needs no
         // re-check. Fail-open: any rewrite problem runs the original.
+        #[cfg(feature = "rtk")]
         let command = match &self.rtk {
             Some(rtk) => match rtk.rewrite(&args.command).await {
                 Some(rewritten) if rewritten != args.command => {
@@ -158,6 +162,8 @@ impl Tool for BashTool {
             },
             None => args.command.clone(),
         };
+        #[cfg(not(feature = "rtk"))]
+        let command = args.command.clone();
 
         let output = if let Some(secs) = args.timeout {
             match timeout(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -208,6 +208,8 @@ pub struct Config {
     #[cfg(feature = "lsp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lsp: Option<types::LspConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtk: Option<types::RtkConfig>,
     #[cfg(feature = "advisor")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub advisor: Option<types::AdvisorConfig>,
@@ -388,6 +390,12 @@ impl Config {
     #[cfg(feature = "lsp")]
     pub fn resolve_lsp(&self) -> Option<&types::LspConfig> {
         self.lsp.as_ref().filter(|l| l.enabled)
+    }
+
+    /// rtk output-filtering configuration, `Some` only when an `[rtk]` table
+    /// exists with `enabled = true`.
+    pub fn resolve_rtk(&self) -> Option<&types::RtkConfig> {
+        self.rtk.as_ref().filter(|r| r.enabled)
     }
 
     pub fn resolve_max_grep_results(&self) -> u64 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -208,6 +208,7 @@ pub struct Config {
     #[cfg(feature = "lsp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lsp: Option<types::LspConfig>,
+    #[cfg(feature = "rtk")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtk: Option<types::RtkConfig>,
     #[cfg(feature = "advisor")]
@@ -394,6 +395,7 @@ impl Config {
 
     /// rtk output-filtering configuration, `Some` only when an `[rtk]` table
     /// exists with `enabled = true`.
+    #[cfg(feature = "rtk")]
     pub fn resolve_rtk(&self) -> Option<&types::RtkConfig> {
         self.rtk.as_ref().filter(|r| r.enabled)
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -201,6 +201,7 @@ pub struct LspServerConfig {
 /// Configuration for the rtk (https://github.com/rtk-ai/rtk) output-filtering
 /// proxy. When enabled, bash commands are passed through `rtk rewrite` before
 /// execution so supported commands return compact output.
+#[cfg(feature = "rtk")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RtkConfig {
@@ -209,6 +210,7 @@ pub struct RtkConfig {
     pub path: Option<CompactString>,
 }
 
+#[cfg(feature = "rtk")]
 impl Default for RtkConfig {
     fn default() -> Self {
         Self {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -202,22 +202,12 @@ pub struct LspServerConfig {
 /// proxy. When enabled, bash commands are passed through `rtk rewrite` before
 /// execution so supported commands return compact output.
 #[cfg(feature = "rtk")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RtkConfig {
     pub enabled: bool,
     /// Path to the rtk binary. Defaults to `rtk` (resolved via PATH).
     pub path: Option<CompactString>,
-}
-
-#[cfg(feature = "rtk")]
-impl Default for RtkConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            path: None,
-        }
-    }
 }
 
 #[cfg(feature = "advisor")]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -198,6 +198,26 @@ pub struct LspServerConfig {
     pub disabled: bool,
 }
 
+/// Configuration for the rtk (https://github.com/rtk-ai/rtk) output-filtering
+/// proxy. When enabled, bash commands are passed through `rtk rewrite` before
+/// execution so supported commands return compact output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RtkConfig {
+    pub enabled: bool,
+    /// Path to the rtk binary. Defaults to `rtk` (resolved via PATH).
+    pub path: Option<CompactString>,
+}
+
+impl Default for RtkConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: None,
+        }
+    }
+}
+
 #[cfg(feature = "advisor")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -37,6 +37,7 @@ pub mod status_signals;
 #[cfg(feature = "lsp")]
 pub mod lsp;
 
+#[cfg(feature = "rtk")]
 pub mod rtk;
 
 pub(crate) mod truncate;

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -37,4 +37,6 @@ pub mod status_signals;
 #[cfg(feature = "lsp")]
 pub mod lsp;
 
+pub mod rtk;
+
 pub(crate) mod truncate;

--- a/src/extras/rtk.rs
+++ b/src/extras/rtk.rs
@@ -1,0 +1,76 @@
+//! Integration with rtk (https://github.com/rtk-ai/rtk), an external CLI proxy
+//! that filters and compresses shell command output before it reaches the LLM
+//! context.
+//!
+//! When enabled via `[rtk] enabled = true`, bash commands are passed through
+//! `rtk rewrite <cmd>` before execution. rtk is the single source of truth for
+//! which commands have a compact equivalent: it prints the rewritten command
+//! on stdout (exit code 0 or 3 depending on version), or nothing (exit code 1)
+//! when the command has no rtk filter. Everything here is fail-open — any
+//! error (binary missing, timeout, empty output) runs the original command
+//! unchanged.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use crate::config::types::RtkConfig;
+
+/// rtk advertises <10ms overhead; this bound only guards against a hung
+/// binary. On expiry the original command runs unfiltered.
+const RTK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A detected, working rtk binary. Construct via [`Rtk::detect`].
+#[derive(Debug, Clone)]
+pub struct Rtk {
+    path: String,
+}
+
+impl Rtk {
+    /// Returns `Some` when rtk is enabled in config and the binary responds to
+    /// `<path> --version`. Logs a warning and returns `None` when the binary
+    /// is enabled but unusable, so misconfiguration never blocks the agent.
+    pub async fn detect(cfg: Option<&RtkConfig>) -> Option<Self> {
+        let cfg = cfg.filter(|c| c.enabled)?;
+        let path = cfg.path.as_deref().unwrap_or("rtk").to_string();
+        let probe = tokio::process::Command::new(&path)
+            .arg("--version")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        match tokio::time::timeout(RTK_TIMEOUT, probe).await {
+            Ok(Ok(status)) if status.success() => {
+                tracing::info!("rtk output filtering enabled (binary: {})", path);
+                Some(Self { path })
+            }
+            _ => {
+                tracing::warn!(
+                    "rtk.enabled is set but '{}' is not a working rtk binary; \
+                     commands will run unfiltered",
+                    path
+                );
+                None
+            }
+        }
+    }
+
+    /// Rewrites `command` via `rtk rewrite`. Returns `None` — meaning "run the
+    /// original" — when rtk has no filter for the command or anything fails.
+    /// The rewritten form only ever wraps the command in `rtk ...` calls, so
+    /// permission checking stays on the original command text.
+    pub async fn rewrite(&self, command: &str) -> Option<String> {
+        let child = tokio::process::Command::new(&self.path)
+            .arg("rewrite")
+            .arg(command)
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output();
+        let output = tokio::time::timeout(RTK_TIMEOUT, child).await.ok()?.ok()?;
+        let rewritten = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if rewritten.is_empty() {
+            None
+        } else {
+            Some(rewritten)
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -70,6 +70,8 @@ mod provider_tests;
 mod renderer_tests;
 #[cfg(test)]
 mod resumed_history_tests;
+#[cfg(test)]
+mod rtk_tests;
 #[cfg(all(test, feature = "export"))]
 mod session_export_tests;
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -70,7 +70,7 @@ mod provider_tests;
 mod renderer_tests;
 #[cfg(test)]
 mod resumed_history_tests;
-#[cfg(test)]
+#[cfg(all(test, feature = "rtk"))]
 mod rtk_tests;
 #[cfg(all(test, feature = "export"))]
 mod session_export_tests;

--- a/src/tests/rtk_tests.rs
+++ b/src/tests/rtk_tests.rs
@@ -1,0 +1,77 @@
+use crate::config::types::RtkConfig;
+use crate::extras::rtk::Rtk;
+
+/// Writes a fake `rtk` binary that mimics the real contract:
+/// `--version` exits 0; `rewrite` prints `rtk <cmd>` (exit 3) for commands
+/// starting with an allowed prefix, otherwise exits 1 with no output.
+fn fake_rtk(dir: &std::path::Path) -> String {
+    let path = dir.join("rtk-fake");
+    std::fs::write(
+        &path,
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then echo 'rtk 0.0.0-fake'; exit 0; fi\n\
+         if [ \"$1\" = \"rewrite\" ]; then\n\
+         case \"$2\" in git*|cargo*) echo \"rtk $2\"; exit 3;; *) exit 1;; esac\n\
+         fi\n\
+         exit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path.to_string_lossy().into_owned()
+}
+
+fn cfg(enabled: bool, path: Option<String>) -> RtkConfig {
+    RtkConfig {
+        enabled,
+        path: path.map(Into::into),
+    }
+}
+
+#[tokio::test]
+async fn detect_disabled_returns_none() {
+    assert!(Rtk::detect(None).await.is_none());
+    assert!(Rtk::detect(Some(&cfg(false, None))).await.is_none());
+}
+
+#[tokio::test]
+async fn detect_bogus_binary_returns_none() {
+    let c = cfg(true, Some("/definitely/not/a/real/rtk".into()));
+    assert!(Rtk::detect(Some(&c)).await.is_none());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn detect_and_rewrite_with_working_binary() {
+    let dir = std::env::temp_dir().join(format!("zs_rtk_test_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = fake_rtk(&dir);
+
+    let rtk = Rtk::detect(Some(&cfg(true, Some(path)))).await;
+    assert!(rtk.is_some());
+    let rtk = rtk.unwrap();
+
+    // Supported command: rewritten (fake exits 3 — stdout is what matters).
+    assert_eq!(
+        rtk.rewrite("git status").await.as_deref(),
+        Some("rtk git status")
+    );
+    // Unsupported command: no rewrite, caller keeps the original.
+    assert_eq!(rtk.rewrite("echo hello").await, None);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn resolve_rtk_filters_disabled() {
+    use crate::config::Config;
+    let mut c = Config::default();
+    assert!(c.resolve_rtk().is_none());
+    c.rtk = Some(cfg(false, None));
+    assert!(c.resolve_rtk().is_none());
+    c.rtk = Some(cfg(true, None));
+    assert!(c.resolve_rtk().is_some());
+}


### PR DESCRIPTION
## Summary

Integrates [rtk](https://github.com/rtk-ai/rtk), an external CLI proxy that filters and compresses shell command output (up to 90% of bash-output tokens), behind a non-default `rtk` Cargo feature (build with `--features rtk`), enabled via config:

```toml
[rtk]
enabled = true
# path = "rtk"   # optional; defaults to rtk on PATH
```

When enabled, every `bash` tool command is passed through `rtk rewrite` before execution. rtk stays the single source of truth for which commands have a compact equivalent — unsupported commands run unchanged, and new rtk filters are picked up automatically on rtk upgrades.

## Design

- **Feature-gated**: everything (config types, bash wiring, prompt, tests) is `cfg(feature = "rtk")`, following the `advisor`/`hooks` precedent. Default builds are completely unchanged.
- **`src/extras/rtk.rs`** (new): `Rtk::detect()` probes the binary once at agent build (`--version`, 5s bound); `Rtk::rewrite()` calls `rtk rewrite <cmd>` per bash call. Fully fail-open: missing binary, timeout, or empty output all run the original command unchanged, so misconfiguration can never break the agent.
- **`src/agent/tools/bash.rs`**: rewrite happens *after* permission checks, which keep running against the original command text — existing permission patterns are unaffected.
- **`src/agent/builder.rs`**: wired into `build_agent_inner`, so subagents get it too (all agents funnel through it). When active, `RTK_PROMPT` is appended to the preamble telling the model output is compacted and where rtk's tee logs (full raw output on failure) live.
- **`src/config`**: `[rtk]` table (`enabled`, `path`) following the `AdvisorConfig` precedent.
- **Docs**: new "rtk output filtering" section in `docs/CONFIG.md`.

## Testing

- 4 new tests in `src/tests/rtk_tests.rs` using a fake rtk binary mimicking the real `rtk rewrite` contract (including rtk 0.43's exit-code-3-on-rewrite quirk); full suite passes 691/691.
- End-to-end verified with `zerostack -p` in a test repo: a `git status` bash call returns rtk's compact format instead of full git output.
