### PR TITLE
Add startup timing instrumentation to diagnose slow launches

### DIFF
--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -25,13 +25,22 @@ impl McpClientManager {
         let mut handles = Vec::new();
         let mut notices = Vec::new();
         for (name, cfg) in configs {
+            let connect_start = std::time::Instant::now();
             match client::McpClientHandle::connect(CompactString::new(name.clone()), cfg).await {
                 Ok(handle) => {
-                    tracing::info!("Connected to MCP server '{}'", name);
+                    tracing::info!(
+                        "Connected to MCP server '{}' in {:?}",
+                        name,
+                        connect_start.elapsed()
+                    );
                     handles.push(handle);
                 }
                 Err(e) => {
-                    tracing::debug!("Failed to connect to MCP server '{}': {e}", name);
+                    tracing::debug!(
+                        "Failed to connect to MCP server '{}' after {:?}: {e}",
+                        name,
+                        connect_start.elapsed()
+                    );
                     notices.push(CompactString::new(format!(
                         "MCP server '{name}' not connected: {e}"
                     )));

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,10 @@ async fn run() -> anyhow::Result<()> {
         }
     }
 
+    let phase_start = std::time::Instant::now();
     let mut startup =
         startup::Startup::init(cli, cfg, is_first_startup, version_changed, is_interactive).await?;
+    tracing::debug!("startup: init took {:?}", phase_start.elapsed());
 
     // ACP mode: serve and exit before feature init
     #[cfg(feature = "acp")]
@@ -116,7 +118,11 @@ async fn run() -> anyhow::Result<()> {
         return extras::acp::serve(startup.cli, startup.cfg, startup.context).await;
     }
 
+    let phase_start = std::time::Instant::now();
     startup.init_features().await?;
+    tracing::debug!("startup: init_features took {:?}", phase_start.elapsed());
+    let phase_start = std::time::Instant::now();
     startup.resolve_prompts().await?;
+    tracing::debug!("startup: resolve_prompts took {:?}", phase_start.elapsed());
     startup.dispatch().await
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -369,6 +369,7 @@ pub async fn list_models_manual(
         Some(&base),
     )?;
     let url = format!("{}/models", base.trim_end_matches('/'));
+    tracing::debug!("list_models_manual: GET {}", url);
     let mut req = http.get(url);
     if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
         req = req.bearer_auth(k);

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -598,7 +598,13 @@ impl Startup {
             } else {
                 "startup"
             };
+            let hooks_start = std::time::Instant::now();
             crate::extras::hooks::dispatch_session_start(source).await;
+            tracing::debug!(
+                "startup: SessionStart hooks ({}) took {:?}",
+                source,
+                hooks_start.elapsed()
+            );
         }
 
         // ARCHITECTURE.md prompt

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -149,6 +149,7 @@ impl<'a> App<'a> {
         ui.session.overhead_tokens =
             crate::agent::builder::estimate_overhead(ui.context, slash.reasoning_enabled);
 
+        let tui_start = std::time::Instant::now();
         render_session(&mut renderer, ui.session, ui.cli, ui.cfg, ui.context)?;
         let marker_path = crate::session::storage::data_dir().join("shown_welcome_msg");
         if ui.cfg.resolve_always_show_welcome() || !marker_path.exists() {
@@ -172,14 +173,22 @@ impl<'a> App<'a> {
             &chain,
             BtwStats::default(),
         )?;
+        tracing::debug!("startup: initial TUI render took {:?}", tui_start.elapsed());
 
         {
             let provider = ui.session.provider.to_string();
             let is_custom = ui.cfg.custom_providers_map().contains_key(&provider);
+            let warm_start = std::time::Instant::now();
             let ids = crate::ui::slash::warm_model_cache(
                 &provider, is_custom, &ui.client, ui.cli, ui.cfg,
             )
             .await;
+            tracing::debug!(
+                "startup: warm_model_cache('{}') took {:?} ({} models)",
+                provider,
+                warm_start.elapsed(),
+                ids.len()
+            );
             input.set_live_model_names(ids);
         }
 
@@ -294,6 +303,7 @@ impl<'a> App<'a> {
             let ask_tx_clone = ui.ask_tx.clone();
             let sandbox_clone = ui.sandbox.clone();
             let reasoning_enabled = slash.reasoning_enabled;
+            tracing::debug!("startup: spawning background agent prebuild");
             tokio::spawn(async move {
                 #[cfg(feature = "mcp")]
                 let mcp = if let Some(ref servers) = cfg_clone.mcp_servers {

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -55,6 +55,12 @@ pub(crate) async fn fetch_models_cached(
             return Ok(arc);
         }
     }
+    tracing::debug!(
+        "fetching model list for provider '{}' over the network (custom={}, refresh={})",
+        provider,
+        is_custom,
+        refresh
+    );
     let mut models = if is_custom {
         list_models_manual(
             provider,
@@ -116,7 +122,25 @@ pub(crate) async fn warm_model_cache(
     cli: &Cli,
     cfg: &Config,
 ) -> Vec<String> {
-    let _ = fetch_models_cached(provider, is_custom, client, cli, cfg, false).await;
+    let start = std::time::Instant::now();
+    match fetch_models_cached(provider, is_custom, client, cli, cfg, false).await {
+        Ok(models) => {
+            tracing::debug!(
+                "model list for '{}': {} entries in {:?}",
+                provider,
+                models.len(),
+                start.elapsed()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "model list fetch for '{}' failed after {:?}: {}",
+                provider,
+                start.elapsed(),
+                e
+            );
+        }
+    }
     cached_model_ids(provider)
 }
 


### PR DESCRIPTION
## Motivation

A user-reported (myself) slow startup (84s stall) produced no log output between `advisor init` and `MCP connecting to N servers`, leaving the TUI painted but unresponsive with no way to tell which startup phase was blocking.

Two structural findings while tracing this:

- In interactive mode, MCP connects inside a background prebuild task, so MCP is **not** what blocks startup — the `MCP connecting` log line just marks when the stall *ends*. The gap covers `resolve_prompts` (SessionStart hooks, 60s default timeout each) and `App::new`, which awaits `warm_model_cache` **before** spawning the input event thread.
- `warm_model_cache` → `fetch_models_cached` → `list_models_manual` performs `GET {base}/models` with **no HTTP timeout** unless the custom provider sets `timeout_secs` (`build_http_client` only applies one in that case). A hanging gateway stalls until the OS TCP connect timeout (~75s on macOS), matching the reported 84s. Failures there were also silently swallowed (`let _ = ...`).

## Changes (debug-level logs only, no behavior change)

- `main.rs` — elapsed time for `init` / `init_features` / `resolve_prompts`
- `startup.rs` — SessionStart hooks dispatch duration
- `ui/app.rs` — initial TUI render time, `warm_model_cache` duration + model count, background prebuild spawn marker
- `ui/slash/providers.rs` — network-vs-catalog fetch marker; model list fetch failures are now warned with duration instead of being silently dropped
- `provider.rs` — log the exact `GET {base}/models` URL in `list_models_manual`
- `extras/mcp` — per-server connect duration on success and failure

Example output in verbose mode:

```
startup: init took 12ms
startup: init_features took 3ms
startup: SessionStart hooks (startup) took 1ms
startup: resolve_prompts took 2ms
startup: initial TUI render took 8ms
fetching model list for provider 'mygateway' over the network (custom=true, refresh=false)
list_models_manual: GET https://gateway.example.com/v1/models
startup: warm_model_cache('mygateway') took 75.2s (0 models)   ← culprit, visible at last
startup: spawning background agent prebuild
MCP connecting to 4 servers
Connected to MCP server 'redmine' in 968ms
```

## Follow-up (not in this PR)

Give the model-list fetch a short built-in timeout (e.g. 5s) or move it off the startup path so the TUI never blocks on it. Happy to do that as a separate PR.

## Testing

`cargo fmt` clean, `cargo test`: 690 passed, 0 failed (rebased on current upstream/main).