### PR TITLE
feat(headless): record tool calls and results in print-mode sessions

### DIFF
--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -161,7 +161,7 @@ Key files:
 | `src/extras/subagents/task_tool.rs`          | `TaskTool` implementation             |
 | `src/extras/subagents/builder.rs`            | Subagent construction (`build_explore_agent`) |
 | `src/extras/subagents/prompt.rs`             | Subagent system prompt                |
-| `src/agent/runner.rs` (`run_subagent`)       | Silent agent execution                |
+| `src/agent/runner.rs` (`run_subagent`)       | Silent agent execution; reports each subagent tool call as an event |
 | `src/agent/builder.rs`                       | Wires `TaskTool` into main agent      |
 | `src/provider.rs` (`AnyAgent::run_subagent`) | Type-erased dispatch                  |
 | `src/main.rs`                                | Initializes `SubagentConfig`          |

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -615,6 +615,27 @@ where
     // returned to the caller (`dispatch_print`) for session persistence. See
     // design.md decision 5.
     let mut recorded_interactions: Vec<ToolInteraction> = Vec::new();
+    // Subagent tool calls reach this loop on a side channel rather than as
+    // stream items: `run_subagent` sends them from the tokio task the `task`
+    // tool spawned, concurrently with this turn's own stream. Only
+    // `spawn_agent` (the TUI) ever published a sender, so headless runs left
+    // subagent activity untraced; publishing one here is what makes it
+    // recordable. Same channel capacity as `spawn_agent`'s, and drained by
+    // the `select!` below while the `task` tool is still running, so a
+    // subagent making many tool calls cannot fill it and stall.
+    #[cfg(feature = "subagents")]
+    let (subagent_tx, mut subagent_rx) = mpsc::channel::<AgentEvent>(32);
+    #[cfg(feature = "subagents")]
+    crate::extras::subagents::set_subagent_event_tx(subagent_tx.clone());
+    // Held for the whole turn: with no sender alive the channel would be
+    // closed, and the `select!` arm below would then complete immediately on
+    // every poll instead of waiting.
+    #[cfg(feature = "subagents")]
+    let _subagent_tx = subagent_tx;
+    // Subagent calls seen since the current main-agent tool call started;
+    // moved into that call's `ToolInteraction` when its result arrives.
+    #[cfg(feature = "subagents")]
+    let mut pending_subagent_calls: Vec<SubagentCall> = Vec::new();
     let mut usage = rig::completion::Usage::new();
     // Set true only when a `Stop` hook forces another turn; drives the outer
     // loop. Stays false (single pass, no continuation) in the hooks-off build.
@@ -630,7 +651,30 @@ where
 
     while continue_turn {
         continue_turn = false;
-        while let Some(item) = stream.next().await {
+        loop {
+            // Wait for the next stream item while staying available to the
+            // subagent channel. `StreamExt::next` is cancel-safe (it only
+            // polls the stream, which owns its own state), so losing the race
+            // to a subagent event costs nothing: the next iteration polls the
+            // same stream again.
+            #[cfg(feature = "subagents")]
+            let next_item = loop {
+                tokio::select! {
+                    // `biased`: drain everything already queued before
+                    // touching the stream, so a subagent event that arrived
+                    // during the `task` call is attributed to that call and
+                    // not to whatever comes next.
+                    biased;
+                    Some(event) = subagent_rx.recv() => {
+                        push_subagent_call(&mut pending_subagent_calls, event);
+                    }
+                    item = stream.next() => break item,
+                }
+            };
+            #[cfg(not(feature = "subagents"))]
+            let next_item = stream.next().await;
+
+            let Some(item) = next_item else { break };
             match item {
                 Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(
                     text,
@@ -687,7 +731,23 @@ where
                         }
                         let _ = std::io::Write::flush(&mut std::io::stdout());
                     }
-                    recorded_interactions.push(ToolInteraction { name, args, output });
+                    // Anything still queued belongs to the call that just
+                    // finished: a subagent only runs inside its `task` call,
+                    // and every send completes before that call returns. The
+                    // `select!` above normally has them already, but a tool
+                    // that sends without ever yielding hands us its result in
+                    // the same poll, leaving them queued until here.
+                    #[cfg(feature = "subagents")]
+                    while let Ok(event) = subagent_rx.try_recv() {
+                        push_subagent_call(&mut pending_subagent_calls, event);
+                    }
+                    recorded_interactions.push(ToolInteraction {
+                        name,
+                        args,
+                        output,
+                        #[cfg(feature = "subagents")]
+                        subagent_calls: std::mem::take(&mut pending_subagent_calls),
+                    });
                     #[cfg(feature = "hooks")]
                     tool_interactions.push(tool_result.clone().into());
                 }
@@ -771,6 +831,37 @@ pub struct ToolInteraction {
     pub name: String,
     pub args: serde_json::Value,
     pub output: String,
+    /// The tool calls subagents made while this call was running, in arrival
+    /// order. Nesting them here is what carries the parent link across the
+    /// concurrency boundary: only this loop knows which main-agent call was
+    /// in flight when each event arrived, and `dispatch_print` turns the
+    /// nesting into `parent_call_id` once the enclosing call has an id.
+    /// Always empty for anything but a `task` call.
+    #[cfg(feature = "subagents")]
+    pub subagent_calls: Vec<SubagentCall>,
+}
+
+/// One tool call made by a subagent, as reported by
+/// [`AgentEvent::SubagentToolCall`]: name plus complete, untruncated argument
+/// JSON. Subagent tool *results* have no event to carry them (design.md
+/// Non-Goals), so there is nothing to pair this with.
+#[cfg(feature = "subagents")]
+#[derive(Debug, Clone)]
+pub struct SubagentCall {
+    pub name: String,
+    pub args: serde_json::Value,
+}
+
+/// Collects a `SubagentToolCall` event; any other event on that channel is
+/// not something a subagent emits and is ignored.
+#[cfg(feature = "subagents")]
+fn push_subagent_call(collected: &mut Vec<SubagentCall>, event: AgentEvent) {
+    if let AgentEvent::SubagentToolCall { name, args } = event {
+        collected.push(SubagentCall {
+            name: name.to_string(),
+            args,
+        });
+    }
 }
 
 /// [`run_print`]'s return value: the assistant's final response text, token

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -590,7 +590,7 @@ pub async fn run_print<M>(
     // `loop_iteration`/`loop_active` fields; see `runner::spawn_agent`.
     // `None` for plain `-p` one-shot runs.
     #[cfg(feature = "hooks")] loop_info: Option<LoopInfo>,
-) -> anyhow::Result<(String, rig::completion::Usage)>
+) -> anyhow::Result<PrintOutcome>
 where
     M: CompletionModel + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
@@ -609,6 +609,12 @@ where
     let mut tool_interactions: Vec<Message> = Vec::new();
     let mut full_response = String::new();
     let mut last_tool_name: Option<String> = None;
+    let mut last_tool_args: Option<serde_json::Value> = None;
+    // Unconditional (independent of `pure_stdout` and the `hooks` feature)
+    // ordered record of this turn's completed tool call/result round trips,
+    // returned to the caller (`dispatch_print`) for session persistence. See
+    // design.md decision 5.
+    let mut recorded_interactions: Vec<ToolInteraction> = Vec::new();
     let mut usage = rig::completion::Usage::new();
     // Set true only when a `Stop` hook forces another turn; drives the outer
     // loop. Stays false (single pass, no continuation) in the hooks-off build.
@@ -642,10 +648,12 @@ where
                 Ok(MultiTurnStreamItem::StreamAssistantItem(
                     StreamedAssistantContent::ToolCall { tool_call, .. },
                 )) => {
+                    let name = tool_call.function.name.clone();
+                    let args = tool_call.function.arguments.clone();
+                    last_tool_name = Some(name.clone());
+                    last_tool_args = Some(args.clone());
                     if pure_stdout {
-                        let name = &tool_call.function.name;
-                        last_tool_name = Some(name.clone());
-                        let summary = format_tool_args_summary(&tool_call.function.arguments);
+                        let summary = format_tool_args_summary(&args);
                         println!("\n◈ {} {}", name, summary);
                         let _ = std::io::Write::flush(&mut std::io::stdout());
                     }
@@ -656,33 +664,30 @@ where
                     tool_result,
                     ..
                 })) => {
-                    if pure_stdout {
-                        let name = last_tool_name.take().unwrap_or_default();
-                        let mut output = String::new();
-                        for c in tool_result.content.iter() {
-                            if let ToolResultContent::Text(t) = c {
-                                if !output.is_empty() {
-                                    output.push('\n');
-                                }
-                                output.push_str(&t.text);
+                    let name = last_tool_name.take().unwrap_or_default();
+                    let args = last_tool_args.take().unwrap_or(serde_json::Value::Null);
+                    let mut output = String::new();
+                    for c in tool_result.content.iter() {
+                        if let ToolResultContent::Text(t) = c {
+                            if !output.is_empty() {
+                                output.push('\n');
                             }
-                        }
-                        if !output.is_empty() {
-                            println!("◈ {} result:", name);
-                            let lines: Vec<&str> = output.lines().collect();
-                            if lines.len() > 40 {
-                                let truncated: Vec<&str> = lines.iter().take(40).copied().collect();
-                                println!("{}", truncated.join("\n"));
-                                println!(
-                                    "(truncated {} more lines)",
-                                    lines.len().saturating_sub(40)
-                                );
-                            } else {
-                                println!("{}", output);
-                            }
-                            let _ = std::io::Write::flush(&mut std::io::stdout());
+                            output.push_str(&t.text);
                         }
                     }
+                    if pure_stdout && !output.is_empty() {
+                        println!("◈ {} result:", name);
+                        let lines: Vec<&str> = output.lines().collect();
+                        if lines.len() > 40 {
+                            let truncated: Vec<&str> = lines.iter().take(40).copied().collect();
+                            println!("{}", truncated.join("\n"));
+                            println!("(truncated {} more lines)", lines.len().saturating_sub(40));
+                        } else {
+                            println!("{}", output);
+                        }
+                        let _ = std::io::Write::flush(&mut std::io::stdout());
+                    }
+                    recorded_interactions.push(ToolInteraction { name, args, output });
                     #[cfg(feature = "hooks")]
                     tool_interactions.push(tool_result.clone().into());
                 }
@@ -745,7 +750,36 @@ where
     }
 
     println!();
-    Ok((full_response, usage))
+    Ok(PrintOutcome {
+        response: full_response,
+        usage,
+        tool_interactions: recorded_interactions,
+    })
+}
+
+/// One complete tool call/result round trip from a `run_print` turn: the
+/// call's name and complete, untruncated argument JSON, plus the result text
+/// it produced. Collected unconditionally (independent of `--pure-stdout`
+/// and the `hooks` feature), unlike the `hooks`-only `tool_interactions:
+/// Vec<Message>` above, which carries the raw `rig` message types needed
+/// only for `Stop`-continuation replay. `dispatch_print` turns each of these
+/// into a `Session::add_tool_call` + `add_tool_result` pair (design.md
+/// decision 5); relies on the single-threaded call/result pairing confirmed
+/// in design.md's Open Questions (2.3).
+#[derive(Debug, Clone)]
+pub struct ToolInteraction {
+    pub name: String,
+    pub args: serde_json::Value,
+    pub output: String,
+}
+
+/// [`run_print`]'s return value: the assistant's final response text, token
+/// usage, and this turn's ordered tool interactions for the caller to
+/// persist into the session.
+pub struct PrintOutcome {
+    pub response: String,
+    pub usage: rig::completion::Usage,
+    pub tool_interactions: Vec<ToolInteraction>,
 }
 
 fn format_tool_args_summary(args_json: &serde_json::Value) -> String {

--- a/src/extras/export.rs
+++ b/src/extras/export.rs
@@ -68,6 +68,7 @@ pub fn parse_jsonl_import(content: &str) -> Result<Vec<SessionMessage>> {
             role: msg.role,
             content: msg.content,
             estimated_tokens: msg.estimated_tokens,
+            tool: None,
         });
     }
     if messages.is_empty() {

--- a/src/extras/loop/headless.rs
+++ b/src/extras/loop/headless.rs
@@ -78,11 +78,15 @@ pub(crate) async fn run_headless_loop(
             )
             .await
         {
-            Ok((r, _usage)) => {
+            Ok(outcome) => {
                 if let Some(ss) = status_signals.as_ref() {
                     ss.send_stop();
                 }
-                r
+                // `--loop` has no `Session` to persist into (`TODO(loop-history)`,
+                // design.md Non-Goals), so `outcome.tool_interactions` is
+                // discarded here; only the response text feeds the loop's
+                // plan/summary state.
+                outcome.response
             }
             Err(e) => {
                 if let Some(ss) = status_signals.as_ref() {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -601,7 +601,7 @@ impl AnyAgent {
         // `--loop` iteration/active state; see `runner::run_print`. `None`
         // for plain `-p` one-shot runs.
         #[cfg(feature = "hooks")] loop_info: Option<LoopInfo>,
-    ) -> anyhow::Result<(String, rig::completion::Usage)> {
+    ) -> anyhow::Result<runner::PrintOutcome> {
         match self {
             AnyAgent::OpenRouter(a) => {
                 runner::run_print(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -38,11 +38,11 @@ pub struct SessionMessage {
 /// by the existing threshold and overflow-file mechanism — see
 /// `Session::tool_result_content`).
 ///
-/// `#[serde(untagged)]`: the two variants are structurally disjoint (`Call`
-/// has `id`/`args`, `Result` has `call_id`/`truncated`), so untagged
-/// deserialization picks the right one unambiguously; this keeps the JSON
-/// shape flat (no extra `type` discriminant) matching the schema already
-/// reviewed upstream.
+/// `#[serde(untagged)]`: the variants are structurally disjoint (`Call` has
+/// `id`/`args`, `Result` has `call_id`/`truncated`, `SubagentCall` has
+/// `parent_call_id`/`args`), so untagged deserialization picks the right one
+/// unambiguously; this keeps the JSON shape flat (no extra `type`
+/// discriminant) matching the schema already reviewed upstream.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ToolRecord {
@@ -56,6 +56,18 @@ pub enum ToolRecord {
         name: CompactString,
         truncated: bool,
         full_output_path: Option<CompactString>,
+    },
+    /// A tool call made by a subagent, attributed to the enclosing `task`
+    /// call via `parent_call_id` (the `Call` record's `id`). Deliberately has
+    /// no `id` of its own: subagent tool *results* have no event to record
+    /// (design.md Non-Goals), so nothing ever links back to one, and an `id`
+    /// field here would make this variant's JSON also satisfy `Call` — which,
+    /// being listed first, would win the untagged match. `parent_call_id` is
+    /// required for the same reason: it is what keeps the two disjoint.
+    SubagentCall {
+        parent_call_id: u64,
+        name: CompactString,
+        args: serde_json::Value,
     },
 }
 
@@ -429,11 +441,35 @@ impl Session {
         }
     }
 
+    /// Records a subagent's tool call with a structured
+    /// [`ToolRecord::SubagentCall`] (complete, untruncated args) alongside the
+    /// existing display summary in `content`. `parent_call_id` is the id of
+    /// the enclosing `task` call — the value [`add_tool_call`](Self::add_tool_call)
+    /// returned for it — which is what attributes the subagent's activity to
+    /// the call that spawned it; subagent events are concurrent with the main
+    /// agent's turn, so position alone cannot express that link.
+    ///
+    /// `None` means the caller had no enclosing call in flight, which the
+    /// event ordering makes unreachable in practice (a subagent only runs
+    /// inside a `task` call). It degrades to the pre-existing behavior of a
+    /// display summary with no structured record, rather than fabricating a
+    /// parent id that would silently point at an unrelated call.
     #[cfg(any(feature = "subagents", feature = "acp"))]
-    pub fn add_subagent_tool_call(&mut self, name: &str, args: &serde_json::Value) {
-        self.add_message(
+    pub fn add_subagent_tool_call(
+        &mut self,
+        parent_call_id: Option<u64>,
+        name: &str,
+        args: &serde_json::Value,
+    ) {
+        let content = crate::ui::utils::format_tool_call_summary(name, args);
+        self.add_message_with_tool(
             MessageRole::SubagentToolCall,
-            &crate::ui::utils::format_tool_call_summary(name, args),
+            &content,
+            parent_call_id.map(|parent_call_id| ToolRecord::SubagentCall {
+                parent_call_id,
+                name: CompactString::new(name),
+                args: args.clone(),
+            }),
         );
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,6 +27,36 @@ pub struct SessionMessage {
     pub role: MessageRole,
     pub content: CompactString,
     pub estimated_tokens: u64,
+    #[serde(default)]
+    pub tool: Option<ToolRecord>,
+}
+
+/// Structured, machine-readable counterpart to a `ToolCall`/`ToolResult`
+/// message's display summary in `content`. `Call` carries the complete,
+/// untruncated argument JSON; `Result` carries linkage and truncation
+/// metadata only (the result text itself stays solely in `content`, governed
+/// by the existing threshold and overflow-file mechanism — see
+/// `Session::tool_result_content`).
+///
+/// `#[serde(untagged)]`: the two variants are structurally disjoint (`Call`
+/// has `id`/`args`, `Result` has `call_id`/`truncated`), so untagged
+/// deserialization picks the right one unambiguously; this keeps the JSON
+/// shape flat (no extra `type` discriminant) matching the schema already
+/// reviewed upstream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolRecord {
+    Call {
+        id: u64,
+        name: CompactString,
+        args: serde_json::Value,
+    },
+    Result {
+        call_id: u64,
+        name: CompactString,
+        truncated: bool,
+        full_output_path: Option<CompactString>,
+    },
 }
 
 /// A single-step restore point captured before a conversation rewind, so the
@@ -89,6 +119,13 @@ pub struct Session {
     pub working_dir: CompactString,
     #[serde(default)]
     pub permission_allowlist: Vec<PermissionAllowEntry>,
+    /// Counter stamping `ToolRecord::Call.id`, persisted so ids stay unique
+    /// across a `--continue`/resume rather than restarting at 0 and
+    /// colliding with ids already in `messages`. Old session files predate
+    /// structured tool records entirely, so defaulting to 0 on load is safe:
+    /// there are no existing ids to collide with.
+    #[serde(default)]
+    pub next_tool_call_id: u64,
     #[cfg(feature = "multimodal")]
     #[serde(skip)]
     pub pending_media: Vec<crate::extras::multimodal::MediaAttachment>,
@@ -193,6 +230,7 @@ impl Session {
                 .map(|p| CompactString::new(p.to_string_lossy()))
                 .unwrap_or_default(),
             permission_allowlist: Vec::new(),
+            next_tool_call_id: 0,
             #[cfg(feature = "multimodal")]
             pending_media: Vec::new(),
             show_cost_always: false,
@@ -305,11 +343,21 @@ impl Session {
     }
 
     pub fn add_message(&mut self, role: MessageRole, content: &str) {
+        self.add_message_with_tool(role, content, None);
+    }
+
+    fn add_message_with_tool(
+        &mut self,
+        role: MessageRole,
+        content: &str,
+        tool: Option<ToolRecord>,
+    ) {
         let tokens = Self::estimate_tokens(content);
         self.messages.push(SessionMessage {
             role,
             content: CompactString::new(content),
             estimated_tokens: tokens,
+            tool,
         });
         self.total_estimated_tokens = self.total_estimated_tokens.saturating_add(tokens);
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
@@ -318,29 +366,65 @@ impl Session {
         self.rewind_undo = None;
     }
 
-    pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) {
-        self.add_message(
+    /// Records the tool call with a structured `ToolRecord::Call` (complete,
+    /// untruncated args) alongside the existing display summary in `content`,
+    /// and returns the stamped id so the caller can link the matching result
+    /// via [`add_tool_result`](Self::add_tool_result).
+    pub fn add_tool_call(&mut self, name: &str, args: &serde_json::Value) -> u64 {
+        let id = self.next_tool_call_id;
+        self.next_tool_call_id = self.next_tool_call_id.saturating_add(1);
+        let content = crate::ui::utils::format_tool_call_summary(name, args);
+        self.add_message_with_tool(
             MessageRole::ToolCall,
-            &crate::ui::utils::format_tool_call_summary(name, args),
+            &content,
+            Some(ToolRecord::Call {
+                id,
+                name: CompactString::new(name),
+                args: args.clone(),
+            }),
         );
+        id
     }
 
-    pub fn add_tool_result(&mut self, name: &str, output: &str) -> String {
-        let content = self.tool_result_content(name, output);
-        self.add_message(MessageRole::ToolResult, &content);
+    /// Records the tool result. `call_id` must be the id returned by the
+    /// [`add_tool_call`](Self::add_tool_call) this result answers, so the
+    /// structured record links the two by id rather than by position (see
+    /// design.md decision 3). The result text itself is never duplicated: it
+    /// stays solely in the returned/`content` string, under the existing
+    /// threshold and overflow-file mechanism.
+    pub fn add_tool_result(&mut self, call_id: u64, name: &str, output: &str) -> String {
+        let (content, truncated, full_output_path) = self.tool_result_content(name, output);
+        self.add_message_with_tool(
+            MessageRole::ToolResult,
+            &content,
+            Some(ToolRecord::Result {
+                call_id,
+                name: CompactString::new(name),
+                truncated,
+                full_output_path: full_output_path.map(CompactString::new),
+            }),
+        );
         content
     }
 
-    fn tool_result_content(&self, name: &str, output: &str) -> String {
+    fn tool_result_content(&self, name: &str, output: &str) -> (String, bool, Option<String>) {
         let output_chars = output.chars().count();
         if output_chars <= TOOL_RESULT_SAVE_THRESHOLD {
-            return format!("{name}:\n{output}");
+            return (format!("{name}:\n{output}"), false, None);
         }
 
         match storage::save_tool_output(&self.id, name, output) {
-            Ok(path) => format_truncated_tool_result(name, output, output_chars, &path),
-            Err(err) => format!(
-                "{name}:\n{output}\n\n[failed to save long tool output separately; kept full output in session to avoid data loss: {err}]"
+            Ok(path) => (
+                format_truncated_tool_result(name, output, output_chars, &path),
+                true,
+                Some(path.display().to_string()),
+            ),
+            Err(err) => (
+                format!(
+                    "{name}:\n{output}\n\n[failed to save long tool output separately; kept full output in session to avoid data loss: {err}]"
+                ),
+                false,
+                None,
             ),
         }
     }
@@ -561,6 +645,7 @@ impl Session {
             role: MessageRole::System,
             content: CompactString::from(summary.clone()),
             estimated_tokens: summary_tokens,
+            tool: None,
         };
 
         // Remove summarized messages and insert summary

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -882,6 +882,15 @@ impl Startup {
                 session.add_message(MessageRole::User, &msg);
                 for interaction in &response_outcome.tool_interactions {
                     let call_id = session.add_tool_call(&interaction.name, &interaction.args);
+                    // Between the call and its result, where they happened.
+                    #[cfg(feature = "subagents")]
+                    for subagent_call in &interaction.subagent_calls {
+                        session.add_subagent_tool_call(
+                            Some(call_id),
+                            &subagent_call.name,
+                            &subagent_call.args,
+                        );
+                    }
                     session.add_tool_result(call_id, &interaction.name, &interaction.output);
                 }
                 session.add_message(MessageRole::Assistant, &response);

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -853,6 +853,7 @@ impl Startup {
                     role: MessageRole::User,
                     content: CompactString::new(&msg),
                     estimated_tokens: Session::estimate_tokens(&msg),
+                    tool: None,
                 });
                 crate::extras::advisor::set_session_messages(msgs);
             }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -874,10 +874,16 @@ impl Startup {
             if let Some(ss) = self.status_signals.as_ref() {
                 ss.send_stop();
             }
-            let (response, usage) = response_result?;
+            let response_outcome = response_result?;
+            let response = response_outcome.response;
+            let usage = response_outcome.usage;
             if !self.cli.no_session {
                 let mut session = self.session;
                 session.add_message(MessageRole::User, &msg);
+                for interaction in &response_outcome.tool_interactions {
+                    let call_id = session.add_tool_call(&interaction.name, &interaction.args);
+                    session.add_tool_result(call_id, &interaction.name, &interaction.output);
+                }
                 session.add_message(MessageRole::Assistant, &response);
                 session.total_input_tokens = session
                     .total_input_tokens

--- a/src/tests/advisor_tests.rs
+++ b/src/tests/advisor_tests.rs
@@ -6,6 +6,7 @@ fn msg(role: MessageRole, content: &str) -> SessionMessage {
         role,
         content: content.into(),
         estimated_tokens: 0,
+        tool: None,
     }
 }
 

--- a/src/tests/fake_model.rs
+++ b/src/tests/fake_model.rs
@@ -82,11 +82,10 @@ pub fn history_at(model: &FakeModel, turn: usize) -> Vec<Message> {
 
 #[tokio::test]
 async fn run_print_returns_scripted_text() {
-    // Under `--features hooks`, `run_print` reaches the process-global Stop
-    // dispatcher; serialize against the tests that install one so a leaked
-    // hook can't force an unscripted continuation here. No-op otherwise.
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = dispatcher_guard::acquire();
+    // `run_print` reaches process-global wiring (the hooks Stop dispatcher,
+    // the subagent event sender); serialize against every other `run_print`
+    // test so none of them clobber each other's.
+    let _run_print_guard = run_print_guard::acquire();
 
     let model = text_chunks(["hello, ", "world"]);
     let agent = rig::agent::AgentBuilder::new(model).build();
@@ -106,31 +105,37 @@ async fn run_print_returns_scripted_text() {
     assert_eq!(outcome.response, "hello, world");
 }
 
-/// Serializes tests that touch the process-global hook dispatcher and clears
-/// it when the guard drops. `run_print`'s `Stop` path reads a process-wide
-/// dispatcher (`extras::hooks::DISPATCHER`), so a test that installs one via
-/// `init_dispatcher` would otherwise leak that hook into any other `run_print`
-/// test running concurrently in the same binary. Every `run_print` test holds
-/// this guard for the duration of its call, so at most one such test runs at a
-/// time and the dispatcher is always reset afterwards.
-#[cfg(feature = "hooks")]
-pub(crate) mod dispatcher_guard {
+/// Serializes tests that call `run_print`, which reaches process-global
+/// singletons that are last-writer-wins:
+///
+/// - the hooks `Stop` dispatcher (`extras::hooks::DISPATCHER`, `hooks` builds
+///   only), which a test installing one via `init_dispatcher` would otherwise
+///   leak into any `run_print` running concurrently in the same binary;
+/// - the subagent event sender (`extras::subagents::SUBAGENT_EVENT_TX`,
+///   `subagents` builds only), which `run_print` sets so subagent tool calls
+///   reach the session — a second `run_print` starting mid-turn would
+///   redirect the first one's subagent events into its own channel.
+///
+/// Every `run_print` test holds this guard for the duration of its call, so at
+/// most one runs at a time and the dispatcher is always reset afterwards.
+pub(crate) mod run_print_guard {
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-    /// Held for the lifetime of a dispatcher-touching test; resets the
-    /// process-global dispatcher on drop.
-    pub(crate) struct DispatcherGuard(#[allow(dead_code)] MutexGuard<'static, ()>);
+    /// Held for the lifetime of a `run_print` test; resets the process-global
+    /// hook dispatcher on drop.
+    pub(crate) struct RunPrintGuard(#[allow(dead_code)] MutexGuard<'static, ()>);
 
-    /// Acquire exclusive access to the process-global hook dispatcher.
-    pub(crate) fn acquire() -> DispatcherGuard {
+    /// Acquire exclusive access to `run_print`'s process-global wiring.
+    pub(crate) fn acquire() -> RunPrintGuard {
         let lock = LOCK.get_or_init(|| Mutex::new(()));
-        DispatcherGuard(lock.lock().unwrap_or_else(|e| e.into_inner()))
+        RunPrintGuard(lock.lock().unwrap_or_else(|e| e.into_inner()))
     }
 
-    impl Drop for DispatcherGuard {
+    impl Drop for RunPrintGuard {
         fn drop(&mut self) {
+            #[cfg(feature = "hooks")]
             crate::extras::hooks::reset_dispatcher();
         }
     }

--- a/src/tests/fake_model.rs
+++ b/src/tests/fake_model.rs
@@ -91,7 +91,7 @@ async fn run_print_returns_scripted_text() {
     let model = text_chunks(["hello, ", "world"]);
     let agent = rig::agent::AgentBuilder::new(model).build();
 
-    let (response, _usage) = crate::agent::runner::run_print(
+    let outcome = crate::agent::runner::run_print(
         &agent,
         "hi",
         false,
@@ -103,7 +103,7 @@ async fn run_print_returns_scripted_text() {
     .await
     .expect("run_print should succeed against the fake model");
 
-    assert_eq!(response, "hello, world");
+    assert_eq!(outcome.response, "hello, world");
 }
 
 /// Serializes tests that touch the process-global hook dispatcher and clears

--- a/src/tests/headless_ask_tests.rs
+++ b/src/tests/headless_ask_tests.rs
@@ -79,10 +79,10 @@ fn write_tool_call_model() -> MockCompletionModel {
 // exactly as production now does for a non-interactive (`-p`) run.
 #[tokio::test]
 async fn headless_ask_denies_instead_of_hanging() {
-    // Under `--features hooks`, `run_print` consults the process-global Stop
-    // dispatcher; serialize against the test that installs one. No-op otherwise.
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    // `run_print` reaches process-global wiring (the hooks Stop dispatcher,
+    // the subagent event sender); serialize against every other `run_print`
+    // test so none of them clobber each other's.
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     let model = write_tool_call_model();
     let permission = Some(Arc::new(Mutex::new(guarded_checker())));

--- a/src/tests/headless_subagent_record_tests.rs
+++ b/src/tests/headless_subagent_record_tests.rs
@@ -1,0 +1,302 @@
+//! E2e proof that a headless (`-p`) run persists the tool calls its
+//! subagents make, each attributed to the `task` call that spawned it.
+//!
+//! Exercises the same `run_print` boundary as `headless_tool_record_tests.rs`
+//! (see that file's header for why the fake `CompletionModel` carrier is
+//! driven directly rather than through the full `dispatch_print` CLI
+//! plumbing), with one addition: a stand-in `task` tool that emits
+//! `AgentEvent::SubagentToolCall` on the process-global subagent channel
+//! exactly as `runner::run_subagent` does. The real `TaskTool` cannot be
+//! driven here — it builds its subagent from the global `SubagentConfig`'s
+//! `AnyClient`, which has no fake-model variant — and `run_subagent` itself
+//! is not what this section changes: the gap being closed is that headless
+//! runs never listened on that channel at all.
+
+use rig::agent::AgentBuilder;
+use rig::tool::Tool;
+use serde::Deserialize;
+
+use crate::agent::runner::{PrintOutcome, run_print};
+use crate::agent::tools::ToolError;
+use crate::event::AgentEvent;
+use crate::retry::RetryConfig;
+use crate::session::{MessageRole, Session, ToolRecord};
+use crate::tests::fake_model::{FakeModel, MockCompletionModel, MockStreamEvent};
+
+#[derive(Debug, Deserialize)]
+struct TaskArgs {
+    prompts: Vec<String>,
+}
+
+/// Stand-in for `TaskTool`: emits one `SubagentToolCall` event per prompt on
+/// the channel `run_print` wires up, then returns a summary, mirroring a real
+/// `task` call whose subagents each ran one tool.
+struct FakeTaskTool;
+
+impl Tool for FakeTaskTool {
+    const NAME: &'static str = "task";
+
+    type Error = ToolError;
+    type Args = TaskArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        "Investigates the codebase via a subagent.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "prompts": { "type": "array", "items": { "type": "string" } } },
+            "required": ["prompts"]
+        })
+    }
+
+    async fn call(&self, args: TaskArgs) -> Result<String, ToolError> {
+        let tx = crate::extras::subagents::clone_subagent_event_tx()
+            .expect("run_print must publish a subagent event sender for the turn");
+        for prompt in &args.prompts {
+            tx.send(AgentEvent::SubagentToolCall {
+                name: "grep".into(),
+                args: serde_json::json!({ "pattern": prompt }),
+            })
+            .await
+            .expect("subagent event channel must stay open for the whole turn");
+        }
+        Ok(format!("investigated {} prompt(s)", args.prompts.len()))
+    }
+}
+
+/// Longer than `format_tool_call_summary`'s 200-char display truncation
+/// (`src/ui/utils.rs`), so a passing assertion on the structured `args` field
+/// proves it carries the complete value, not the truncated display summary
+/// that lands in `content`.
+fn long_prompt(tag: &str) -> String {
+    format!("{tag}-{}", "x".repeat(500))
+}
+
+fn task_call_event(id: &str, prompts: &[String]) -> MockStreamEvent {
+    MockStreamEvent::tool_call(id, "task", serde_json::json!({ "prompts": prompts }))
+}
+
+/// Mirrors `dispatch_print`'s recording sequence (`src/startup.rs`) exactly:
+/// the user message, then per tool interaction its call, the subagent calls
+/// it spawned, and its result, then the assistant message.
+fn record_turn_into_session(
+    session: &mut Session,
+    prompt: &str,
+    result: anyhow::Result<PrintOutcome>,
+) -> anyhow::Result<()> {
+    let outcome = result?;
+    session.add_message(MessageRole::User, prompt);
+    for interaction in &outcome.tool_interactions {
+        let call_id = session.add_tool_call(&interaction.name, &interaction.args);
+        for subagent_call in &interaction.subagent_calls {
+            session.add_subagent_tool_call(Some(call_id), &subagent_call.name, &subagent_call.args);
+        }
+        session.add_tool_result(call_id, &interaction.name, &interaction.output);
+    }
+    session.add_message(MessageRole::Assistant, &outcome.response);
+    Ok(())
+}
+
+fn call_id_of(session: &Session, index: usize) -> u64 {
+    match &session.messages[index].tool {
+        Some(ToolRecord::Call { id, .. }) => *id,
+        other => panic!("expected a Call record at message {index}, got {other:?}"),
+    }
+}
+
+fn subagent_record(session: &Session, index: usize) -> (u64, String, serde_json::Value) {
+    match &session.messages[index].tool {
+        Some(ToolRecord::SubagentCall {
+            parent_call_id,
+            name,
+            args,
+        }) => (*parent_call_id, name.to_string(), args.clone()),
+        other => panic!("expected a SubagentCall record at message {index}, got {other:?}"),
+    }
+}
+
+async fn run_task_turn(model: FakeModel, max_turns: usize) -> anyhow::Result<PrintOutcome> {
+    let agent = AgentBuilder::new(model)
+        .tool(FakeTaskTool)
+        .default_max_turns(max_turns)
+        .build();
+
+    run_print(
+        &agent,
+        "investigate",
+        false,
+        &RetryConfig::default(),
+        Vec::new(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn headless_subagent_calls_recorded_with_full_args_and_parent_call_id() {
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
+
+    let prompts = vec![long_prompt("first"), long_prompt("second")];
+    let model = MockCompletionModel::from_stream_turns(vec![
+        vec![
+            task_call_event("call-1", &prompts),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("done".to_string()),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ]);
+
+    let outcome = run_task_turn(model, 2)
+        .await
+        .expect("run_print should succeed against the fake model");
+
+    assert_eq!(outcome.tool_interactions.len(), 1);
+    let interaction = &outcome.tool_interactions[0];
+    assert_eq!(interaction.name, "task");
+    assert_eq!(
+        interaction
+            .subagent_calls
+            .iter()
+            .map(|c| (c.name.as_str(), c.args.clone()))
+            .collect::<Vec<_>>(),
+        prompts
+            .iter()
+            .map(|p| ("grep", serde_json::json!({ "pattern": p })))
+            .collect::<Vec<_>>(),
+        "every subagent tool call of the enclosing task call must be collected, \
+         in order and with complete args"
+    );
+
+    let mut session = Session::new("anthropic", "claude-test", 200_000, "");
+    record_turn_into_session(&mut session, "investigate", Ok(outcome))
+        .expect("recording a successful turn must not fail");
+
+    assert_eq!(
+        session.messages.iter().map(|m| m.role).collect::<Vec<_>>(),
+        vec![
+            MessageRole::User,
+            MessageRole::ToolCall,
+            MessageRole::SubagentToolCall,
+            MessageRole::SubagentToolCall,
+            MessageRole::ToolResult,
+            MessageRole::Assistant,
+        ],
+        "subagent calls belong between their task call and its result, the \
+         order they happened in"
+    );
+
+    let task_call_id = call_id_of(&session, 1);
+    for (offset, prompt) in prompts.iter().enumerate() {
+        let (parent_call_id, name, args) = subagent_record(&session, 2 + offset);
+        assert_eq!(parent_call_id, task_call_id);
+        assert_eq!(name, "grep");
+        assert_eq!(args, serde_json::json!({ "pattern": prompt }));
+        // The display summary in `content` is truncated at 200 chars
+        // (`format_tool_call_summary`); the structured field must not be.
+        assert!(
+            session.messages[2 + offset].content.len() < prompt.len(),
+            "content should be the truncated display summary, not the full args"
+        );
+    }
+}
+
+/// A subagent that makes more tool calls than the event channel can hold must
+/// not stall the turn: `run_print` has to keep draining while the `task` call
+/// is still running, not only once its result arrives. Without that, the
+/// sender blocks on a full channel with nobody reading it, the `task` tool
+/// never returns, and the run hangs — so this test's failure mode is the
+/// timeout, and it is the reason the drain is a `select!` arm rather than a
+/// sweep at the end of the call.
+#[tokio::test]
+async fn subagent_calls_beyond_the_channel_capacity_do_not_stall_the_turn() {
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
+
+    // Comfortably over the channel's capacity.
+    let prompts: Vec<String> = (0..200).map(|i| format!("prompt {i}")).collect();
+    let model = MockCompletionModel::from_stream_turns(vec![
+        vec![
+            task_call_event("call-1", &prompts),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("done".to_string()),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ]);
+
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), run_task_turn(model, 2))
+        .await
+        .expect("the turn must not stall on a full subagent event channel")
+        .expect("run_print should succeed against the fake model");
+
+    assert_eq!(outcome.tool_interactions.len(), 1);
+    assert_eq!(
+        outcome.tool_interactions[0]
+            .subagent_calls
+            .iter()
+            .map(|c| c.args["pattern"].as_str().unwrap_or_default().to_string())
+            .collect::<Vec<_>>(),
+        prompts,
+        "every subagent call must be collected, in order, however many there are"
+    );
+}
+
+/// The parent link is per call, not per turn: with two `task` calls in one
+/// turn, each subagent record points at the call it ran under.
+#[tokio::test]
+async fn subagent_calls_attribute_to_their_own_task_call() {
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
+
+    let first = vec!["first prompt".to_string()];
+    let second = vec!["second prompt".to_string()];
+    let model = MockCompletionModel::from_stream_turns(vec![
+        vec![
+            task_call_event("call-1", &first),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            task_call_event("call-2", &second),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("done".to_string()),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ]);
+
+    let outcome = run_task_turn(model, 3)
+        .await
+        .expect("run_print should succeed against the fake model");
+
+    assert_eq!(outcome.tool_interactions.len(), 2);
+    for (interaction, prompts) in outcome
+        .tool_interactions
+        .iter()
+        .zip([&first, &second].into_iter())
+    {
+        assert_eq!(interaction.subagent_calls.len(), 1);
+        assert_eq!(
+            interaction.subagent_calls[0].args,
+            serde_json::json!({ "pattern": prompts[0] }),
+            "a task call must collect only the subagent calls it spawned"
+        );
+    }
+
+    let mut session = Session::new("anthropic", "claude-test", 200_000, "");
+    record_turn_into_session(&mut session, "investigate", Ok(outcome))
+        .expect("recording a successful turn must not fail");
+
+    // User, (call, subagent call, result) x 2, assistant.
+    assert_eq!(session.messages.len(), 8);
+    let first_call_id = call_id_of(&session, 1);
+    let second_call_id = call_id_of(&session, 4);
+    assert_ne!(first_call_id, second_call_id);
+    assert_eq!(subagent_record(&session, 2).0, first_call_id);
+    assert_eq!(subagent_record(&session, 5).0, second_call_id);
+}

--- a/src/tests/headless_tool_record_tests.rs
+++ b/src/tests/headless_tool_record_tests.rs
@@ -114,10 +114,10 @@ fn record_turn_into_session(
 
 #[tokio::test]
 async fn headless_tool_call_recorded_with_full_args_independent_of_pure_stdout() {
-    // Under `--features hooks`, `run_print` consults the process-global Stop
-    // dispatcher; serialize against the test that installs one. No-op otherwise.
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    // `run_print` reaches process-global wiring (the hooks Stop dispatcher,
+    // the subagent event sender); serialize against every other `run_print`
+    // test so none of them clobber each other's.
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     let model = echo_call_model();
     let agent = AgentBuilder::new(model)
@@ -193,8 +193,7 @@ async fn headless_tool_call_recorded_with_full_args_independent_of_pure_stdout()
 
 #[tokio::test]
 async fn headless_mid_stream_error_after_tool_call_records_nothing() {
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     let model = echo_then_error_model();
     let agent = AgentBuilder::new(model)

--- a/src/tests/headless_tool_record_tests.rs
+++ b/src/tests/headless_tool_record_tests.rs
@@ -1,0 +1,232 @@
+//! E2e proof that a headless (`-p`) run persists structured tool call/result
+//! records into the session, independent of `--pure-stdout`, and that a
+//! turn ending in a mid-stream error persists nothing.
+//!
+//! Exercises the same `run_print` boundary as `resumed_history_tests.rs`
+//! (see that file's header for why the fake `CompletionModel` carrier is
+//! driven directly rather than through the full `dispatch_print` CLI
+//! plumbing) via [`record_turn_into_session`], which mirrors
+//! `dispatch_print`'s own recording sequence exactly: `?` on the
+//! `run_print` result (so a mid-stream `Err` never reaches the
+//! session-mutating code at all), then `add_message(User)`, one
+//! `add_tool_call`/`add_tool_result` pair per returned `ToolInteraction`,
+//! then `add_message(Assistant)`.
+
+use rig::agent::AgentBuilder;
+use rig::tool::Tool;
+use serde::Deserialize;
+
+use crate::agent::runner::{PrintOutcome, run_print};
+use crate::agent::tools::ToolError;
+use crate::retry::RetryConfig;
+use crate::session::{MessageRole, Session, ToolRecord};
+use crate::tests::fake_model::{FakeModel, MockCompletionModel, MockStreamEvent};
+
+#[derive(Debug, Deserialize)]
+struct EchoArgs {
+    text: String,
+}
+
+/// Minimal test-only tool: echoes its `text` argument back with a fixed
+/// prefix. Unlike `WriteTool` (used by `headless_ask_tests.rs`), it needs no
+/// permission/ask-channel plumbing: these tests only need a real call/result
+/// round trip through rig's own tool-execution machinery, since the mock
+/// model can script a `ToolCall` event but not the `ToolResult` that follows
+/// it — that comes from an actually registered `Tool` being invoked.
+struct EchoTool;
+
+impl Tool for EchoTool {
+    const NAME: &'static str = "echo";
+
+    type Error = ToolError;
+    type Args = EchoArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        "Echoes the given text back.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+            "required": ["text"]
+        })
+    }
+
+    async fn call(&self, args: EchoArgs) -> Result<String, ToolError> {
+        Ok(format!("echoed: {}", args.text))
+    }
+}
+
+/// Longer than `format_tool_call_summary`'s 200-char display truncation
+/// (`src/ui/utils.rs`), so a passing assertion on the structured `args`
+/// field proves it carries the complete value, not the truncated display
+/// summary that lands in `content`.
+fn long_arg_text() -> String {
+    "x".repeat(500)
+}
+
+fn echo_call_model() -> FakeModel {
+    MockCompletionModel::from_stream_turns(vec![
+        vec![
+            MockStreamEvent::tool_call(
+                "call-1",
+                "echo",
+                serde_json::json!({ "text": long_arg_text() }),
+            ),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("done".to_string()),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ])
+}
+
+fn echo_then_error_model() -> FakeModel {
+    MockCompletionModel::from_stream_turns(vec![
+        vec![
+            MockStreamEvent::tool_call("call-1", "echo", serde_json::json!({ "text": "x" })),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![MockStreamEvent::error("stream broke mid-turn")],
+    ])
+}
+
+/// Mirrors `dispatch_print`'s recording sequence (`src/startup.rs`) exactly,
+/// including the `?` that makes a mid-stream `Err` short-circuit before any
+/// session mutation.
+fn record_turn_into_session(
+    session: &mut Session,
+    prompt: &str,
+    result: anyhow::Result<PrintOutcome>,
+) -> anyhow::Result<()> {
+    let outcome = result?;
+    session.add_message(MessageRole::User, prompt);
+    for interaction in &outcome.tool_interactions {
+        let call_id = session.add_tool_call(&interaction.name, &interaction.args);
+        session.add_tool_result(call_id, &interaction.name, &interaction.output);
+    }
+    session.add_message(MessageRole::Assistant, &outcome.response);
+    Ok(())
+}
+
+#[tokio::test]
+async fn headless_tool_call_recorded_with_full_args_independent_of_pure_stdout() {
+    // Under `--features hooks`, `run_print` consults the process-global Stop
+    // dispatcher; serialize against the test that installs one. No-op otherwise.
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+
+    let model = echo_call_model();
+    let agent = AgentBuilder::new(model)
+        .tool(EchoTool)
+        .default_max_turns(2)
+        .build();
+
+    // `pure_stdout: false` — recording must not depend on stdout formatting
+    // being enabled (spec scenario "Headless run without --pure-stdout still
+    // records").
+    let outcome = run_print(
+        &agent,
+        "please echo",
+        false,
+        &RetryConfig::default(),
+        Vec::new(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await
+    .expect("run_print should succeed against the fake model");
+
+    assert_eq!(outcome.tool_interactions.len(), 1);
+    {
+        let interaction = &outcome.tool_interactions[0];
+        assert_eq!(interaction.name, "echo");
+        assert_eq!(
+            interaction.args,
+            serde_json::json!({ "text": long_arg_text() })
+        );
+        assert_eq!(interaction.output, format!("echoed: {}", long_arg_text()));
+    }
+
+    let mut session = Session::new("anthropic", "claude-test", 200_000, "");
+    record_turn_into_session(&mut session, "please echo", Ok(outcome))
+        .expect("recording a successful turn must not fail");
+
+    assert_eq!(session.messages.len(), 4);
+    assert_eq!(session.messages[0].role, MessageRole::User);
+    assert_eq!(session.messages[1].role, MessageRole::ToolCall);
+    assert_eq!(session.messages[2].role, MessageRole::ToolResult);
+    assert_eq!(session.messages[3].role, MessageRole::Assistant);
+
+    match &session.messages[1].tool {
+        Some(ToolRecord::Call { name, args, .. }) => {
+            assert_eq!(name.as_str(), "echo");
+            let expected_text = long_arg_text();
+            assert_eq!(args, &serde_json::json!({ "text": expected_text }));
+            // The display summary in `content` is truncated at 200 chars
+            // (`format_tool_call_summary`); the structured field must not be.
+            assert!(
+                session.messages[1].content.len() < expected_text.len(),
+                "content should be the truncated display summary, not the full args"
+            );
+        }
+        other => panic!("expected a Call record, got {other:?}"),
+    }
+
+    match &session.messages[2].tool {
+        Some(ToolRecord::Result {
+            call_id,
+            name,
+            truncated,
+            ..
+        }) => {
+            assert_eq!(*call_id, 0);
+            assert_eq!(name.as_str(), "echo");
+            assert!(!truncated);
+        }
+        other => panic!("expected a Result record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn headless_mid_stream_error_after_tool_call_records_nothing() {
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+
+    let model = echo_then_error_model();
+    let agent = AgentBuilder::new(model)
+        .tool(EchoTool)
+        .default_max_turns(2)
+        .build();
+
+    let response_result = run_print(
+        &agent,
+        "please echo",
+        false,
+        &RetryConfig::default(),
+        Vec::new(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await;
+
+    assert!(
+        response_result.is_err(),
+        "a mid-stream error after a completed tool call must surface as Err, \
+         not a partial Ok that would let a truncated turn get persisted"
+    );
+
+    let mut session = Session::new("anthropic", "claude-test", 200_000, "");
+    let record_result = record_turn_into_session(&mut session, "please echo", response_result);
+
+    assert!(record_result.is_err());
+    assert_eq!(
+        session.messages.len(),
+        0,
+        "a turn that fails mid-stream must not add any messages, including \
+         the tool call that already completed before the failure"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -34,6 +34,8 @@ mod feed_tests;
 mod grep_tests;
 #[cfg(test)]
 mod headless_ask_tests;
+#[cfg(test)]
+mod headless_tool_record_tests;
 #[cfg(all(test, feature = "hooks"))]
 mod hooks;
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -34,6 +34,8 @@ mod feed_tests;
 mod grep_tests;
 #[cfg(test)]
 mod headless_ask_tests;
+#[cfg(all(test, feature = "subagents"))]
+mod headless_subagent_record_tests;
 #[cfg(test)]
 mod headless_tool_record_tests;
 #[cfg(all(test, feature = "hooks"))]

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -142,6 +142,7 @@ fn serialize_single_user_message() {
         role: MessageRole::User,
         content: CompactString::new("hello"),
         estimated_tokens: 1,
+        tool: None,
     }];
     let result = serialize_conversation(&msgs);
     assert!(result.contains("[User]: hello"));
@@ -154,16 +155,19 @@ fn serialize_multiple_roles() {
             role: MessageRole::User,
             content: CompactString::new("hi"),
             estimated_tokens: 1,
+            tool: None,
         },
         SessionMessage {
             role: MessageRole::Assistant,
             content: CompactString::new("hey"),
             estimated_tokens: 1,
+            tool: None,
         },
         SessionMessage {
             role: MessageRole::System,
             content: CompactString::new("note"),
             estimated_tokens: 1,
+            tool: None,
         },
     ];
     let result = serialize_conversation(&msgs);

--- a/src/tests/resumed_history_tests.rs
+++ b/src/tests/resumed_history_tests.rs
@@ -31,10 +31,10 @@ async fn resumed_session_history_reaches_model_initial_turn() {
     let model = text_chunks(["got it"]);
     let agent = AgentBuilder::new(model.clone()).build();
 
-    // Under `--features hooks`, `run_print` consults the process-global Stop
-    // dispatcher; serialize against the test that installs one. No-op otherwise.
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    // `run_print` reaches process-global wiring (the hooks Stop dispatcher,
+    // the subagent event sender); serialize against every other `run_print`
+    // test so none of them clobber each other's.
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     // Mirrors `dispatch_print`'s own `convert_history(&self.session)` call:
     // this is the `-p --continue` code path being exercised end to end.
@@ -75,10 +75,10 @@ async fn resumed_session_tool_messages_replay_as_tagged_history_entries() {
     let model = text_chunks(["got it"]);
     let agent = AgentBuilder::new(model.clone()).build();
 
-    // Under `--features hooks`, `run_print` consults the process-global Stop
-    // dispatcher; serialize against the test that installs one. No-op otherwise.
-    #[cfg(feature = "hooks")]
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    // `run_print` reaches process-global wiring (the hooks Stop dispatcher,
+    // the subagent event sender); serialize against every other `run_print`
+    // test so none of them clobber each other's.
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     let _outcome = run_print(
         &agent,
@@ -129,7 +129,7 @@ async fn resumed_session_history_survives_stop_hook_continuation() {
     // Installs a process-global Stop hook below; the guard serializes against
     // other `run_print` tests and clears the dispatcher when it drops, so the
     // hook can't leak into them.
-    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+    let _run_print_guard = crate::tests::fake_model::run_print_guard::acquire();
 
     let session = resumed_session();
     let expected_history = convert_history(&session);

--- a/src/tests/resumed_history_tests.rs
+++ b/src/tests/resumed_history_tests.rs
@@ -38,7 +38,7 @@ async fn resumed_session_history_reaches_model_initial_turn() {
 
     // Mirrors `dispatch_print`'s own `convert_history(&self.session)` call:
     // this is the `-p --continue` code path being exercised end to end.
-    let (_response, _usage) = run_print(
+    let _outcome = run_print(
         &agent,
         "continue",
         false,
@@ -55,6 +55,60 @@ async fn resumed_session_history_reaches_model_initial_turn() {
         observed_history, expected_history,
         "run_print must forward the resumed session's prior messages to the \
          model as history on the initial stream_chat call"
+    );
+}
+
+// 2.7: now that headless sessions can contain tool call/result messages
+// (this section's addition), `-p --continue` must replay them through the
+// same `convert_history` interactive resume already uses. `convert_history`
+// itself is untouched (design.md decision 7, "replay alignment is accepted,
+// not worked around"); this proves the existing `[ToolCall]:`/`[ToolResult]:`
+// tagging actually reaches the model at the `run_print` boundary once a
+// resumed session has tool messages to replay, not just in isolation.
+#[tokio::test]
+async fn resumed_session_tool_messages_replay_as_tagged_history_entries() {
+    let mut session = resumed_session();
+    let call_id = session.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
+    session.add_tool_result(call_id, "read", "file contents");
+    let expected_history = convert_history(&session);
+
+    let model = text_chunks(["got it"]);
+    let agent = AgentBuilder::new(model.clone()).build();
+
+    // Under `--features hooks`, `run_print` consults the process-global Stop
+    // dispatcher; serialize against the test that installs one. No-op otherwise.
+    #[cfg(feature = "hooks")]
+    let _dispatcher_guard = crate::tests::fake_model::dispatcher_guard::acquire();
+
+    let _outcome = run_print(
+        &agent,
+        "continue",
+        false,
+        &RetryConfig::default(),
+        expected_history.clone(),
+        #[cfg(feature = "hooks")]
+        None,
+    )
+    .await
+    .expect("run_print should succeed against the fake model");
+
+    let observed_history = history_at(&model, 0);
+    assert_eq!(
+        observed_history, expected_history,
+        "run_print must forward the resumed session's tool messages to the \
+         model as history, exactly as it does for plain user/assistant turns"
+    );
+
+    let rendered = format!("{observed_history:?}");
+    assert!(
+        rendered.contains("[ToolCall]:"),
+        "resumed history must carry a [ToolCall] entry for the replayed tool \
+         call, rendered: {rendered}"
+    );
+    assert!(
+        rendered.contains("[ToolResult]:"),
+        "resumed history must carry a [ToolResult] entry for the replayed \
+         tool result, rendered: {rendered}"
     );
 }
 
@@ -112,7 +166,7 @@ async fn resumed_session_history_survives_stop_hook_continuation() {
     );
     init_dispatcher(HookDispatcher::from_config(&config).unwrap());
 
-    let (response, _usage) = run_print(
+    let outcome = run_print(
         &agent,
         "continue",
         false,
@@ -124,7 +178,7 @@ async fn resumed_session_history_survives_stop_hook_continuation() {
     .expect("run_print should succeed against the fake model");
 
     assert_eq!(
-        response, "partial answerfinal answer",
+        outcome.response, "partial answerfinal answer",
         "the Stop-forced continuation must run to completion and the returned \
          response must keep both turns' text (the first turn was already \
          streamed to stdout), not just the second turn's"

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -96,7 +96,11 @@ fn save_session_preserves_tool_messages() {
     s.add_message(MessageRole::User, "question");
     let call_id = s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
     s.add_tool_result(call_id, "read", "file contents");
-    s.add_subagent_tool_call("task", &serde_json::json!({ "prompts": ["find x"] }));
+    s.add_subagent_tool_call(
+        Some(call_id),
+        "task",
+        &serde_json::json!({ "prompts": ["find x"] }),
+    );
     s.add_message(MessageRole::Assistant, "answer");
     save_session(&s).unwrap();
 
@@ -263,6 +267,94 @@ fn tool_record_round_trips_through_json() {
         }
         other => panic!("expected ToolRecord::Result round-trip, got {other:?}"),
     }
+}
+
+#[cfg(any(feature = "subagents", feature = "acp"))]
+#[test]
+fn subagent_tool_call_links_to_the_enclosing_task_call() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000, "");
+    let call_id = s.add_tool_call("task", &serde_json::json!({ "prompts": ["find x"] }));
+    s.add_subagent_tool_call(
+        Some(call_id),
+        "grep",
+        &serde_json::json!({ "pattern": "fn x" }),
+    );
+    s.add_tool_result(call_id, "task", "found it");
+
+    assert_eq!(s.messages[1].role, MessageRole::SubagentToolCall);
+    match s.messages[1].tool.clone().expect("subagent call record") {
+        ToolRecord::SubagentCall {
+            parent_call_id,
+            name,
+            args,
+        } => {
+            assert_eq!(parent_call_id, call_id);
+            assert_eq!(name, "grep");
+            assert_eq!(args, serde_json::json!({ "pattern": "fn x" }));
+        }
+        other => panic!("expected ToolRecord::SubagentCall, got {other:?}"),
+    }
+    drop(env);
+}
+
+/// The linkage is never faked: with no enclosing call id to point at, the
+/// message keeps its display summary and simply carries no structured
+/// record, rather than claiming a parent it does not have.
+#[cfg(any(feature = "subagents", feature = "acp"))]
+#[test]
+fn subagent_tool_call_without_a_parent_records_no_structured_record() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000, "");
+    s.add_subagent_tool_call(None, "grep", &serde_json::json!({ "pattern": "fn x" }));
+
+    assert_eq!(s.messages[0].role, MessageRole::SubagentToolCall);
+    assert!(s.messages[0].tool.is_none());
+    assert!(s.messages[0].content.contains("grep"));
+    drop(env);
+}
+
+/// `ToolRecord` is `#[serde(untagged)]`, so a subagent record must stay
+/// structurally distinguishable from a plain `Call`: it carries
+/// `parent_call_id` and deliberately no `id`, otherwise serde would resolve
+/// its JSON to the `Call` variant listed first.
+#[cfg(any(feature = "subagents", feature = "acp"))]
+#[test]
+fn subagent_tool_record_round_trips_without_colliding_with_call() {
+    let subagent = ToolRecord::SubagentCall {
+        parent_call_id: 3,
+        name: "grep".into(),
+        args: serde_json::json!({ "pattern": "fn x" }),
+    };
+    let json = serde_json::to_value(&subagent).unwrap();
+    assert_eq!(json["parent_call_id"], 3);
+    assert!(json.get("id").is_none());
+    assert!(json.get("call_id").is_none());
+    match serde_json::from_value::<ToolRecord>(json).unwrap() {
+        ToolRecord::SubagentCall {
+            parent_call_id,
+            name,
+            args,
+        } => {
+            assert_eq!(parent_call_id, 3);
+            assert_eq!(name, "grep");
+            assert_eq!(args, serde_json::json!({ "pattern": "fn x" }));
+        }
+        other => panic!("expected ToolRecord::SubagentCall round-trip, got {other:?}"),
+    }
+
+    // The reverse direction: a main-agent call must not be swallowed by the
+    // subagent variant either.
+    let call_json = serde_json::to_value(ToolRecord::Call {
+        id: 3,
+        name: "task".into(),
+        args: serde_json::json!({ "prompts": ["find x"] }),
+    })
+    .unwrap();
+    assert!(matches!(
+        serde_json::from_value::<ToolRecord>(call_json).unwrap(),
+        ToolRecord::Call { .. }
+    ));
 }
 
 #[test]

--- a/src/tests/session_storage_tests.rs
+++ b/src/tests/session_storage_tests.rs
@@ -1,5 +1,6 @@
 use crate::session::MessageRole;
 use crate::session::Session;
+use crate::session::ToolRecord;
 use crate::session::storage::{
     delete_session, find_sessions_by_prefix, load_suffix, save_session, suffix_path,
 };
@@ -93,8 +94,8 @@ fn save_session_preserves_tool_messages() {
     let env = setup_test_env();
     let mut s = Session::new("anthropic", "claude", 200000, "");
     s.add_message(MessageRole::User, "question");
-    s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
-    s.add_tool_result("read", "file contents");
+    let call_id = s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
+    s.add_tool_result(call_id, "read", "file contents");
     s.add_subagent_tool_call("task", &serde_json::json!({ "prompts": ["find x"] }));
     s.add_message(MessageRole::Assistant, "answer");
     save_session(&s).unwrap();
@@ -120,7 +121,7 @@ fn long_tool_result_is_saved_and_truncated_in_session() {
     let tail = "T".repeat(TOOL_RESULT_TAIL_CHARS);
     let output = format!("{head}{omitted}{tail}");
 
-    let returned = s.add_tool_result("bash/unsafe", &output);
+    let returned = s.add_tool_result(0, "bash/unsafe", &output);
 
     let content = s.messages[0].content.as_str();
     assert_eq!(returned, content);
@@ -154,13 +155,141 @@ fn long_tool_result_save_failure_keeps_full_output() {
 
     let mut s = Session::new("anthropic", "claude", 200000, "");
     let output = "x".repeat(TOOL_RESULT_SAVE_THRESHOLD + 1);
-    s.add_tool_result("bash", &output);
+    s.add_tool_result(0, "bash", &output);
 
     let content = s.messages[0].content.as_str();
     assert!(content.contains(&output));
     assert!(content.contains("failed to save long tool output separately"));
     let _ = std::fs::remove_file(path);
     drop(lock);
+}
+
+#[test]
+fn tool_call_and_result_link_by_id() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000, "");
+    let call_id = s.add_tool_call("read", &serde_json::json!({ "path": "src/main.rs" }));
+    s.add_tool_result(call_id, "read", "file contents");
+
+    match s.messages[0].tool.clone().expect("call record") {
+        ToolRecord::Call { id, name, args } => {
+            assert_eq!(id, call_id);
+            assert_eq!(name, "read");
+            assert_eq!(args, serde_json::json!({ "path": "src/main.rs" }));
+        }
+        other => panic!("expected ToolRecord::Call, got {other:?}"),
+    }
+    match s.messages[1].tool.clone().expect("result record") {
+        ToolRecord::Result {
+            call_id: linked,
+            name,
+            truncated,
+            full_output_path,
+        } => {
+            assert_eq!(linked, call_id);
+            assert_eq!(name, "read");
+            assert!(!truncated);
+            assert!(full_output_path.is_none());
+        }
+        other => panic!("expected ToolRecord::Result, got {other:?}"),
+    }
+    drop(env);
+}
+
+#[test]
+fn oversized_tool_result_has_truncated_record_with_overflow_path() {
+    let env = setup_test_env();
+    let mut s = Session::new("anthropic", "claude", 200000, "");
+    let call_id = s.add_tool_call("bash", &serde_json::json!({ "command": "ls" }));
+    let output = "x".repeat(TOOL_RESULT_SAVE_THRESHOLD + 1);
+    s.add_tool_result(call_id, "bash", &output);
+
+    match s.messages[1].tool.clone().expect("result record") {
+        ToolRecord::Result {
+            call_id: linked,
+            truncated,
+            full_output_path,
+            ..
+        } => {
+            assert_eq!(linked, call_id);
+            assert!(truncated);
+            let path = full_output_path.expect("overflow path recorded");
+            assert!(Path::new(path.as_str()).starts_with(&env.dir));
+            assert_eq!(std::fs::read_to_string(path.as_str()).unwrap(), output);
+        }
+        other => panic!("expected ToolRecord::Result, got {other:?}"),
+    }
+    drop(env);
+}
+
+#[test]
+fn tool_record_round_trips_through_json() {
+    let call = ToolRecord::Call {
+        id: 7,
+        name: "read".into(),
+        args: serde_json::json!({ "path": "a.rs" }),
+    };
+    let call_json = serde_json::to_value(&call).unwrap();
+    assert_eq!(call_json["id"], 7);
+    assert!(call_json.get("call_id").is_none());
+    match serde_json::from_value::<ToolRecord>(call_json).unwrap() {
+        ToolRecord::Call { id, name, args } => {
+            assert_eq!(id, 7);
+            assert_eq!(name, "read");
+            assert_eq!(args, serde_json::json!({ "path": "a.rs" }));
+        }
+        other => panic!("expected ToolRecord::Call round-trip, got {other:?}"),
+    }
+
+    let result = ToolRecord::Result {
+        call_id: 7,
+        name: "read".into(),
+        truncated: true,
+        full_output_path: Some("/tmp/out.txt".into()),
+    };
+    let result_json = serde_json::to_value(&result).unwrap();
+    assert_eq!(result_json["call_id"], 7);
+    assert!(result_json.get("id").is_none());
+    match serde_json::from_value::<ToolRecord>(result_json).unwrap() {
+        ToolRecord::Result {
+            call_id,
+            truncated,
+            full_output_path,
+            ..
+        } => {
+            assert_eq!(call_id, 7);
+            assert!(truncated);
+            assert_eq!(full_output_path.as_deref(), Some("/tmp/out.txt"));
+        }
+        other => panic!("expected ToolRecord::Result round-trip, got {other:?}"),
+    }
+}
+
+#[test]
+fn old_session_file_without_tool_records_loads_with_tool_none() {
+    let json = r#"{
+        "id": "legacy-session",
+        "name": "old session",
+        "messages": [
+            { "role": "user", "content": "hi", "estimated_tokens": 1 },
+            { "role": "tool_call", "content": "read: src/main.rs", "estimated_tokens": 3 }
+        ],
+        "compactions": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "total_cost": 0.0,
+        "total_estimated_tokens": 4,
+        "context_window": 128000,
+        "model": "gpt-4",
+        "provider": "openai",
+        "working_dir": "/tmp"
+    }"#;
+
+    let session: Session = serde_json::from_str(json).expect("old session file loads");
+    assert_eq!(session.messages.len(), 2);
+    assert!(session.messages[0].tool.is_none());
+    assert!(session.messages[1].tool.is_none());
+    assert_eq!(session.next_tool_call_id, 0);
 }
 
 #[test]

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -106,7 +106,7 @@ pub async fn handle_agent_event(
             }
             run.response_buf.clear();
             run.response_start_block = None;
-            ui.session.add_tool_call(&name, &args);
+            run.pending_tool_call_id = Some(ui.session.add_tool_call(&name, &args));
             save_session_if_enabled(ui.session, ui.cli, renderer)?;
             let line = format!(
                 "◈ {}",
@@ -125,7 +125,15 @@ pub async fn handle_agent_event(
             renderer.write_line(&sanitize_output(&line), C_TOOL)?;
         }
         AgentEvent::ToolResult { name, output } => {
-            ui.session.add_tool_result(&name, &output);
+            let call_id = run.pending_tool_call_id.take().unwrap_or_else(|| {
+                tracing::warn!(
+                    "ToolResult for {name} arrived with no pending ToolCall id; \
+                     linking to 0 (the agent event stream is expected to be strictly \
+                     sequential, so this should not happen)"
+                );
+                0
+            });
+            ui.session.add_tool_result(call_id, &name, &output);
             save_session_if_enabled(ui.session, ui.cli, renderer)?;
             if name == "todo_write" {
                 let list = TODO_LIST.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -116,7 +116,15 @@ pub async fn handle_agent_event(
         }
         #[cfg(any(feature = "subagents", feature = "acp"))]
         AgentEvent::SubagentToolCall { name, args } => {
-            ui.session.add_subagent_tool_call(&name, &args);
+            // Peeked, not taken: the enclosing `task` call's `ToolResult` is
+            // still to come and owns the consuming `take()`. Subagent events
+            // are sent from the task the `task` tool spawned, but they reach
+            // this handler through the same mpsc channel as the main agent's
+            // own events, and the subagent finishes before the `task` tool
+            // returns — so they always arrive between that call's `ToolCall`
+            // and `ToolResult`, with its id still pending here.
+            ui.session
+                .add_subagent_tool_call(run.pending_tool_call_id, &name, &args);
             save_session_if_enabled(ui.session, ui.cli, renderer)?;
             let line = format!(
                 "⌥ {}",

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -140,6 +140,14 @@ pub(crate) struct AgentRunState {
     pub was_reasoning: bool,
     pub turn_trace: Vec<compact_str::CompactString>,
     pub awaiting_compaction_relief: bool,
+    /// The id `Session::add_tool_call` stamped for the most recent `ToolCall`
+    /// event, held until the matching `ToolResult` event consumes it via
+    /// `Session::add_tool_result`. The agent event stream is strictly
+    /// sequential (one tool call's result always arrives before the next
+    /// call starts — see design.md's single-threaded-execution finding), so a
+    /// single pending slot is sufficient; it never needs to hold more than
+    /// one id at a time.
+    pub pending_tool_call_id: Option<u64>,
 }
 
 /// What happens when the current run finishes: chained prompts, dot-prompt


### PR DESCRIPTION
Closes #229

## What this does

Adds a structured, machine readable `tool` field to session messages (`SessionMessage.tool: Option<ToolRecord>`) and records it identically from the TUI and the headless `-p` path, covering main agent tool calls, tool results, and subagent tool calls.

- `Session` gains a persisted `next_tool_call_id` counter. `add_tool_call` stamps and returns a per session id and stores `ToolRecord::Call { id, name, args }` with the complete, untruncated argument JSON, alongside the existing display summary in `content`. `add_tool_result` now takes the matching `call_id` and stores `ToolRecord::Result { call_id, name, truncated, full_output_path }`; the result text itself stays only in `content`, governed by the existing 12,000 char threshold and overflow file mechanism, nothing is duplicated.
- Linking a result to its call by id, not position, matters once other messages interleave between them, for example a subagent event landing between an outer `task` call and its result.
- TUI call sites (`event_handler.rs`) thread the id through a single `pending_tool_call_id` slot on `AgentRunState`, since the agent event stream processes one tool call/result pair at a time.
- `run_print` (the headless path) now collects the turn's tool call/result round trips unconditionally, name, complete args JSON, and output text, and returns them alongside the response and usage in a new `PrintOutcome` struct. This is independent of `--pure-stdout` (which only ever controlled what got printed to stdout, never what got saved) and of the `hooks` feature's own `tool_interactions` vector, which stays separate since it carries the raw `rig::Message` type needed only for Stop hook continuation replay.
- `dispatch_print`, which owns the `Session`, appends each returned interaction as an `add_tool_call` plus `add_tool_result` pair before the assistant message. This happens after the same `?` that already discards a mid stream error's partial response, so a failed turn adds zero messages, consistent with the existing behavior of never persisting a partial assistant turn.
- Subagent tool calls (behind the existing `subagents`/`acp` gates): a `task` call's subagent activity is recorded as `subagent_tool_call` messages carrying `ToolRecord::SubagentCall { parent_call_id, name, args }`, where `parent_call_id` points at the enclosing `task` call's id. In the TUI this peeks the same `pending_tool_call_id` slot (without consuming it). In headless, `run_print` publishes a sender for the existing `SubagentToolCall` event channel and drains it inside its stream loop with a biased `tokio::select!` plus a `try_recv` sweep in the `ToolResult` arm. Draining in the loop is required, not just convenient: the channel is bounded (capacity 32), and while a `task` call runs the consumer would otherwise be parked on the stream, so a chatty subagent would block its sender forever and hang the turn. A regression test drives 200 subagent calls through the real loop to pin this.
- When a subagent event has no enclosing call id to attach to, the record degrades to the pre existing summary only message rather than fabricating a link.
- `dispatch_loop` (the `--loop` headless path) is adapted to compile against the new return type only. `--loop` has no `Session` to record into today (see the `TODO(loop-history)` comment already in that file), so its tool interactions are read and discarded, not recorded; that is a separate, larger change.
- Old session files load unchanged (`tool: None` via `#[serde(default)]`).

## Why

A headless `-p` run previously wrote only the user prompt and final assistant text to its session file. Every tool call and result from that turn was invisible outside the terminal, and only visible there at all under `--pure-stdout`; subagent activity was invisible everywhere, since its event channel was only consumed by the TUI. The TUI path already recorded tool activity, but only as a display summary (truncated at 200 chars, no reliable boundary between tool name and arguments), so even the TUI's session file had no structured record of what a tool was actually called with. This closes those gaps: full argument fidelity in both paths, headless `-p` sessions now carry the same tool level record the TUI does, and subagent tool calls are attributable to the `task` call that spawned them.

One further, deliberate behavior change falls out of this: once headless sessions contain tool messages, `-p --continue` replays them through `convert_history`'s existing `[ToolCall]`/`[ToolResult]` tagging (untouched by this PR), so a resumed headless turn now sees prior tool activity, matching what a resumed TUI session already shows the model.

## Out of scope

- Subagent tool results: no event exists for them today (`run_subagent` forwards tool calls and drops results), so recording them would need a new event type first; left for its own change.
- `--loop` recording (no `Session` in that path).
- Any change to stdout output, the `◈` format, or `--pure-stdout` semantics.

## Tests

- New unit tests for the schema: id/call_id linkage, the truncated flag and overflow path on an oversized result, untagged round trips for all three `ToolRecord` variants, and an old session file loading with `tool: None`.
- New e2e tests at the `run_print` boundary (a fake `CompletionModel` carrier, no live model calls): a headless tool call is recorded with full untruncated args regardless of `--pure-stdout`; a turn that fails mid stream after a completed tool call records nothing; subagent calls are recorded with the right `parent_call_id`; and the 200 call channel capacity regression described above.
- A further `resumed_history_tests.rs` case proves a resumed session's tool messages replay through `convert_history` at this same boundary, not just in isolation.
- `just check` (fmt plus clippy, all targets, all features) and `cargo test --all-features` are both green (920 tests); `cargo test --features subagents` passes 703.

## LoC breakdown

Logic (production code): 341 insertions, 50 deletions, of which roughly 73 lines are explanatory comments on the channel draining and untagged enum constraints
Tests: 862 insertions, 40 deletions
Docs: 1 line corrected in `docs/SUBAGENTS.md`
Total: 18 files changed, 1204 insertions, 91 deletions
