### PR TITLE
docs: SEO metadata, sitemap/robots, and working internal links on the Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,15 +28,36 @@ jobs:
       - name: Convert markdown to HTML
         run: |
           cd docs
-          for md in *.md; do
+          # Internal .md links must point at the built .html pages.
+          sed -i -e 's/\.md#/.html#/g' -e 's/\.md)/.html)/g' *.md providers/*.md
+          for md in *.md providers/*.md; do
             name="${md%.md}"
-            title="$(head -1 "$md" | sed 's/^# //')"
+            title="$(grep -m1 '^# ' "$md" | sed 's/^# //')"
             pandoc "$md" \
               --template=template.html \
+              --wrap=none \
               --metadata title="$title" \
               --metadata pagetitle="$title — zerostack" \
+              --metadata name="$(basename "$name")" \
               -o "${name}.html"
           done
+
+      - name: Generate sitemap.xml
+        run: |
+          cd docs
+          base="https://gi-dellav.github.io/zerostack"
+          today="$(date +%F)"
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            find . -name '*.html' ! -name 'template.html' | sort | while read -r html; do
+              path="${html#./}"
+              loc="$base/$path"
+              [ "$path" = "index.html" ] && loc="$base/"
+              printf '  <url><loc>%s</loc><lastmod>%s</lastmod></url>\n' "$loc" "$today"
+            done
+            echo '</urlset>'
+          } > sitemap.xml
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,7 @@
+---
+description: "How ARCHITECTURE.md files give the zerostack agent and its subagents high-level design context about your project."
+---
+
 # ARCHITECTURE.md
 
 zerostack supports an optional `ARCHITECTURE.md` file that gives both the main

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,3 +1,7 @@
+---
+description: "Complete reference of zerostack slash commands, keyboard shortcuts, and input prefixes for the terminal UI."
+---
+
 # Slash Commands
 
 All slash commands are available from the TUI input prompt.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,3 +1,7 @@
+---
+description: "Full zerostack configuration reference: config file locations, providers, permissions, hooks, MCP, themes, and every available option."
+---
+
 # Configuration
 
 zerostack reads an optional config file. It supports TOML, YAML and JSON

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -1,3 +1,7 @@
+---
+description: "Get started with zerostack: install the minimal Rust coding agent, configure an LLM provider, and run your first session."
+---
+
 # Part 1. Get Started
 
 Thanks for picking up zerostack, here you can find a easy guide on installing zerostack, setting up a model, and getting to know the basic commands.
@@ -124,7 +128,7 @@ Prompts change *how* the agent behaves. Type `.` at the start of a message to on
 | `refactor` | Restructuring existing code |
 
 This is the short list; run `/prompt` in the agent (or see the root
-[README](../README.md#prompts-system)) for the full set of built-in prompts,
+[README](https://github.com/gi-dellav/zerostack#prompts-system)) for the full set of built-in prompts,
 including `frontend-design`, `review-security`, `simplify`, `write-prompt`,
 `autoconfig`, `orchestrator`, and `write-text`.
 
@@ -169,7 +173,7 @@ Everything above ships in the default build. A few extras are compiled in
 only when you ask for them: lifecycle hooks (`--features hooks`), a
 second-model advisor (`--features advisor`), image/PDF message attachments
 (`--features multimodal,pdf`), and ACP editor integration
-(`--features acp`). See the root [README](../README.md) for what each one
+(`--features acp`). See the root [README](https://github.com/gi-dellav/zerostack) for what each one
 does and how to enable it.
 
 # Conclusions

--- a/docs/HASHEDIT.md
+++ b/docs/HASHEDIT.md
@@ -1,3 +1,7 @@
+---
+description: "HashEdit — zerostack's CRC-tagged file editing system for token-efficient, conflict-safe agent edits: algorithm specification."
+---
+
 # Hash-Anchored Edits: Algorithm Specification
 
 ## Overview

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,3 +1,7 @@
+---
+description: "Persistent markdown memory in zerostack: global notes, project scratchpads, daily logs, and the agent's memory tools."
+---
+
 # Memory System
 
 ## Overview

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,3 +1,7 @@
+---
+description: "Configure LLM providers in zerostack: OpenRouter, OpenAI-compatible endpoints, Anthropic, Gemini, Ollama, custom headers, and prompt caching."
+---
+
 # Providers
 
 zerostack supports five built-in providers and allows custom provider

--- a/docs/PUBLISHING_RELEASES.md
+++ b/docs/PUBLISHING_RELEASES.md
@@ -1,3 +1,7 @@
+---
+description: "How zerostack releases are published: crates.io, Homebrew, AUR, Conda, Nix packages, and the release workflow."
+---
+
 # Publishing Releases
 
 This guide covers the full release workflow: bumping the version, tagging, publishing to crates.io, and updating downstream package managers.

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -1,3 +1,7 @@
+---
+description: "Parallel read-only subagents in zerostack: the task tool, model and provider overrides, and per-agent tool limits."
+---
+
 # Subagents (read-only codebase exploration)
 
 ## Overview

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,33 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>zerostack — minimal coding agent</title>
+<meta name="description" content="Minimal AI coding agent for the terminal, written in Rust. Sandboxed execution, granular permissions, MCP support, session rewind — around 16 MB RAM, free and open source.">
+<link rel="canonical" href="https://gi-dellav.github.io/zerostack/">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://gi-dellav.github.io/zerostack/">
+<meta property="og:title" content="zerostack — minimal coding agent">
+<meta property="og:description" content="Minimal AI coding agent for the terminal, written in Rust. Sandboxed execution, granular permissions, MCP support, session rewind — around 16 MB RAM, free and open source.">
+<meta property="og:image" content="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="zerostack — minimal coding agent">
+<meta name="twitter:description" content="Minimal AI coding agent for the terminal, written in Rust. Sandboxed execution, granular permissions, MCP support, session rewind — around 16 MB RAM, free and open source.">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/banner.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "zerostack",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Linux, macOS",
+  "description": "Minimal AI coding agent for the terminal, written in Rust. Sandboxed execution, granular permissions, MCP support, session rewind — around 16 MB RAM, free and open source.",
+  "url": "https://gi-dellav.github.io/zerostack/",
+  "downloadUrl": "https://github.com/gi-dellav/zerostack/releases",
+  "codeRepository": "https://github.com/gi-dellav/zerostack",
+  "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "author": { "@type": "Person", "name": "Giuseppe Della Vedova" }
+}
+</script>
 <link rel="icon" href="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/logo_rounded.png" type="image/png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/providers/Minimax.md
+++ b/docs/providers/Minimax.md
@@ -1,3 +1,7 @@
+---
+description: "Use MiniMax models with zerostack through an OpenAI-compatible custom provider."
+---
+
 # MiniMax
 
 MiniMax is available in zerostack through custom provider definitions. The

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://gi-dellav.github.io/zerostack/sitemap.xml

--- a/docs/template.html
+++ b/docs/template.html
@@ -4,6 +4,19 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>$pagetitle$</title>
+$if(description)$
+<meta name="description" content="$description$">
+<meta property="og:description" content="$description$">
+<meta name="twitter:description" content="$description$">
+$endif$
+<link rel="canonical" href="https://gi-dellav.github.io/zerostack/$name$.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://gi-dellav.github.io/zerostack/$name$.html">
+<meta property="og:title" content="$pagetitle$">
+<meta property="og:image" content="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="$pagetitle$">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/banner.png">
 <link rel="icon" href="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/logo_rounded.png" type="image/png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

SEO pass over the GitHub Pages site — no content changes, no Rust code touched.

**index.html**
- Meta description, Open Graph + Twitter card tags (uses `assets/banner.png`), canonical URL
- JSON-LD `SoftwareApplication` block (name, license, repo, download URL) for rich search results

**template.html + docs/*.md**
- Every doc page now carries a `description` YAML front-matter entry, rendered by the template as meta description + OG/Twitter tags
- Canonical URL per page via a new `name` pandoc metadata variable

**pages.yml**
- **Fixes broken internal links**: docs link to each other as `.md`, which 404'd on Pages — the build now rewrites `.md` → `.html` before pandoc runs
- Also converts `docs/providers/*.md` (previously skipped, so the MiniMax page wasn't on the site)
- Generates `sitemap.xml` from the built pages; `--wrap=none` keeps meta attributes on one line
- Title extraction now uses the first `# ` heading (front matter changed line 1)

**docs/robots.txt** — allows all, points at the sitemap.

Also fixed two `../README.md` links in GET_STARTED.md to point at the GitHub repo (they 404'd on Pages).

## Verification

Replicated the workflow locally with pandoc 3.10.1: all 11 pages build, descriptions render on a single line, internal links resolve to `.html`, sitemap is well-formed with the root URL special-cased.

Note: URLs assume the default Pages domain `https://gi-dellav.github.io/zerostack/` — if a custom domain is configured later, the canonical/OG/sitemap bases should be updated (they're in three places: index.html, template.html, pages.yml).