### PR TITLE
feat(session): record active prompt name and source

### DIFF
--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -32,6 +32,49 @@ pub fn load() -> HashMap<String, String> {
     prompts
 }
 
+/// Whether prompt `name`'s currently-loaded content is the compiled-in
+/// default or a user customization.
+///
+/// Compares content rather than testing file existence: `ensure_global()`
+/// seeds every embedded prompt into the global prompts dir on first run, so
+/// `code.md` being present on disk says nothing about whether the user
+/// touched it. A prompt counts as [`UserFile`](crate::session::PromptSource::UserFile)
+/// only when the text that actually shaped the session differs from the
+/// compiled-in one, or has no compiled-in counterpart at all.
+///
+/// Reads the highest-precedence on-disk copy, mirroring the last-writer-wins
+/// order in [`load()`]: `.zerostack/prompts/`, then the project's
+/// `data/prompts/`, then the global dir. A lower-precedence copy being edited
+/// is irrelevant when a higher-precedence one shadows it.
+pub fn source_of(name: &str) -> crate::session::PromptSource {
+    use crate::session::PromptSource;
+
+    let file_name = format!("{name}.md");
+    let effective = [zerostack_dir(), PathBuf::from("data/prompts"), global_dir()]
+        .into_iter()
+        .find_map(|dir| std::fs::read_to_string(dir.join(&file_name)).ok());
+
+    match effective {
+        // Nothing on disk, so `load()` served the embedded copy. A name with
+        // no embedded copy either cannot reach here: callers resolve against
+        // `load()`'s map first.
+        None => PromptSource::BuiltIn,
+        // On disk but byte-identical to the embedded default: a seeded copy,
+        // not a customization. Also covers a name with no embedded
+        // counterpart, which can only have come from a user file.
+        Some(content) => {
+            let embedded = EMBEDDED
+                .get_file(&file_name)
+                .and_then(|f| f.contents_utf8());
+            if embedded == Some(content.as_str()) {
+                PromptSource::BuiltIn
+            } else {
+                PromptSource::UserFile
+            }
+        }
+    }
+}
+
 pub fn ensure_global() -> anyhow::Result<()> {
     let dir = global_dir();
     if !dir.exists() {
@@ -178,5 +221,78 @@ mod tests {
         assert!(prompts.contains_key("code"));
         assert!(prompts.contains_key("ask"));
         assert!(prompts.contains_key("default"));
+    }
+
+    #[test]
+    fn test_source_of_built_in_prompt() {
+        let _td = TestDir::new();
+        let prompts = load();
+        assert!(prompts.contains_key("code"));
+        assert_eq!(source_of("code"), crate::session::PromptSource::BuiltIn);
+    }
+
+    #[test]
+    fn test_source_of_user_file_shadowing_a_built_in_name() {
+        let _td = TestDir::new();
+        let zs_dir = zerostack_dir();
+        write_prompt(&zs_dir, "code", "from .zerostack/");
+
+        let prompts = load();
+        assert_eq!(prompts["code"], "from .zerostack/");
+        assert_eq!(source_of("code"), crate::session::PromptSource::UserFile);
+    }
+
+    #[test]
+    fn test_source_of_user_only_prompt() {
+        let _td = TestDir::new();
+        let dir = zerostack_dir();
+        write_prompt(&dir, "myproject", "# My Project Prompt");
+
+        let prompts = load();
+        assert!(prompts.contains_key("myproject"));
+        assert_eq!(
+            source_of("myproject"),
+            crate::session::PromptSource::UserFile
+        );
+    }
+
+    /// The case a file-existence check gets wrong: every real run calls
+    /// `ensure_global()`, which writes all embedded prompts to the global
+    /// dir, so `code.md` exists on disk without the user having touched it.
+    #[test]
+    fn test_source_of_built_in_survives_ensure_global() {
+        let _td = TestDir::new();
+        ensure_global().unwrap();
+        assert!(
+            global_dir().join("code.md").exists(),
+            "ensure_global should have seeded the global prompts dir"
+        );
+
+        assert_eq!(source_of("code"), crate::session::PromptSource::BuiltIn);
+    }
+
+    #[test]
+    fn test_source_of_edited_global_copy() {
+        let _td = TestDir::new();
+        ensure_global().unwrap();
+        write_prompt(&global_dir(), "code", "edited in place");
+
+        let prompts = load();
+        assert_eq!(prompts["code"], "edited in place");
+        assert_eq!(source_of("code"), crate::session::PromptSource::UserFile);
+    }
+
+    /// Only the copy that actually shaped the session counts: an edited
+    /// global copy is shadowed by a `.zerostack/` one holding the stock text.
+    #[test]
+    fn test_source_of_reads_highest_precedence_copy() {
+        let _td = TestDir::new();
+        let built_in = load()["code"].clone();
+        write_prompt(&global_dir(), "code", "edited in place");
+        write_prompt(&zerostack_dir(), "code", &built_in);
+
+        let prompts = load();
+        assert_eq!(prompts["code"], built_in);
+        assert_eq!(source_of("code"), crate::session::PromptSource::BuiltIn);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -99,6 +99,28 @@ pub struct PermissionAllowEntry {
     pub pattern: CompactString,
 }
 
+/// Whether a session's active prompt content was the compiled-in default or
+/// a user customization. `UserFile` means the text that shaped the session
+/// differed from the compiled-in one, or had no compiled-in counterpart at
+/// all; a file merely existing on disk is not enough, since the global
+/// prompts dir is seeded with every default on first run. See
+/// [`prompts::source_of`](crate::context::prompts::source_of).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptSource {
+    BuiltIn,
+    UserFile,
+}
+
+/// Which prompt shaped the session: its name and where its content came
+/// from. Last one wins; no history of switches is kept, matching what the
+/// status bar already shows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromptRef {
+    pub name: CompactString,
+    pub source: PromptSource,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: CompactString,
@@ -138,6 +160,11 @@ pub struct Session {
     /// there are no existing ids to collide with.
     #[serde(default)]
     pub next_tool_call_id: u64,
+    /// The prompt active when the session was last saved: name and source
+    /// (built-in vs user file). `None` for sessions with no active prompt,
+    /// and for files written before this field existed.
+    #[serde(default)]
+    pub prompt: Option<PromptRef>,
     #[cfg(feature = "multimodal")]
     #[serde(skip)]
     pub pending_media: Vec<crate::extras::multimodal::MediaAttachment>,
@@ -243,6 +270,7 @@ impl Session {
                 .unwrap_or_default(),
             permission_allowlist: Vec::new(),
             next_tool_call_id: 0,
+            prompt: None,
             #[cfg(feature = "multimodal")]
             pending_media: Vec::new(),
             show_cost_always: false,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,7 +10,7 @@ use crate::permission::ask::{AskReceiver, AskSender};
 use crate::permission::checker::{PermCheck, PermissionChecker};
 use crate::provider::{self, AnyClient};
 use crate::sandbox::Sandbox;
-use crate::session::{self, MessageRole, Session};
+use crate::session::{self, MessageRole, PromptRef, Session};
 
 #[cfg(feature = "advisor")]
 use crate::session::SessionMessage;
@@ -675,6 +675,10 @@ impl Startup {
 
                 self.context.current_prompt = Some(prompt_text);
                 self.context.current_prompt_name = Some(default_prompt.to_string());
+                self.session.prompt = Some(PromptRef {
+                    name: CompactString::new(default_prompt),
+                    source: context::prompts::source_of(default_prompt),
+                });
 
                 apply_startup_prompt_model(
                     default_prompt,
@@ -711,6 +715,10 @@ impl Startup {
 
                 self.context.current_prompt = Some(prompt_text);
                 self.context.current_prompt_name = Some(name.clone());
+                self.session.prompt = Some(PromptRef {
+                    name: CompactString::new(name.as_str()),
+                    source: context::prompts::source_of(name),
+                });
 
                 apply_startup_prompt_model(
                     name,

--- a/src/tests/prompt_mode_tests.rs
+++ b/src/tests/prompt_mode_tests.rs
@@ -4,7 +4,12 @@ use std::sync::{Arc, Mutex};
 use crate::context::ContextFiles;
 use crate::permission::checker::{PermCheck, PermissionChecker};
 use crate::permission::{PermissionConfigs, SecurityMode};
+use crate::session::Session;
 use crate::ui::{PromptModeOutcome, apply_prompt_mode};
+
+fn make_session() -> Session {
+    Session::new("openai", "gpt-4", 128000, "")
+}
 
 fn make_context(prompts: &[(&str, &str)]) -> ContextFiles {
     ContextFiles {
@@ -43,27 +48,37 @@ fn current_mode(perm: &PermCheck) -> SecurityMode {
 #[test]
 fn prompt_without_directive_keeps_content_and_mode_untouched() {
     let mut context = make_context(&[("code", "You are a coder.")]);
+    let mut session = make_session();
     let perm = make_perm(SecurityMode::Standard);
 
-    let outcome = apply_prompt_mode("code", &mut context, &Some(perm.clone()));
+    let outcome = apply_prompt_mode("code", &mut context, &mut session, &Some(perm.clone()));
 
     assert_eq!(outcome, PromptModeOutcome::None);
     assert_eq!(context.current_prompt.as_deref(), Some("You are a coder."));
     assert_eq!(context.current_prompt_name.as_deref(), Some("code"));
     assert_eq!(current_mode(&perm), SecurityMode::Standard);
+    assert_eq!(
+        session.prompt.as_ref().map(|p| p.name.as_str()),
+        Some("code")
+    );
 }
 
 #[test]
 fn mode_directive_is_stripped_and_applied() {
     let mut context = make_context(&[("review", "%%mode=readonly\nReview the code.")]);
+    let mut session = make_session();
     let perm = make_perm(SecurityMode::Standard);
 
-    let outcome = apply_prompt_mode("review", &mut context, &Some(perm.clone()));
+    let outcome = apply_prompt_mode("review", &mut context, &mut session, &Some(perm.clone()));
 
     assert_eq!(outcome, PromptModeOutcome::Applied(SecurityMode::ReadOnly));
     assert_eq!(context.current_prompt.as_deref(), Some("Review the code."));
     assert_eq!(context.current_prompt_name.as_deref(), Some("review"));
     assert_eq!(current_mode(&perm), SecurityMode::ReadOnly);
+    assert_eq!(
+        session.prompt.as_ref().map(|p| p.name.as_str()),
+        Some("review")
+    );
 }
 
 #[test]
@@ -72,40 +87,54 @@ fn last_user_mode_restores_the_user_selected_mode() {
         ("review", "%%mode=readonly\nReview the code."),
         ("code", "%%mode=last_user_mode\nYou are a coder."),
     ]);
+    let mut session = make_session();
     let perm = make_perm(SecurityMode::Guarded);
 
     // A prompt-imposed mode must not clobber the user-selected mode...
-    apply_prompt_mode("review", &mut context, &Some(perm.clone()));
+    apply_prompt_mode("review", &mut context, &mut session, &Some(perm.clone()));
     assert_eq!(current_mode(&perm), SecurityMode::ReadOnly);
+    assert_eq!(
+        session.prompt.as_ref().map(|p| p.name.as_str()),
+        Some("review")
+    );
 
     // ...so a `last_user_mode` prompt restores it afterwards.
-    let outcome = apply_prompt_mode("code", &mut context, &Some(perm.clone()));
+    let outcome = apply_prompt_mode("code", &mut context, &mut session, &Some(perm.clone()));
 
     assert_eq!(outcome, PromptModeOutcome::RestoredUserMode);
     assert_eq!(current_mode(&perm), SecurityMode::Guarded);
     assert_eq!(context.current_prompt.as_deref(), Some("You are a coder."));
     assert_eq!(context.current_prompt_name.as_deref(), Some("code"));
+    // Runtime switch: the record reflects whichever prompt was active last,
+    // not the one it was switched from.
+    assert_eq!(
+        session.prompt.as_ref().map(|p| p.name.as_str()),
+        Some("code")
+    );
 }
 
 #[test]
 fn unknown_prompt_is_a_noop() {
     let mut context = make_context(&[("code", "You are a coder.")]);
+    let mut session = make_session();
     let perm = make_perm(SecurityMode::Standard);
 
-    let outcome = apply_prompt_mode("missing", &mut context, &Some(perm.clone()));
+    let outcome = apply_prompt_mode("missing", &mut context, &mut session, &Some(perm.clone()));
 
     assert_eq!(outcome, PromptModeOutcome::None);
     assert!(context.current_prompt.is_none());
     assert!(context.current_prompt_name.is_none());
     assert_eq!(current_mode(&perm), SecurityMode::Standard);
+    assert!(session.prompt.is_none());
 }
 
 #[test]
 fn unrecognized_mode_strips_directive_but_keeps_current_mode() {
     let mut context = make_context(&[("weird", "%%mode=bogus\nBody.")]);
+    let mut session = make_session();
     let perm = make_perm(SecurityMode::Standard);
 
-    let outcome = apply_prompt_mode("weird", &mut context, &Some(perm.clone()));
+    let outcome = apply_prompt_mode("weird", &mut context, &mut session, &Some(perm.clone()));
 
     assert_eq!(outcome, PromptModeOutcome::None);
     assert_eq!(context.current_prompt.as_deref(), Some("Body."));
@@ -116,10 +145,27 @@ fn unrecognized_mode_strips_directive_but_keeps_current_mode() {
 #[test]
 fn without_permission_checker_prompt_is_still_selected() {
     let mut context = make_context(&[("review", "%%mode=readonly\nReview the code.")]);
+    let mut session = make_session();
 
-    let outcome = apply_prompt_mode("review", &mut context, &None);
+    let outcome = apply_prompt_mode("review", &mut context, &mut session, &None);
 
     assert_eq!(outcome, PromptModeOutcome::None);
     assert_eq!(context.current_prompt.as_deref(), Some("Review the code."));
     assert_eq!(context.current_prompt_name.as_deref(), Some("review"));
+}
+
+#[test]
+fn unknown_prompt_leaves_the_previous_record_untouched() {
+    let mut context = make_context(&[("code", "You are a coder.")]);
+    let mut session = make_session();
+    let perm = make_perm(SecurityMode::Standard);
+
+    apply_prompt_mode("code", &mut context, &mut session, &Some(perm.clone()));
+    apply_prompt_mode("missing", &mut context, &mut session, &Some(perm.clone()));
+
+    // An unknown name is a no-op: it must not clobber the last real switch.
+    assert_eq!(
+        session.prompt.as_ref().map(|p| p.name.as_str()),
+        Some("code")
+    );
 }

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -4,6 +4,7 @@ use crate::session::ToolRecord;
 use crate::session::storage::{
     delete_session, find_sessions_by_prefix, load_suffix, save_session, suffix_path,
 };
+use crate::session::{PromptRef, PromptSource};
 use crate::session::{TOOL_RESULT_HEAD_CHARS, TOOL_RESULT_SAVE_THRESHOLD, TOOL_RESULT_TAIL_CHARS};
 use std::env;
 use std::path::Path;
@@ -85,6 +86,49 @@ fn save_session_preserves_messages() {
     assert_eq!(found[0].messages.len(), 2);
     assert_eq!(found[0].messages[0].content, "question");
     assert_eq!(found[0].messages[1].content, "answer");
+    drop(env);
+}
+
+#[test]
+fn save_session_round_trips_prompt_provenance() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000, "");
+    s.prompt = Some(PromptRef {
+        name: "code".into(),
+        source: PromptSource::BuiltIn,
+    });
+    save_session(&s).unwrap();
+
+    let found = find_sessions_by_prefix(&s.id[..8]).unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(
+        found[0].prompt,
+        Some(PromptRef {
+            name: "code".into(),
+            source: PromptSource::BuiltIn,
+        })
+    );
+    drop(env);
+}
+
+#[test]
+fn old_session_file_without_prompt_field_loads_as_none() {
+    let env = setup_test_env();
+    // Simulates a session file written before `prompt` existed: build one via
+    // `Session::new`, serialize it, then drop the `prompt` key entirely
+    // before writing it to disk, as an old binary would have.
+    let s = Session::new("anthropic", "claude", 200000, "");
+    let mut value = serde_json::to_value(&s).unwrap();
+    value.as_object_mut().unwrap().remove("prompt");
+    let json = serde_json::to_string(&value).unwrap();
+    let path = crate::session::storage::data_dir()
+        .join("sessions")
+        .join(format!("{}.json", s.id));
+    std::fs::write(&path, json).unwrap();
+
+    let found = find_sessions_by_prefix(&s.id[..8]).unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].prompt, None);
     drop(env);
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -14,7 +14,7 @@ use crate::event::{AgentEvent, BtwEvent, UserEvent};
 #[cfg(feature = "mcp")]
 use crate::extras::mcp::McpClientManager;
 use crate::provider::AnyAgent;
-use crate::session::MessageRole;
+use crate::session::{MessageRole, PromptRef};
 use crate::ui::event_handler;
 use crate::ui::events::{render_session, sanitize_output};
 use crate::ui::input::InputEditor;
@@ -915,6 +915,15 @@ impl<'a> App<'a> {
             } else {
                 None
             };
+            self.ui.session.prompt =
+                self.ui
+                    .context
+                    .current_prompt_name
+                    .as_deref()
+                    .map(|name| PromptRef {
+                        name: name.into(),
+                        source: crate::context::prompts::source_of(name),
+                    });
             if let Some(perm) = &self.ui.permission {
                 let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                 guard.restore_user_mode();
@@ -984,6 +993,15 @@ impl<'a> App<'a> {
             } else {
                 None
             };
+            self.ui.session.prompt =
+                self.ui
+                    .context
+                    .current_prompt_name
+                    .as_deref()
+                    .map(|name| PromptRef {
+                        name: name.into(),
+                        source: crate::context::prompts::source_of(name),
+                    });
             if let Some(perm) = &self.ui.permission {
                 let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
                 guard.restore_user_mode();
@@ -1022,7 +1040,12 @@ impl<'a> App<'a> {
         extra: Option<&str>,
     ) -> anyhow::Result<()> {
         let next_name = phase.next_prompt_name();
-        apply_prompt_mode(next_name, self.ui.context, &self.ui.permission);
+        apply_prompt_mode(
+            next_name,
+            self.ui.context,
+            self.ui.session,
+            &self.ui.permission,
+        );
         apply_prompt_model(
             next_name,
             &mut self.ui,
@@ -1076,7 +1099,12 @@ impl<'a> App<'a> {
             let msg = msg.trim();
             if !prompt_name.is_empty() && self.ui.context.prompts.contains_key(prompt_name) {
                 self.chain.dot_prompt_restore = self.ui.context.current_prompt_name.clone();
-                apply_prompt_mode(prompt_name, self.ui.context, &self.ui.permission);
+                apply_prompt_mode(
+                    prompt_name,
+                    self.ui.context,
+                    self.ui.session,
+                    &self.ui.permission,
+                );
                 apply_prompt_model(
                     prompt_name,
                     &mut self.ui,
@@ -1097,7 +1125,12 @@ impl<'a> App<'a> {
 
         let prompt_name = after_dot.trim();
         if self.ui.context.prompts.contains_key(prompt_name) {
-            apply_prompt_mode(prompt_name, self.ui.context, &self.ui.permission);
+            apply_prompt_mode(
+                prompt_name,
+                self.ui.context,
+                self.ui.session,
+                &self.ui.permission,
+            );
             apply_prompt_model(
                 prompt_name,
                 &mut self.ui,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,7 +33,7 @@ use crate::permission::ask::AskReceiver;
 use crate::permission::checker::PermCheck;
 use crate::permission::{self, SecurityMode};
 use crate::provider::AnyAgent;
-use crate::session::{MessageRole, Session};
+use crate::session::{MessageRole, PromptRef, Session};
 use crate::ui::event_handler::ensure_agent;
 #[cfg(feature = "advisor")]
 use crate::ui::events::sanitize_output;
@@ -62,6 +62,7 @@ pub(crate) enum PromptModeOutcome {
 pub(crate) fn apply_prompt_mode(
     name: &str,
     context: &mut ContextFiles,
+    session: &mut Session,
     permission: &Option<PermCheck>,
 ) -> PromptModeOutcome {
     let Some(content) = context.prompts.get(name) else {
@@ -74,6 +75,10 @@ pub(crate) fn apply_prompt_mode(
         content.clone()
     });
     context.current_prompt_name = Some(name.to_string());
+    session.prompt = Some(PromptRef {
+        name: name.into(),
+        source: crate::context::prompts::source_of(name),
+    });
     apply_mode_directive(mode_directive, permission)
 }
 

--- a/src/ui/slash/content.rs
+++ b/src/ui/slash/content.rs
@@ -40,6 +40,7 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
         } else {
             ctx.context.current_prompt = None;
             ctx.context.current_prompt_name = None;
+            ctx.session.prompt = None;
             // Revert to the config default model
             let default_model = ctx.cli.resolve_model(ctx.cfg);
             let default_provider = ctx.cli.resolve_provider(ctx.cfg);
@@ -62,7 +63,7 @@ async fn handle_prompt(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result
     } else {
         let name = parts[1].trim();
         if ctx.context.prompts.contains_key(name) {
-            match apply_prompt_mode(name, ctx.context, ctx.permission) {
+            match apply_prompt_mode(name, ctx.context, ctx.session, ctx.permission) {
                 PromptModeOutcome::RestoredUserMode => {
                     if let Some(perm) = ctx.permission {
                         let current = perm

--- a/src/ui/slash/review.rs
+++ b/src/ui/slash/review.rs
@@ -59,7 +59,7 @@ pub async fn handle(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
     ctx.context.one_shot_restore = ctx.context.current_prompt_name.clone();
 
     // Switch to review prompt
-    apply_prompt_mode("review", ctx.context, ctx.permission);
+    apply_prompt_mode("review", ctx.context, ctx.session, ctx.permission);
 
     let model_switched = ctx.switch_to_prompt_model("review").await;
     if !model_switched {


### PR DESCRIPTION
Closes #227

## Current behavior

The prompt shaping a session lives only in memory, on `ContextFiles::current_prompt_name`. It is set at startup from `default_prompt` or `--load-prompt`, and updated at runtime through `apply_prompt_mode` plus a few direct assignment sites. It surfaces in exactly one place, the status bar. The session file has no field for it, so a saved session cannot say whether it ran under `code`, `plan`, `review`, or a user prompt file, even though a prompt's `%%mode=` directive now drives permission enforcement.

## What changes

- `Session` gains `#[serde(default)] pub prompt: Option<PromptRef>`, where `PromptRef` is `{ name, source }` and `source` is `BuiltIn` or `UserFile`.
- `context::prompts` gains `source_of(name)`, a small helper that checks the same override directories `load()` already walks (global prompts dir, the project's `data/prompts/`, `.zerostack/prompts/`) to classify a resolved prompt's origin, without changing `load()`'s `HashMap<String, String>` return shape.
- Startup prompt resolution writes the field in both the `default_prompt` block and the `--load-prompt` block.
- `apply_prompt_mode` now takes the session and writes the field, so its five call sites (`/prompt <name>`, `/review`, chain phase transitions, both dot-prefix branches) pick it up by construction. The three sites that assign `current_prompt_name` directly instead of going through `apply_prompt_mode` (`/prompt default`, and the two dot-prefix restore paths) get the same treatment.
- No switch history is kept; the last prompt active wins, matching what the status bar already shows.
- `#[serde(default)]` keeps existing session files loading with `prompt: None`.

## Tests

- `src/session/mod.rs` schema plus a save/load round trip test and a test that a session file written before this field existed still loads, with `prompt: None`.
- `src/context/prompts.rs`: `source_of` unit tests for a built-in prompt, a user file shadowing a built-in name, and a prompt that only exists as a user file.
- `src/tests/prompt_mode_tests.rs`: `apply_prompt_mode` now asserts the session's recorded prompt name and source, including that an unknown prompt name is a no-op that leaves the previous record untouched, and that switching twice leaves the record reflecting the prompt active last.

Verified with `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`, both clean.
