### PR TITLE
feat: configurable semantic role colors in themes and config

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -652,6 +652,12 @@ Controls the terminal color escape sequences emitted. Two values:
 - `chat_background` — background color for the main conversation buffer.
 - `input_background` — background color for the text input area.
 - `status_background` — background color for the status bar (lowest line).
+- `roles` — map of semantic role → color, overriding the default palette for
+  conversation blocks. Known roles: `user`, `agent`, `reasoning`, `tool`,
+  `tool_result`, `error`, `system`, `welcome`, `permission`, `plain`. Unknown
+  roles and unparsable colors are ignored with a warning. Roles work in theme
+  files too (same `colors` object); a theme without a `roles` map restores
+  the default palette.
 
 Supported named colors: `reset`, `black`, `red`, `green`, `yellow`, `blue`,
 `magenta`, `cyan`, `white`, `grey`, `dark_grey`, `dark_red`, `dark_green`,
@@ -664,7 +670,13 @@ Example:
     "scheme_type": "full",
     "chat_background": "#1e1e2e",
     "input_background": "#181825",
-    "status_background": "#11111b"
+    "status_background": "#11111b",
+    "roles": {
+      "agent": "#cdd6f4",
+      "error": "#f38ba8",
+      "tool": "#f9e2af",
+      "permission": "#cba6f7"
+    }
   }
 }
 ```

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -144,6 +144,11 @@ pub struct ColorsConfig {
     pub chat_background: Option<CompactString>,
     pub input_background: Option<CompactString>,
     pub status_background: Option<CompactString>,
+    /// Semantic role → color overrides, e.g. `{ "agent": "white",
+    /// "error": "#ff5555", "tool": "yellow", "permission": "magenta" }`.
+    /// Known roles: user, agent, reasoning, tool, tool_result, error,
+    /// system, welcome, permission, plain.
+    pub roles: Option<HashMap<String, String>>,
     #[serde(default)]
     pub scheme_type: SchemeType,
 }

--- a/src/context/themes.rs
+++ b/src/context/themes.rs
@@ -62,5 +62,11 @@ pub fn apply(content: &str, renderer: &mut Renderer) {
         } else {
             renderer.set_background_colors(chat_bg, input_bg, status_bg);
         }
+        // Semantic role colors: a theme without a `roles` map restores the
+        // default palette so switching themes drops the previous roles.
+        match &colors.roles {
+            Some(roles) => crate::ui::roles::apply(roles),
+            None => crate::ui::roles::reset(),
+        }
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -114,6 +114,11 @@ impl<'a> App<'a> {
             } else {
                 renderer.set_background_colors(chat_bg, input_bg, status_bg);
             }
+            // Semantic role colors from `[colors.roles]`, same as themes.
+            match &colors.roles {
+                Some(roles) => crate::ui::roles::apply(roles),
+                None => crate::ui::roles::reset(),
+            }
         }
 
         let mut input = InputEditor::new();

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -5,13 +5,13 @@ use crossterm::style::Color;
 
 use super::markdown::{markdown_to_styled, word_wrap};
 use super::renderer::LineEntry;
-use super::{C_AGENT, C_ERROR, C_PERM, C_TOOL};
 
 /// Semantic role of a conversation block in the feed.
 ///
 /// Roles are independent of terminal colors; `BlockStyle::color()` maps each
-/// role to the color used by the custom renderer.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// role to a color, honoring `[colors.roles]` overrides from the active
+/// theme or config (see `ui::roles`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BlockStyle {
     User,
     Agent,
@@ -26,19 +26,10 @@ pub enum BlockStyle {
 }
 
 impl BlockStyle {
+    /// The color this role renders in, honoring `[colors.roles]` overrides
+    /// from the active theme or config (see `ui::roles`).
     pub fn color(self) -> Color {
-        match self {
-            BlockStyle::User => Color::Green,
-            BlockStyle::Agent => C_AGENT,
-            BlockStyle::Reasoning => Color::DarkMagenta,
-            BlockStyle::Tool => C_TOOL,
-            BlockStyle::ToolResult => Color::DarkGrey,
-            BlockStyle::Error => C_ERROR,
-            BlockStyle::System => Color::DarkGrey,
-            BlockStyle::Welcome => Color::Cyan,
-            BlockStyle::Permission => C_PERM,
-            BlockStyle::Plain => Color::White,
-        }
+        super::roles::color(self)
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod markdown;
 mod permission_handler;
 pub(crate) mod pickers;
 pub(crate) mod renderer;
+pub(crate) mod roles;
 pub(crate) mod slash;
 pub(crate) mod state;
 pub(crate) mod statusline;

--- a/src/ui/roles.rs
+++ b/src/ui/roles.rs
@@ -1,0 +1,139 @@
+//! Configurable semantic role colors.
+//!
+//! Every feed block has a semantic [`BlockStyle`] (agent, error, tool,
+//! permission, …). Historically each role mapped to a hardcoded color; this
+//! module holds the optional overrides coming from a theme's or the config's
+//! `[colors.roles]` map. Overrides are global process state, matching the
+//! project's other one-shot UI settings (statusline, edit system, …), and
+//! are applied/reset whenever a theme is selected so switching themes drops
+//! the previous theme's roles.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crossterm::style::Color;
+
+use super::feed::BlockStyle;
+use super::utils::parse_color;
+use super::{C_AGENT, C_ERROR, C_PERM, C_TOOL};
+
+static ROLE_OVERRIDES: RwLock<Option<HashMap<BlockStyle, Color>>> = RwLock::new(None);
+
+/// The built-in palette, used for any role without a configured override.
+pub(crate) fn default_color(role: BlockStyle) -> Color {
+    match role {
+        BlockStyle::User => Color::Green,
+        BlockStyle::Agent => C_AGENT,
+        BlockStyle::Reasoning => Color::DarkMagenta,
+        BlockStyle::Tool => C_TOOL,
+        BlockStyle::ToolResult => Color::DarkGrey,
+        BlockStyle::Error => C_ERROR,
+        BlockStyle::System => Color::DarkGrey,
+        BlockStyle::Welcome => Color::Cyan,
+        BlockStyle::Permission => C_PERM,
+        BlockStyle::Plain => Color::White,
+    }
+}
+
+/// The color a role renders in: the configured override when one was applied
+/// by the current theme/config, otherwise [`default_color`].
+pub(crate) fn color(role: BlockStyle) -> Color {
+    ROLE_OVERRIDES
+        .read()
+        .ok()
+        .and_then(|guard| guard.as_ref().and_then(|m| m.get(&role).copied()))
+        .unwrap_or_else(|| default_color(role))
+}
+
+/// Map a `[colors.roles]` key to its semantic role. Accepts the plain names
+/// (`tool_result` also as `toolresult`, `tool-result`).
+fn role_from_name(name: &str) -> Option<BlockStyle> {
+    match name.trim().to_lowercase().as_str() {
+        "user" => Some(BlockStyle::User),
+        "agent" => Some(BlockStyle::Agent),
+        "reasoning" => Some(BlockStyle::Reasoning),
+        "tool" => Some(BlockStyle::Tool),
+        "tool_result" | "toolresult" | "tool-result" => Some(BlockStyle::ToolResult),
+        "error" => Some(BlockStyle::Error),
+        "system" => Some(BlockStyle::System),
+        "welcome" => Some(BlockStyle::Welcome),
+        "permission" => Some(BlockStyle::Permission),
+        "plain" => Some(BlockStyle::Plain),
+        _ => None,
+    }
+}
+
+/// Apply a `[colors.roles]` map from a theme or the config: reset to the
+/// default palette, then apply each known role with a parsable color.
+/// Unknown role names and unparsable colors are skipped with a warning so a
+/// typo never breaks rendering.
+pub(crate) fn apply(roles: &HashMap<String, String>) {
+    let mut overrides = HashMap::new();
+    for (name, value) in roles {
+        match role_from_name(name) {
+            Some(role) => match parse_color(value) {
+                Some(color) => {
+                    overrides.insert(role, color);
+                }
+                None => {
+                    tracing::warn!("ignoring unparsable color '{value}' for role '{name}'");
+                }
+            },
+            None => {
+                tracing::warn!("ignoring unknown color role '{name}'");
+            }
+        }
+    }
+    if let Ok(mut guard) = ROLE_OVERRIDES.write() {
+        *guard = Some(overrides);
+    }
+}
+
+/// Drop all overrides (a theme/config without a `roles` map restores the
+/// default palette).
+pub(crate) fn reset() {
+    if let Ok(mut guard) = ROLE_OVERRIDES.write() {
+        *guard = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_names_resolve() {
+        assert_eq!(role_from_name("agent"), Some(BlockStyle::Agent));
+        assert_eq!(role_from_name("TOOL_RESULT"), Some(BlockStyle::ToolResult));
+        assert_eq!(role_from_name("permission"), Some(BlockStyle::Permission));
+        assert_eq!(role_from_name("nope"), None);
+    }
+
+    #[test]
+    fn overrides_apply_and_reset() {
+        reset();
+        assert_eq!(color(BlockStyle::Tool), default_color(BlockStyle::Tool));
+
+        let mut roles = HashMap::new();
+        roles.insert("tool".to_string(), "#ff5555".to_string());
+        roles.insert("error".to_string(), "blue".to_string());
+        roles.insert("bogus".to_string(), "red".to_string());
+        roles.insert("agent".to_string(), "not-a-color".to_string());
+        apply(&roles);
+
+        assert_eq!(
+            color(BlockStyle::Tool),
+            Color::Rgb {
+                r: 0xff,
+                g: 0x55,
+                b: 0x55
+            }
+        );
+        assert_eq!(color(BlockStyle::Error), Color::Blue);
+        // Unknown role / bad color leave the defaults in place.
+        assert_eq!(color(BlockStyle::Agent), default_color(BlockStyle::Agent));
+
+        reset();
+        assert_eq!(color(BlockStyle::Tool), default_color(BlockStyle::Tool));
+    }
+}


### PR DESCRIPTION
## Summary

Implements item 3 of the "Input and pickers" section of #186: *"Extend the theme/config system to map semantic roles (agent, error, tool, permission) to configurable colors."*

Semantic conversation roles are now recolorable from both theme files and the `[colors]` config section, via a new `roles` map:

```json
{
  "colors": {
    "chat_background": "#1e1e2e",
    "roles": {
      "agent": "#cdd6f4",
      "error": "#f38ba8",
      "tool": "#f9e2af",
      "permission": "#cba6f7"
    }
  }
}
```

## Changes

- **New `src/ui/roles.rs`**: global registry of role color overrides with the historical palette as defaults. `BlockStyle::color()` resolves through it, so all feed blocks — and legacy `write_line(color)` call sites that map to roles via `style_from_color` — pick up themed colors automatically.
- **All 10 roles supported**: `user`, `agent`, `reasoning`, `tool`, `tool_result`, `error`, `system`, `welcome`, `permission`, `plain`. Colors are parsed with the existing `parse_color` (named colors + `#rrggbb`).
- **Robust application**: unknown role names and unparsable colors are skipped with a `tracing` warning, never breaking rendering. Applying a theme or config *without* a `roles` map resets to the default palette, so switching themes doesn't leak the previous theme's roles.
- **Docs**: `docs/CONFIG.md` colors section documents `roles` with an example.
- No changes to bundled themes; default behavior is pixel-identical to before.

## Verification

- `cargo test` (717 passed), `cargo test --no-default-features` (602 passed), `cargo clippy --all-features -- -D warnings` and `cargo clippy --no-default-features -- -D warnings` — all clean.
- New unit tests for the registry (override/fallback/reset, role-name parsing, bad input handling).
- Smoke-tested on a pty with a roles theme: themed colors render in the actual TUI output.

Refs #186
