### PR TITLE
feat: LSP integration with diagnostics feedback to the agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4873,6 +4882,19 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
 
 [[package]]
 name = "lz4"
@@ -8732,6 +8754,7 @@ dependencies = [
  "http 1.4.2",
  "ignore",
  "include_dir",
+ "lsp-types",
  "mimalloc",
  "pulldown-cmark",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ multimodal = ["rig/image"]
 pdf = ["multimodal", "rig/pdf"]   
 advisor = []
 hooks = []
+lsp = ["dep:lsp-types"]
 
 [dependencies]
 rig = { version = "0.40", features = ["rmcp"] }
@@ -73,6 +74,7 @@ include_dir = "0.7"
 http = "1"
 agent-client-protocol = { version = "1.0.1", optional = true }
 blocking = { version = "1", optional = true }
+lsp-types = { version = "0.97", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 
 [dev-dependencies]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1084,6 +1084,62 @@ The `/advisor` slash command provides runtime control:
 /advisor context-limit <n>  Set max kilobytes of conversation context
 ```
 
+## LSP
+
+zerostack can run language servers for the files the agent edits and feed
+diagnostics (errors/warnings) back into `edit`/`write` tool results — the
+agent sees type errors immediately instead of discovering them on the next
+build. An `lsp_diagnostics` tool also lets the agent query one file or the
+whole project on demand.
+
+This integration is behind the non-default `lsp` Cargo feature — build with
+`--features lsp` to enable it.
+
+### TOML
+
+```toml
+[lsp]
+enabled = true
+
+[lsp.servers.rust]          # override a built-in default
+command = "rust-analyzer"
+extensions = [".rs"]
+
+[lsp.servers.myserver]      # fully custom server
+command = "my-ls"
+args = ["--stdio"]
+extensions = [".my"]
+# env = { RUST_LOG = "debug" }
+# initialization = { ... }   # server-specific initializationOptions
+# disabled = false           # true removes a same-named built-in
+```
+
+### YAML
+
+```yaml
+lsp:
+  enabled: true
+  servers:
+    rust:
+      command: rust-analyzer
+      extensions: [".rs"]
+```
+
+Built-in server defaults (used only when the binary is on PATH):
+rust-analyzer, gopls, typescript-language-server, pyright-langserver,
+clangd, bash-language-server, lua-language-server.
+
+Behavior notes:
+
+- Servers are **PATH binaries only** — zerostack never auto-installs a
+  language server. A missing binary is skipped with a debug log.
+- Servers start lazily on the first edit touching one of their extensions
+  (workspace root = session cwd) and stop when zerostack exits.
+- Everything is fail-open: a hung or crashed server only means "no
+  diagnostics", never a failed edit.
+- Post-edit diagnostics are capped (errors first, ~20 lines); nothing is
+  appended when the file is clean.
+
 ## Logging
 
 zerostack uses the `tracing` framework for structured logging. By default, only

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -182,7 +182,21 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     additional_params: Option<serde_json::Value>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
 ) -> Agent<M> {
-    let preamble = build_preamble(context, reasoning_enabled);
+    #[cfg(feature = "lsp")]
+    let lsp_manager = if cli.resolve_no_tools(cfg) {
+        None
+    } else {
+        cfg.resolve_lsp().map(|c| {
+            crate::extras::lsp::LspManager::new(c, std::env::current_dir().unwrap_or_default())
+        })
+    };
+
+    #[cfg_attr(not(feature = "lsp"), allow(unused_mut))]
+    let mut preamble = build_preamble(context, reasoning_enabled);
+    #[cfg(feature = "lsp")]
+    if lsp_manager.is_some() {
+        preamble.push_str(crate::agent::prompt::LSP_PROMPT);
+    }
 
     let mut builder = AgentBuilder::new(model).preamble(&preamble);
 
@@ -209,6 +223,13 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         let max_grep_results = cfg.resolve_max_grep_results();
         let max_find_results = cfg.resolve_max_find_results();
         let max_list_dir_entries = cfg.resolve_max_list_dir_entries();
+        let write_tool =
+            tools::WriteTool::new(permission.clone(), ask_tx.clone(), max_text_file_size);
+        #[cfg(feature = "lsp")]
+        let write_tool = write_tool.with_lsp(lsp_manager.clone());
+        let edit_tool = tools::EditTool::new(permission.clone(), ask_tx.clone());
+        #[cfg(feature = "lsp")]
+        let edit_tool = edit_tool.with_lsp(lsp_manager.clone());
         let base_tools: SmallVec<[Box<dyn rig::tool::ToolDyn>; 8]> = SmallVec::from_buf([
             Box::new(tools::ReadTool::new(
                 permission.clone(),
@@ -216,12 +237,8 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 max_text_file_size,
                 max_read_lines,
             )),
-            Box::new(tools::WriteTool::new(
-                permission.clone(),
-                ask_tx.clone(),
-                max_text_file_size,
-            )),
-            Box::new(tools::EditTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(write_tool),
+            Box::new(edit_tool),
             Box::new(tools::BashTool::new(
                 permission.clone(),
                 ask_tx.clone(),
@@ -254,7 +271,8 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 feature = "subagents",
                 feature = "memory",
                 feature = "mcp",
-                feature = "advisor"
+                feature = "advisor",
+                feature = "lsp"
             )),
             allow(unused_mut)
         )]
@@ -307,6 +325,11 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         if crate::extras::advisor::with_config(|c| c.enabled) {
             use crate::extras::advisor::AdvisorTool;
             all_tools.push(Box::new(AdvisorTool::new()));
+        }
+
+        #[cfg(feature = "lsp")]
+        if let Some(lsp) = &lsp_manager {
+            all_tools.push(Box::new(tools::lsp::LspTool::new(lsp.clone())));
         }
 
         let all_tools = filter_tools_by_allowlist(all_tools, &cli.tools);

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -38,6 +38,18 @@ You are an expert coding assistant. Read, write, edit files and run commands. Re
 
 pub const TODO_TOOLS_PROMPT: &str = "";
 
+/// Appended to the preamble when LSP integration is active (`[lsp]
+/// enabled = true`). Tells the model that diagnostics arrive automatically
+/// after edits and that it can query them on demand.
+#[cfg(feature = "lsp")]
+pub const LSP_PROMPT: &str = "\n\n## LSP diagnostics\n\
+Language servers are running for this project: after every successful edit or \
+write, fresh diagnostics (errors/warnings) are appended to the tool result \
+automatically. Trust them and fix what they report before moving on — no need \
+to run a manual typecheck just to confirm. Use the lsp_diagnostics tool to \
+query a file before editing it, or to list diagnostics across the project. \
+Files with no server configured simply return no diagnostics.";
+
 pub const COMPACTION_PROMPT: &str = "\
 You are a conversation summarizer for a coding session. Distill the following conversation into a concise summary.
 

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -6,15 +6,32 @@ use crate::agent::tools::{
     levenshtein_similarity, normalize_whitespace,
 };
 use crate::config::types::EditSystem;
+#[cfg(feature = "lsp")]
+use crate::extras::lsp::LspManager;
 
 pub struct EditTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    /// When `Some`, edited files are synced to their language server and
+    /// fresh diagnostics are appended to the tool result.
+    #[cfg(feature = "lsp")]
+    pub lsp: Option<LspManager>,
 }
 
 impl EditTool {
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        EditTool { permission, ask_tx }
+        EditTool {
+            permission,
+            ask_tx,
+            #[cfg(feature = "lsp")]
+            lsp: None,
+        }
+    }
+
+    #[cfg(feature = "lsp")]
+    pub fn with_lsp(mut self, lsp: Option<LspManager>) -> Self {
+        self.lsp = lsp;
+        self
     }
 }
 
@@ -605,6 +622,15 @@ impl Tool for EditTool {
         }
         if let Some(msg) = coaching {
             result = format!("{}\n\n{}", msg, result);
+        }
+
+        #[cfg(feature = "lsp")]
+        if let Some(lsp) = &self.lsp {
+            let file = std::path::Path::new(&path);
+            lsp.notify_changed(file).await;
+            if let Some(block) = lsp.diagnostics_block_for_edit(file).await {
+                result.push_str(&block);
+            }
         }
 
         Ok(result)

--- a/src/agent/tools/lsp.rs
+++ b/src/agent/tools/lsp.rs
@@ -1,0 +1,78 @@
+//! `lsp_diagnostics` agent tool: on-demand language-server diagnostics.
+//! Post-edit diagnostics are appended to edit/write results automatically;
+//! this tool is for querying a file before editing it, or surveying the
+//! whole project.
+
+use std::path::Path;
+use std::time::Duration;
+
+use rig::tool::Tool;
+use serde::Deserialize;
+
+use crate::agent::tools::ToolError;
+use crate::extras::lsp::LspManager;
+
+/// Longer than the post-edit wait: an explicit query justifies giving the
+/// server more time to catch up.
+const QUERY_WAIT: Duration = Duration::from_secs(3);
+
+pub struct LspTool {
+    pub manager: LspManager,
+}
+
+#[derive(Deserialize)]
+pub struct LspArgs {
+    /// File to inspect. Omit to list diagnostics for every file.
+    pub path: Option<String>,
+}
+
+impl LspTool {
+    pub fn new(manager: LspManager) -> Self {
+        Self { manager }
+    }
+}
+
+impl Tool for LspTool {
+    const NAME: &'static str = "lsp_diagnostics";
+
+    type Error = ToolError;
+    type Args = LspArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        "Get language-server diagnostics (errors/warnings). With `path`: diagnostics for that file, synced from disk first. Without: every file that currently has diagnostics.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "File to inspect (optional; omit for all files)" }
+            }
+        })
+    }
+
+    async fn call(&self, args: LspArgs) -> Result<String, ToolError> {
+        match args.path {
+            Some(path) => {
+                let expanded = crate::fs::expand_tilde(&path);
+                let path = Path::new(&expanded);
+                if !path.exists() {
+                    return Err(ToolError::Msg(format!("File '{expanded}' does not exist.")));
+                }
+                self.manager.notify_changed(path).await;
+                Ok(self
+                    .manager
+                    .diagnostics_block(path, QUERY_WAIT)
+                    .await
+                    .map(|block| block.trim_start().to_string())
+                    .unwrap_or_else(|| format!("No diagnostics for {expanded}.")))
+            }
+            None => Ok(self
+                .manager
+                .all_diagnostics_block()
+                .map(|block| format!("Files with diagnostics:\n{block}"))
+                .unwrap_or_else(|| "No diagnostics.".to_string())),
+        }
+    }
+}

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod edit;
 pub(crate) mod find_files;
 pub(crate) mod grep;
 pub(crate) mod list_dir;
+#[cfg(feature = "lsp")]
+pub(crate) mod lsp;
 pub(crate) mod normalize;
 pub(crate) mod read;
 pub(crate) mod todo;

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use rig::tool::Tool;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, WriteArgs, check_perm_path};
+#[cfg(feature = "lsp")]
+use crate::extras::lsp::LspManager;
 
 const DEFAULT_MAX_TEXT_SIZE: u64 = 1024 * 1024;
 
@@ -10,6 +12,10 @@ pub struct WriteTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub max_text_file_size: u64,
+    /// When `Some`, written files are synced to their language server and
+    /// fresh diagnostics are appended to the tool result.
+    #[cfg(feature = "lsp")]
+    pub lsp: Option<LspManager>,
 }
 
 impl WriteTool {
@@ -22,7 +28,15 @@ impl WriteTool {
             permission,
             ask_tx,
             max_text_file_size: max_text_file_size.unwrap_or(DEFAULT_MAX_TEXT_SIZE),
+            #[cfg(feature = "lsp")]
+            lsp: None,
         }
+    }
+
+    #[cfg(feature = "lsp")]
+    pub fn with_lsp(mut self, lsp: Option<LspManager>) -> Self {
+        self.lsp = lsp;
+        self
     }
 }
 
@@ -88,6 +102,15 @@ impl Tool for WriteTool {
         if let Some(msg) = coaching {
             result = format!("{}\n\n{}", msg, result);
         }
+
+        #[cfg(feature = "lsp")]
+        if let Some(lsp) = &self.lsp {
+            lsp.notify_changed(path).await;
+            if let Some(block) = lsp.diagnostics_block_for_edit(path).await {
+                result.push_str(&block);
+            }
+        }
+
         Ok(result)
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -205,6 +205,9 @@ pub struct Config {
     pub colors: Option<types::ColorsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain: Option<types::ChainConfig>,
+    #[cfg(feature = "lsp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lsp: Option<types::LspConfig>,
     #[cfg(feature = "advisor")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub advisor: Option<types::AdvisorConfig>,
@@ -378,6 +381,13 @@ impl Config {
     /// "no bash output truncation" behaviour.
     pub fn resolve_max_bash_output_lines(&self) -> Option<u64> {
         self.max_bash_output_lines
+    }
+
+    /// LSP configuration, `Some` only when an `[lsp]` table exists with
+    /// `enabled = true`.
+    #[cfg(feature = "lsp")]
+    pub fn resolve_lsp(&self) -> Option<&types::LspConfig> {
+        self.lsp.as_ref().filter(|l| l.enabled)
     }
 
     pub fn resolve_max_grep_results(&self) -> u64 {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -169,6 +169,35 @@ impl Default for ChainConfig {
     }
 }
 
+/// Configuration for LSP (Language Server Protocol) integration. When
+/// enabled, language servers are spawned lazily for edited files and
+/// diagnostics are fed back to the agent after edits.
+#[cfg(feature = "lsp")]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LspConfig {
+    pub enabled: bool,
+    /// Per-server overrides or custom servers, keyed by name. An entry with
+    /// the same name as a built-in default replaces it.
+    pub servers: HashMap<String, LspServerConfig>,
+}
+
+#[cfg(feature = "lsp")]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LspServerConfig {
+    /// Server binary, resolved via PATH. Empty when the entry only disables
+    /// a built-in server.
+    pub command: CompactString,
+    pub args: Vec<CompactString>,
+    /// File extensions this server handles, e.g. [".rs"].
+    pub extensions: Vec<CompactString>,
+    pub env: HashMap<String, String>,
+    /// Server-specific `initializationOptions` sent during `initialize`.
+    pub initialization: Option<serde_json::Value>,
+    pub disabled: bool,
+}
+
 #[cfg(feature = "advisor")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/src/extras/lsp/client.rs
+++ b/src/extras/lsp/client.rs
@@ -1,0 +1,348 @@
+//! One running language server process: spawn, `initialize` handshake,
+//! full-document sync, and `publishDiagnostics` collection into the shared
+//! [`DiagStore`]. Everything is fail-open — callers get `None`/no-op on any
+//! error so a broken server never breaks an edit.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::{Notify, oneshot};
+
+use super::rpc;
+use crate::config::types::LspServerConfig;
+
+/// `file://` URI for a path, with minimal percent-encoding (anything outside
+/// RFC 3986 unreserved + `/` is hex-escaped). Relative paths resolve against
+/// the process cwd.
+pub(crate) fn file_uri(path: &Path) -> Option<String> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    let s = abs.to_str()?;
+    let mut out = String::with_capacity(s.len() + 7);
+    out.push_str("file://");
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    Some(out)
+}
+
+const INIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Diagnostics for one file, as last published by one server.
+pub struct FileDiags {
+    pub server: String,
+    /// Bumped on every `publishDiagnostics` for this file — lets callers
+    /// wait for the publish that follows their `didChange`.
+    pub version: u64,
+    pub diagnostics: Vec<lsp_types::Diagnostic>,
+}
+
+/// uri → latest diagnostics. Shared between the manager and every client's
+/// reader task.
+pub type DiagStore = Arc<Mutex<HashMap<String, FileDiags>>>;
+
+pub struct LspClient {
+    name: String,
+    child: tokio::process::Child,
+    stdin: Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>,
+    next_id: AtomicI64,
+    pending: Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>>,
+    /// uri → last synced document version.
+    open: Mutex<HashMap<String, i64>>,
+}
+
+impl LspClient {
+    /// Spawns the server and runs the `initialize` handshake. Returns `None`
+    /// (with a log) on any failure: missing binary, spawn error, init timeout.
+    pub async fn spawn(
+        name: &str,
+        cfg: &LspServerConfig,
+        root: &Path,
+        diags: DiagStore,
+        diag_notify: Arc<Notify>,
+    ) -> Option<Arc<Self>> {
+        let mut child = tokio::process::Command::new(cfg.command.as_str())
+            .args(cfg.args.iter().map(|a| a.as_str()))
+            .envs(&cfg.env)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| {
+                tracing::debug!("lsp[{name}]: cannot spawn '{}': {e}", cfg.command);
+                e
+            })
+            .ok()?;
+
+        let stdin = child.stdin.take()?;
+        let stdout = child.stdout.take()?;
+        let stderr = child.stderr.take()?;
+
+        let pending: Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let stdin = Arc::new(tokio::sync::Mutex::new(stdin));
+
+        // Reader task: routes responses to pending requests, stores
+        // diagnostics, and answers server→client requests with null so a
+        // server never hangs waiting on us.
+        {
+            let pending = pending.clone();
+            let stdin = stdin.clone();
+            let server_name = name.to_string();
+            tokio::spawn(async move {
+                let mut stdout = stdout;
+                loop {
+                    let frame = match rpc::read_frame(&mut stdout).await {
+                        Ok(Some(f)) => f,
+                        Ok(None) => break, // clean EOF: server exited
+                        Err(e) => {
+                            tracing::debug!("lsp[{server_name}]: read error: {e}");
+                            break;
+                        }
+                    };
+                    let Ok(msg) = serde_json::from_slice::<Value>(&frame) else {
+                        continue;
+                    };
+                    let method = msg.get("method").and_then(Value::as_str);
+                    let id = msg.get("id").and_then(Value::as_i64);
+                    match (method, id) {
+                        // Server→client request: reply null, we declare no
+                        // capabilities that would legitimately trigger one.
+                        (Some(_), Some(id)) => {
+                            let reply = json!({"jsonrpc": "2.0", "id": id, "result": Value::Null});
+                            let body = serde_json::to_vec(&reply).unwrap_or_default();
+                            let mut w = stdin.lock().await;
+                            let _ = rpc::write_frame(&mut *w, &body).await;
+                        }
+                        // Server→client notification.
+                        (Some(m), None) => {
+                            if m == "textDocument/publishDiagnostics"
+                                && let Some(params) = msg.get("params")
+                            {
+                                store_diagnostics(&diags, &server_name, params);
+                                diag_notify.notify_waiters();
+                            }
+                        }
+                        // Response to one of our requests.
+                        (None, Some(id)) => {
+                            if let Some(tx) = pending.lock().unwrap().remove(&id) {
+                                let _ = tx.send(msg);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                // Server died: fail every outstanding request.
+                pending.lock().unwrap().clear();
+            });
+        }
+
+        // Drain stderr into the trace log so noisy servers don't fill pipes.
+        {
+            let server_name = name.to_string();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::trace!("lsp[{server_name}] stderr: {line}");
+                }
+            });
+        }
+
+        let client = Arc::new(Self {
+            name: name.to_string(),
+            child,
+            stdin,
+            next_id: AtomicI64::new(1),
+            pending,
+            open: Mutex::new(HashMap::new()),
+        });
+
+        let root_uri = file_uri(root)
+            .ok_or_else(|| {
+                tracing::debug!("lsp[{name}]: root '{}' is not a valid uri", root.display());
+            })
+            .ok()?;
+        let init_params = json!({
+            "processId": std::process::id(),
+            "rootUri": root_uri,
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {
+                        "dynamicRegistration": false,
+                        "willSave": false,
+                        "willSaveWaitUntil": false,
+                        "didSave": false
+                    },
+                    "publishDiagnostics": {}
+                }
+            },
+            "initializationOptions": cfg.initialization.clone().unwrap_or(Value::Null),
+            "clientInfo": { "name": "zerostack", "version": env!("CARGO_PKG_VERSION") }
+        });
+        client
+            .request("initialize", init_params, INIT_TIMEOUT)
+            .await?;
+        client.notify("initialized", json!({})).await;
+        tracing::info!("lsp[{name}]: initialized (root {})", root.display());
+        Some(client)
+    }
+
+    async fn request(&self, method: &str, params: Value, timeout: Duration) -> Option<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id, tx);
+        let msg = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        let body = serde_json::to_vec(&msg).ok()?;
+        {
+            let mut w = self.stdin.lock().await;
+            rpc::write_frame(&mut *w, &body).await.ok()?;
+        }
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(resp)) => Some(resp),
+            _ => {
+                self.pending.lock().unwrap().remove(&id);
+                tracing::debug!("lsp[{}]: '{}' timed out", self.name, method);
+                None
+            }
+        }
+    }
+
+    async fn notify(&self, method: &str, params: Value) {
+        let msg = json!({"jsonrpc": "2.0", "method": method, "params": params});
+        if let Ok(body) = serde_json::to_vec(&msg) {
+            let mut w = self.stdin.lock().await;
+            let _ = rpc::write_frame(&mut *w, &body).await;
+        }
+    }
+
+    /// Syncs a file's current disk content with the server: `didOpen` on
+    /// first touch, full-content `didChange` afterwards.
+    pub async fn sync_file(&self, path: &Path) {
+        let Some(uri) = file_uri(path) else {
+            return;
+        };
+        let Ok(text) = tokio::fs::read_to_string(path).await else {
+            return; // unreadable/binary file — skip silently
+        };
+        let uri_str = uri.clone();
+        enum Sync {
+            Open,
+            Change(i64),
+        }
+        let action = {
+            let mut open = self.open.lock().unwrap();
+            match open.get_mut(&uri_str) {
+                Some(version) => {
+                    *version += 1;
+                    Sync::Change(*version)
+                }
+                None => {
+                    open.insert(uri_str, 1);
+                    Sync::Open
+                }
+            }
+        }; // lock released before any await
+        match action {
+            Sync::Open => {
+                self.notify(
+                    "textDocument/didOpen",
+                    json!({
+                        "textDocument": {
+                            "uri": uri,
+                            "languageId": language_id(path),
+                            "version": 1,
+                            "text": text
+                        }
+                    }),
+                )
+                .await;
+            }
+            Sync::Change(v) => {
+                self.notify(
+                    "textDocument/didChange",
+                    json!({
+                        "textDocument": { "uri": uri, "version": v },
+                        "contentChanges": [{ "text": text }]
+                    }),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+impl Drop for LspClient {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+fn store_diagnostics(diags: &DiagStore, server: &str, params: &Value) {
+    let Some(uri) = params.get("uri").and_then(Value::as_str) else {
+        return;
+    };
+    let diagnostics: Vec<lsp_types::Diagnostic> =
+        serde_json::from_value(params.get("diagnostics").cloned().unwrap_or(Value::Null))
+            .unwrap_or_default();
+    let mut store = diags.lock().unwrap();
+    let entry = store.entry(uri.to_string()).or_insert_with(|| FileDiags {
+        server: server.to_string(),
+        version: 0,
+        diagnostics: Vec::new(),
+    });
+    entry.version += 1;
+    entry.diagnostics = diagnostics;
+}
+
+/// LSP `languageId` for didOpen. Servers mostly infer from the extension,
+/// but a correct id avoids ambiguity on shared extensions (`.h`, `.m`).
+fn language_id(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "rs" => "rust",
+        "go" => "go",
+        "ts" | "mts" | "cts" => "typescript",
+        "tsx" => "typescriptreact",
+        "js" | "mjs" | "cjs" => "javascript",
+        "jsx" => "javascriptreact",
+        "py" | "pyi" => "python",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx" => "cpp",
+        "sh" | "bash" | "zsh" => "shellscript",
+        "lua" => "lua",
+        other => match other {
+            "java" => "java",
+            "rb" => "ruby",
+            "php" => "php",
+            "cs" => "csharp",
+            "swift" => "swift",
+            "kt" | "kts" => "kotlin",
+            "nix" => "nix",
+            "yaml" | "yml" => "yaml",
+            "json" => "json",
+            "toml" => "toml",
+            "md" => "markdown",
+            _ => "plaintext",
+        },
+    }
+}

--- a/src/extras/lsp/mod.rs
+++ b/src/extras/lsp/mod.rs
@@ -1,0 +1,235 @@
+//! LSP (Language Server Protocol) integration: spawns language servers for
+//! files the agent edits and feeds diagnostics back into tool results.
+//!
+//! Enabled via `[lsp] enabled = true` (requires the `lsp` cargo feature).
+//! Everything is fail-open: a missing server binary, a hung handshake, or a
+//! crashed server only means "no diagnostics", never a failed edit.
+
+pub(crate) mod client;
+pub(crate) mod registry;
+pub mod rpc;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use lsp_types::DiagnosticSeverity;
+use tokio::sync::Notify;
+
+use crate::config::types::LspConfig;
+use client::{DiagStore, LspClient};
+
+/// How long to wait for the `publishDiagnostics` that follows an edit before
+/// falling back to whatever is already stored. Kept short so clean edits
+/// stay fast; servers that don't republish identical diagnostics just time
+/// out and reuse the previous (identical) set.
+const DIAG_WAIT: Duration = Duration::from_millis(1000);
+
+/// Max diagnostics lines appended to a tool result.
+const MAX_DIAG_LINES: usize = 20;
+
+#[derive(Clone)]
+pub struct LspManager {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    root: PathBuf,
+    servers: Vec<(String, crate::config::types::LspServerConfig)>,
+    /// server name → client, `None` caching a failed spawn so a missing
+    /// binary isn't retried on every edit.
+    clients: tokio::sync::Mutex<HashMap<String, Option<Arc<LspClient>>>>,
+    diags: DiagStore,
+    diag_notify: Arc<Notify>,
+}
+
+impl LspManager {
+    pub fn new(cfg: &LspConfig, root: PathBuf) -> Self {
+        let servers = registry::resolve_servers(&cfg.servers);
+        tracing::debug!(
+            "lsp: {} server definitions resolved (root {})",
+            servers.len(),
+            root.display()
+        );
+        Self {
+            inner: Arc::new(Inner {
+                root,
+                servers,
+                clients: tokio::sync::Mutex::new(HashMap::new()),
+                diags: DiagStore::default(),
+                diag_notify: Arc::new(Notify::new()),
+            }),
+        }
+    }
+
+    /// Whether any configured server claims this path's extension.
+    pub fn handles(&self, path: &Path) -> bool {
+        registry::server_for_path(&self.inner.servers, path).is_some()
+    }
+
+    /// Client for the server claiming `path`, spawning it on first use.
+    /// `None` when no server matches or the spawn failed (cached).
+    async fn client_for(&self, path: &Path) -> Option<Arc<LspClient>> {
+        let (name, cfg) = registry::server_for_path(&self.inner.servers, path)?;
+        let mut clients = self.inner.clients.lock().await;
+        if let Some(cached) = clients.get(name) {
+            return cached.clone();
+        }
+        let spawned = LspClient::spawn(name, cfg, &self.inner.root, self.inner.diags.clone(), {
+            self.inner.diag_notify.clone()
+        })
+        .await;
+        clients.insert(name.clone(), spawned.clone());
+        spawned
+    }
+
+    /// Syncs a file's disk content with its language server (no-op when no
+    /// server handles the extension or the server failed to start).
+    pub async fn notify_changed(&self, path: &Path) {
+        if let Some(client) = self.client_for(path).await {
+            client.sync_file(path).await;
+        }
+    }
+
+    /// Diagnostics block for one file, formatted for appending to a tool
+    /// result. Waits up to `wait` for the publish following the last sync.
+    /// `None` when the file is clean or has no server.
+    pub async fn diagnostics_block(&self, path: &Path, wait: Duration) -> Option<String> {
+        if !self.handles(path) {
+            return None;
+        }
+        let uri = client::file_uri(path)?;
+        let v0 = self
+            .inner
+            .diags
+            .lock()
+            .unwrap()
+            .get(&uri)
+            .map(|d| d.version)
+            .unwrap_or(0);
+        let deadline = tokio::time::Instant::now() + wait;
+        loop {
+            let current = self
+                .inner
+                .diags
+                .lock()
+                .unwrap()
+                .get(&uri)
+                .map(|d| d.version)
+                .unwrap_or(0);
+            if current > v0 {
+                break;
+            }
+            if tokio::time::timeout_at(deadline, self.inner.diag_notify.notified())
+                .await
+                .is_err()
+            {
+                break; // timeout: use whatever is stored
+            }
+        }
+        let store = self.inner.diags.lock().unwrap();
+        let file = store.get(&uri)?;
+        format_file_diags(&file.server, &file.diagnostics)
+    }
+
+    /// Compact diagnostics block for one file. Errors and warnings only,
+    /// capped at [`MAX_DIAG_LINES`]. `None` when the file is clean or has no
+    /// server.
+    pub async fn diagnostics_block_for_edit(&self, path: &Path) -> Option<String> {
+        self.diagnostics_block(path, DIAG_WAIT).await
+    }
+
+    /// All files that currently have diagnostics, formatted for the
+    /// `lsp_diagnostics` tool. `None` when everything is clean.
+    pub fn all_diagnostics_block(&self) -> Option<String> {
+        let store = self.inner.diags.lock().unwrap();
+        let mut out = String::new();
+        let mut lines = 0usize;
+        let mut entries: Vec<_> = store.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (uri, file) in entries {
+            let interesting: Vec<_> = file
+                .diagnostics
+                .iter()
+                .filter(|d| d.severity <= Some(DiagnosticSeverity::WARNING))
+                .collect();
+            if interesting.is_empty() {
+                continue;
+            }
+            let display = uri
+                .strip_prefix("file://")
+                .and_then(|p| p.strip_prefix(self.inner.root.to_str()?))
+                .map(|p| p.trim_start_matches('/').to_string())
+                .unwrap_or_else(|| uri.clone());
+            for d in interesting {
+                if lines >= MAX_DIAG_LINES {
+                    out.push_str("  … (truncated)\n");
+                    return Some(out);
+                }
+                out.push_str(&format_diag_line(&display, d));
+                lines += 1;
+            }
+        }
+        if out.is_empty() { None } else { Some(out) }
+    }
+
+    /// Test hook: inject diagnostics as if a server had published them.
+    #[cfg(test)]
+    pub(crate) fn inject_diagnostics(
+        &self,
+        uri: &str,
+        server: &str,
+        diagnostics: Vec<lsp_types::Diagnostic>,
+    ) {
+        self.inner.diags.lock().unwrap().insert(
+            uri.to_string(),
+            client::FileDiags {
+                server: server.to_string(),
+                version: 1,
+                diagnostics,
+            },
+        );
+    }
+}
+
+/// "LSP diagnostics (server):" header + one line per error/warning, capped.
+/// `None` when there is nothing worth reporting (clean edits stay silent).
+fn format_file_diags(server: &str, diags: &[lsp_types::Diagnostic]) -> Option<String> {
+    let mut sorted: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity <= Some(DiagnosticSeverity::WARNING))
+        .collect();
+    if sorted.is_empty() {
+        return None;
+    }
+    sorted.sort_by_key(|d| d.severity);
+    let mut out = format!("\n\nLSP diagnostics ({server}):");
+    for (i, d) in sorted.iter().enumerate() {
+        if i >= MAX_DIAG_LINES {
+            out.push_str("\n  … (truncated)");
+            break;
+        }
+        out.push_str(&format_diag_line("", d));
+    }
+    Some(out)
+}
+
+fn format_diag_line(location_prefix: &str, d: &lsp_types::Diagnostic) -> String {
+    let severity = match d.severity {
+        Some(DiagnosticSeverity::ERROR) => "error",
+        Some(DiagnosticSeverity::WARNING) => "warning",
+        Some(DiagnosticSeverity::INFORMATION) => "info",
+        _ => "hint",
+    };
+    let line = d.range.start.line + 1;
+    let col = d.range.start.character + 1;
+    let message = d.message.lines().next().unwrap_or_default();
+    let message = message.chars().take(200).collect::<String>();
+    let where_ = if location_prefix.is_empty() {
+        format!("{line}:{col}")
+    } else {
+        format!("{location_prefix}:{line}:{col}")
+    };
+    format!("\n  {where_} {severity}: {message}")
+}

--- a/src/extras/lsp/registry.rs
+++ b/src/extras/lsp/registry.rs
@@ -1,0 +1,89 @@
+//! Built-in language-server defaults and resolution against user
+//! `[lsp.servers]` config. Servers are PATH binaries only — zerostack never
+//! auto-installs anything; a missing binary is skipped at spawn time.
+
+use std::collections::HashMap;
+
+use compact_str::CompactString;
+
+use crate::config::types::LspServerConfig;
+
+fn server(command: &str, args: &[&str], extensions: &[&str]) -> LspServerConfig {
+    LspServerConfig {
+        command: CompactString::from(command),
+        args: args.iter().map(|s| CompactString::from(*s)).collect(),
+        extensions: extensions.iter().map(|s| CompactString::from(*s)).collect(),
+        env: HashMap::new(),
+        initialization: None,
+        disabled: false,
+    }
+}
+
+/// Defaults applied when `[lsp]` is enabled. Each is used only if its binary
+/// is found on PATH at spawn time.
+pub fn builtin_servers() -> Vec<(&'static str, LspServerConfig)> {
+    vec![
+        ("rust", server("rust-analyzer", &[], &[".rs"])),
+        ("go", server("gopls", &[], &[".go"])),
+        (
+            "typescript",
+            server(
+                "typescript-language-server",
+                &["--stdio"],
+                &[".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+            ),
+        ),
+        (
+            "python",
+            server("pyright-langserver", &["--stdio"], &[".py", ".pyi"]),
+        ),
+        (
+            "clangd",
+            server(
+                "clangd",
+                &[],
+                &[".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"],
+            ),
+        ),
+        (
+            "bash",
+            server(
+                "bash-language-server",
+                &["start"],
+                &[".sh", ".bash", ".zsh"],
+            ),
+        ),
+        ("lua", server("lua-language-server", &[], &[".lua"])),
+    ]
+}
+
+/// Merges user config over the built-ins: a same-named entry replaces the
+/// built-in, `disabled = true` removes it, new names add custom servers.
+/// Entries without a command are dropped (they can only ever disable).
+pub fn resolve_servers(user: &HashMap<String, LspServerConfig>) -> Vec<(String, LspServerConfig)> {
+    let mut servers: HashMap<String, LspServerConfig> = builtin_servers()
+        .into_iter()
+        .map(|(name, cfg)| (name.to_string(), cfg))
+        .collect();
+    for (name, cfg) in user {
+        if cfg.disabled || cfg.command.is_empty() {
+            servers.remove(name);
+        } else {
+            servers.insert(name.clone(), cfg.clone());
+        }
+    }
+    servers.into_iter().collect()
+}
+
+/// First server claiming this path's extension (case-insensitive, dot
+/// included in configured extensions).
+pub fn server_for_path<'a>(
+    servers: &'a [(String, LspServerConfig)],
+    path: &std::path::Path,
+) -> Option<&'a (String, LspServerConfig)> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    let dot_ext = format!(".{ext}");
+    servers
+        .iter()
+        .find(|(_, cfg)| cfg.extensions.iter().any(|e| e.as_str() == dot_ext))
+}

--- a/src/extras/lsp/rpc.rs
+++ b/src/extras/lsp/rpc.rs
@@ -1,0 +1,70 @@
+//! Minimal JSON-RPC framing for LSP: `Content-Length`-headed messages over
+//! the server's stdio. Hand-rolled to keep the dependency tree at `lsp-types`
+//! only. Unit-tested over `tokio::io::duplex` — no live server needed.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+const MAX_HEADER_BYTES: usize = 8 * 1024;
+const MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
+
+/// Writes one framed JSON-RPC message.
+pub async fn write_frame<W: AsyncWrite + Unpin>(w: &mut W, body: &[u8]) -> std::io::Result<()> {
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    w.write_all(header.as_bytes()).await?;
+    w.write_all(body).await?;
+    w.flush().await
+}
+
+/// Reads one framed JSON-RPC message. Returns `Ok(None)` on a clean EOF
+/// before any header byte (server exited); an error on EOF mid-message.
+pub async fn read_frame<R: AsyncRead + Unpin>(r: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let mut headers = Vec::with_capacity(64);
+    let mut byte = [0u8; 1];
+    loop {
+        let n = r.read(&mut byte).await?;
+        if n == 0 {
+            if headers.is_empty() {
+                return Ok(None);
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "eof inside LSP headers",
+            ));
+        }
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if headers.len() > MAX_HEADER_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "LSP header block too large",
+            ));
+        }
+    }
+
+    let headers = String::from_utf8_lossy(&headers);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("Content-Length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        })
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "missing Content-Length in LSP frame",
+            )
+        })?;
+    if content_length > MAX_BODY_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "LSP message body too large",
+        ));
+    }
+
+    let mut body = vec![0u8; content_length];
+    r.read_exact(&mut body).await?;
+    Ok(Some(body))
+}

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -34,4 +34,7 @@ pub mod multimodal;
 
 pub mod status_signals;
 
+#[cfg(feature = "lsp")]
+pub mod lsp;
+
 pub(crate) mod truncate;

--- a/src/tests/lsp_tests.rs
+++ b/src/tests/lsp_tests.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use compact_str::CompactString;
+use tokio::io::AsyncWriteExt;
+
+use crate::config::types::{LspConfig, LspServerConfig};
+use crate::extras::lsp::registry::{resolve_servers, server_for_path};
+use crate::extras::lsp::{LspManager, rpc};
+
+// ── rpc framing ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn frame_roundtrip() {
+    let (mut a, mut b) = tokio::io::duplex(4096);
+    rpc::write_frame(&mut a, br#"{"jsonrpc":"2.0","id":1}"#)
+        .await
+        .unwrap();
+    rpc::write_frame(&mut a, br#"{"jsonrpc":"2.0","id":2}"#)
+        .await
+        .unwrap();
+    assert_eq!(
+        rpc::read_frame(&mut b).await.unwrap().as_deref(),
+        Some(&br#"{"jsonrpc":"2.0","id":1}"#[..])
+    );
+    assert_eq!(
+        rpc::read_frame(&mut b).await.unwrap().as_deref(),
+        Some(&br#"{"jsonrpc":"2.0","id":2}"#[..])
+    );
+    drop(a);
+    // Clean EOF before any header byte → None (server exited).
+    assert_eq!(rpc::read_frame(&mut b).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn frame_missing_content_length_errors() {
+    let (mut a, mut b) = tokio::io::duplex(4096);
+    a.write_all(b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n{}")
+        .await
+        .unwrap();
+    assert!(rpc::read_frame(&mut b).await.is_err());
+}
+
+#[tokio::test]
+async fn frame_eof_mid_message_errors() {
+    let (mut a, mut b) = tokio::io::duplex(4096);
+    a.write_all(b"Content-Length: 100\r\n\r\n{}").await.unwrap();
+    drop(a);
+    assert!(rpc::read_frame(&mut b).await.is_err());
+}
+
+// ── registry ────────────────────────────────────────────────────────────
+
+fn custom(command: &str, extensions: &[&str]) -> LspServerConfig {
+    LspServerConfig {
+        command: CompactString::from(command),
+        extensions: extensions.iter().map(|s| CompactString::from(*s)).collect(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn builtin_matches_rust_extension() {
+    let servers = resolve_servers(&HashMap::new());
+    let (name, _) = server_for_path(&servers, Path::new("src/main.rs")).unwrap();
+    assert_eq!(name, "rust");
+    assert!(server_for_path(&servers, Path::new("readme.txt")).is_none());
+}
+
+#[test]
+fn user_override_replaces_builtin() {
+    let mut user = HashMap::new();
+    user.insert("rust".to_string(), custom("my-analyzer", &[".rs"]));
+    let servers = resolve_servers(&user);
+    let (name, cfg) = server_for_path(&servers, Path::new("main.rs")).unwrap();
+    assert_eq!(name, "rust");
+    assert_eq!(cfg.command.as_str(), "my-analyzer");
+}
+
+#[test]
+fn disabled_removes_builtin() {
+    let mut user = HashMap::new();
+    user.insert(
+        "rust".to_string(),
+        LspServerConfig {
+            disabled: true,
+            ..Default::default()
+        },
+    );
+    let servers = resolve_servers(&user);
+    assert!(server_for_path(&servers, Path::new("main.rs")).is_none());
+}
+
+#[test]
+fn custom_server_is_added() {
+    let mut user = HashMap::new();
+    user.insert("mine".to_string(), custom("my-ls", &[".my"]));
+    let servers = resolve_servers(&user);
+    let (name, _) = server_for_path(&servers, Path::new("x.my")).unwrap();
+    assert_eq!(name, "mine");
+}
+
+#[test]
+fn empty_command_is_dropped() {
+    let mut user = HashMap::new();
+    user.insert("bogus".to_string(), custom("", &[".bogus"]));
+    let servers = resolve_servers(&user);
+    assert!(server_for_path(&servers, Path::new("x.bogus")).is_none());
+}
+
+// ── config ──────────────────────────────────────────────────────────────
+
+#[test]
+fn resolve_lsp_requires_enabled() {
+    let mut cfg = crate::config::Config::default();
+    assert!(cfg.resolve_lsp().is_none());
+    cfg.lsp = Some(LspConfig::default());
+    assert!(cfg.resolve_lsp().is_none());
+    cfg.lsp = Some(LspConfig {
+        enabled: true,
+        ..Default::default()
+    });
+    assert!(cfg.resolve_lsp().is_some());
+}
+
+// ── manager formatting (no live server) ─────────────────────────────────
+
+fn diag(
+    severity: lsp_types::DiagnosticSeverity,
+    line: u32,
+    col: u32,
+    msg: &str,
+) -> lsp_types::Diagnostic {
+    lsp_types::Diagnostic {
+        range: lsp_types::Range {
+            start: lsp_types::Position {
+                line,
+                character: col,
+            },
+            end: lsp_types::Position {
+                line,
+                character: col,
+            },
+        },
+        severity: Some(severity),
+        message: msg.to_string(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn unhandled_extension_yields_nothing() {
+    let manager = LspManager::new(&LspConfig::default(), PathBuf::from("/tmp"));
+    let path = Path::new("/tmp/x.unknownext");
+    assert!(!manager.handles(path));
+    assert!(
+        manager
+            .diagnostics_block(path, Duration::from_millis(10))
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn injected_diagnostics_format_errors_first() {
+    let manager = LspManager::new(&LspConfig::default(), PathBuf::from("/tmp"));
+    let path = Path::new("/tmp/x.rs");
+    assert!(manager.handles(path));
+    manager.inject_diagnostics(
+        "file:///tmp/x.rs",
+        "rust",
+        vec![
+            diag(
+                lsp_types::DiagnosticSeverity::WARNING,
+                4,
+                2,
+                "unused variable",
+            ),
+            diag(
+                lsp_types::DiagnosticSeverity::ERROR,
+                11,
+                4,
+                "mismatched types",
+            ),
+            diag(lsp_types::DiagnosticSeverity::HINT, 0, 0, "not shown"),
+        ],
+    );
+    let block = manager
+        .diagnostics_block(path, Duration::from_millis(10))
+        .await
+        .unwrap();
+    let error_pos = block.find("12:5 error: mismatched types").unwrap();
+    let warn_pos = block.find("5:3 warning: unused variable").unwrap();
+    assert!(error_pos < warn_pos, "errors must sort first: {block}");
+    assert!(
+        !block.contains("not shown"),
+        "hints are filtered out: {block}"
+    );
+}
+
+#[test]
+fn clean_project_reports_nothing() {
+    let manager = LspManager::new(&LspConfig::default(), PathBuf::from("/tmp"));
+    assert!(manager.all_diagnostics_block().is_none());
+    manager.inject_diagnostics(
+        "file:///tmp/x.rs",
+        "rust",
+        vec![diag(lsp_types::DiagnosticSeverity::ERROR, 0, 0, "boom")],
+    );
+    let block = manager.all_diagnostics_block().unwrap();
+    assert!(block.contains("x.rs:1:1 error: boom"), "{block}");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -44,6 +44,8 @@ mod list_dir_tests;
 mod logging_tests;
 #[cfg(all(test, feature = "loop"))]
 mod loop_tests;
+#[cfg(all(test, feature = "lsp"))]
+mod lsp_tests;
 #[cfg(test)]
 mod markdown_tests;
 #[cfg(all(test, feature = "mcp"))]


### PR DESCRIPTION
Closes #222

## Summary

Adds Language Server Protocol support behind a new non-default `lsp` cargo feature, closing the biggest gap vs opencode. When enabled, language servers spawn lazily for files the agent edits, and **fresh diagnostics are appended to `edit`/`write` tool results** — the agent sees type errors immediately instead of discovering them on the next build. A new `lsp_diagnostics` tool queries one file or the whole project on demand.

```toml
[lsp]
enabled = true

[lsp.servers.myserver]   # optional custom servers / overrides
command = "my-ls"
args = ["--stdio"]
extensions = [".my"]
```

Built-in defaults (rust-analyzer, gopls, typescript-language-server, pyright, clangd, bash-language-server, lua-language-server) are used when the binary is on PATH.

## Design

- **`lsp-types` is the only new dependency** (optional). JSON-RPC framing is hand-rolled over tokio stdio (~100 lines, unit-tested over `tokio::io::duplex`) — no `tower-lsp`.
- **PATH binaries only, no auto-install** — matches zerostack's minimalistic philosophy (contrast: opencode auto-installs servers).
- **Fail-open everywhere**: missing binary, hung handshake, crashed server, or a 1s diagnostics timeout only ever means "no diagnostics", never a failed edit.
- **Full-document sync**: after each successful edit/write the file is sent via `didOpen`/`didChange`; `publishDiagnostics` notifications are collected per file. Post-edit block shows errors first, capped at 20 lines, silent when clean.
- **Lazy lifecycle**: server starts on first edit touching its extension (root = session cwd); cleanup via kill-on-drop plus server exit on stdin EOF. Mid-session agent rebuilds (`/new`, model switch) drop and kill old servers.
- Built-in server set merged with `[lsp.servers]` overrides; `disabled = true` removes one.
- `LSP_PROMPT` appended to the preamble when active so the model trusts the automatic diagnostics instead of re-running manual typechecks. Subagents inherit everything through `build_agent_inner`.

## Testing

- 12 new tests: rpc framing (round-trip, missing Content-Length, mid-message EOF), registry merge rules, config resolution, diagnostics formatting/severity ordering — no live-server dependency.
- Full suite: 687 default (unchanged), 904 with `--all-features`; `cargo clippy --all-features -- -D warnings` clean.
- **Live smoke test** with clangd: agent introduced `return "oops";` into a C file via the edit tool; `lsp_diagnostics` returned `2:12 error: Incompatible pointer to integer conversion returning 'char[5]' from a function with result type 'int'`.

## Out of scope (phase 2, noted in #222)

Navigation tools (definition/references/hover), pull diagnostics (LSP 3.17), auto-install, multi-root.