### PR TITLE
feat: character-level chat selection that persists after mouse release

### DIFF
--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -173,8 +173,8 @@ mod dirty {
         assert!(!r.chat_needs_redraw());
         // Selection fields are public and mutated directly by callers.
         r.selection_active = true;
-        r.selection_start = Some(0);
-        r.selection_end = Some(0);
+        r.selection_start = Some((0, 0));
+        r.selection_end = Some((0, 0));
         assert!(r.chat_needs_redraw());
         r.mark_chat_clean();
         r.clear_selection();
@@ -187,6 +187,46 @@ mod dirty {
         r.mark_chat_clean();
         r.invalidate();
         assert!(r.chat_needs_redraw());
+    }
+
+    #[test]
+    fn selected_text_slices_first_and_last_lines() {
+        let mut r = Renderer::new().unwrap();
+        r.feed_mut().push_line(BlockStyle::Plain, "hello world");
+        r.feed_mut().push_line(BlockStyle::Plain, "second line");
+        r.feed_mut().push_line(BlockStyle::Plain, "third line");
+        r.selection_active = true;
+        r.selection_dragging = false;
+        r.selection_start = Some((0, 6));
+        r.selection_end = Some((2, 5));
+
+        assert_eq!(
+            r.selected_text().as_deref(),
+            Some("world\nsecond line\nthird")
+        );
+    }
+
+    #[test]
+    fn selected_text_normalizes_reversed_drag() {
+        let mut r = Renderer::new().unwrap();
+        r.feed_mut().push_line(BlockStyle::Plain, "hello world");
+        r.feed_mut().push_line(BlockStyle::Plain, "second line");
+        r.selection_active = true;
+        r.selection_start = Some((1, 4));
+        r.selection_end = Some((0, 2));
+
+        assert_eq!(r.selected_text().as_deref(), Some("llo world\nseco"));
+    }
+
+    #[test]
+    fn selected_text_none_for_empty_point_selection() {
+        let mut r = Renderer::new().unwrap();
+        r.feed_mut().push_line(BlockStyle::Plain, "hello world");
+        r.selection_active = true;
+        r.selection_start = Some((0, 3));
+        r.selection_end = Some((0, 3));
+
+        assert_eq!(r.selected_text(), None);
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -507,13 +507,30 @@ impl<'a> App<'a> {
                 }
             }
             UserEvent::MouseUp { row, col } => {
-                // The drag ends but the selection stays highlighted; `y`
-                // copies it, Esc clears it, the next click starts a new one.
+                // The drag ends but the selection stays highlighted (`y`
+                // copies again, Esc clears, the next click starts a new
+                // one). It is copied to the system clipboard right away:
+                // while mouse capture is on the terminal emulator has no
+                // native selection, so Cmd+C/Ctrl+Shift+C has nothing to
+                // grab — the app has to write the pasteboard itself.
                 if self.renderer.selection_dragging {
                     if let Some(point) = self.renderer.selection_point_at(row, col) {
                         self.renderer.selection_end = Some(point);
                     }
                     self.renderer.selection_dragging = false;
+                    if let Some(text) = self.renderer.selected_text() {
+                        match copy_to_clipboard(&text) {
+                            Ok(()) => {
+                                self.renderer.write_line("copied selection", Color::Green)?;
+                            }
+                            Err(e) => {
+                                self.renderer.write_line(
+                                    &format!("copy to clipboard failed: {}", e),
+                                    C_ERROR,
+                                )?;
+                            }
+                        }
+                    }
                 }
             }
             UserEvent::Paste(data) => {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -491,32 +491,29 @@ impl<'a> App<'a> {
                             self.renderer
                                 .write_line(&format!("cannot open link: {}", e), C_ERROR)?;
                         }
-                    } else {
+                    } else if let Some(point) = self.renderer.selection_point_at(row, col) {
                         self.renderer.selection_active = true;
-                        self.renderer.selection_start = Some(idx);
-                        self.renderer.selection_end = Some(idx);
+                        self.renderer.selection_dragging = true;
+                        self.renderer.selection_start = Some(point);
+                        self.renderer.selection_end = Some(point);
                     }
                 }
             }
-            UserEvent::MouseDrag { row, col: _ } => {
-                if self.renderer.selection_active
-                    && let Some(idx) = self.renderer.buffer_line_at_row(row)
+            UserEvent::MouseDrag { row, col } => {
+                if self.renderer.selection_dragging
+                    && let Some(point) = self.renderer.selection_point_at(row, col)
                 {
-                    self.renderer.selection_end = Some(idx);
+                    self.renderer.selection_end = Some(point);
                 }
             }
-            UserEvent::MouseUp { row, col: _ } => {
-                if self.renderer.selection_active {
-                    if let Some(idx) = self.renderer.buffer_line_at_row(row) {
-                        self.renderer.selection_end = Some(idx);
+            UserEvent::MouseUp { row, col } => {
+                // The drag ends but the selection stays highlighted; `y`
+                // copies it, Esc clears it, the next click starts a new one.
+                if self.renderer.selection_dragging {
+                    if let Some(point) = self.renderer.selection_point_at(row, col) {
+                        self.renderer.selection_end = Some(point);
                     }
-                    if let Some(text) = self.renderer.selected_text()
-                        && let Err(e) = copy_to_clipboard(&text)
-                    {
-                        self.renderer
-                            .write_line(&format!("copy to clipboard failed: {}", e), C_ERROR)?;
-                    }
-                    self.renderer.clear_selection();
+                    self.renderer.selection_dragging = false;
                 }
             }
             UserEvent::Paste(data) => {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -59,8 +59,8 @@ struct ChatSnapshot {
     visible_rows: usize,
     scroll_offset: usize,
     selection_active: bool,
-    selection_start: Option<usize>,
-    selection_end: Option<usize>,
+    selection_start: Option<(usize, usize)>,
+    selection_end: Option<(usize, usize)>,
     partial: CompactString,
     partial_style: BlockStyle,
     chat_bg: Option<Color>,
@@ -134,9 +134,17 @@ pub struct Renderer {
     chat_bg: Option<Color>,
     input_bg: Option<Color>,
     status_bg: Option<Color>,
+    /// A selection exists in the chat buffer (highlighted). Set on mouse
+    /// down, cleared by `y` (after copy) or Esc.
     pub selection_active: bool,
-    pub selection_start: Option<usize>,
-    pub selection_end: Option<usize>,
+    /// Selection endpoints as `(visual_line, display_col)` — character-level,
+    /// not whole rows. The drag start/end, in no particular order.
+    pub selection_start: Option<(usize, usize)>,
+    pub selection_end: Option<(usize, usize)>,
+    /// True while the mouse button is held mid-drag. On release the
+    /// selection stays visible (this becomes false; `selection_active` stays
+    /// true) until `y` copies or Esc clears it.
+    pub selection_dragging: bool,
     prev_input_height: usize,
     /// Number of statusline rows (1-3), fixed by the statusline config at startup.
     statusline_height: usize,
@@ -182,6 +190,7 @@ impl Renderer {
             selection_active: false,
             selection_start: None,
             selection_end: None,
+            selection_dragging: false,
             prev_input_height: 0,
             statusline_height: 1,
             chat_margin: 0,
@@ -393,8 +402,23 @@ impl Renderer {
     pub fn clear_selection(&mut self) {
         self.chat_dirty = true;
         self.selection_active = false;
+        self.selection_dragging = false;
         self.selection_start = None;
         self.selection_end = None;
+    }
+
+    /// Map a screen `(row, col)` in the chat viewport to a selection point
+    /// `(visual_line, display_col)`, accounting for the chat left margin.
+    /// `None` when the row maps to no buffer line.
+    pub fn selection_point_at(&self, row: u16, col: u16) -> Option<(usize, usize)> {
+        let idx = self.buffer_line_at_row(row)?;
+        Some((idx, col.saturating_sub(self.chat_margin) as usize))
+    }
+
+    /// Selection endpoints ordered by `(line, col)`, when both are set.
+    fn normalized_selection(&self) -> Option<((usize, usize), (usize, usize))> {
+        let (s, e) = (self.selection_start?, self.selection_end?);
+        Some(if s <= e { (s, e) } else { (e, s) })
     }
 
     pub fn link_url_at(&self, buf_idx: usize, col: u16) -> Option<String> {
@@ -413,21 +437,32 @@ impl Renderer {
         None
     }
 
+    /// The selected text, honoring character-level endpoints: the first and
+    /// last lines are sliced to their display columns, lines in between are
+    /// taken whole. `None` when the selection is empty.
     pub fn selected_text(&self) -> Option<String> {
-        let (start, end) = match (self.selection_start, self.selection_end) {
-            (Some(s), Some(e)) if s <= e => (s, e),
-            (Some(s), Some(e)) => (e, s),
-            _ => return None,
-        };
+        let ((lo_line, lo_col), (hi_line, hi_col)) = self.normalized_selection()?;
         let lines = self.chat_lines(self.max_line_width());
         let mut result = String::new();
-        for i in start..=end {
-            if let Some(entry) = lines.get(i) {
-                if !result.is_empty() {
-                    result.push('\n');
-                }
-                result.push_str(&entry.text);
+        for i in lo_line..=hi_line {
+            let Some(entry) = lines.get(i) else {
+                continue;
+            };
+            let line_width = display_width(&entry.text);
+            let start = if i == lo_line { lo_col } else { 0 };
+            let end = if i == hi_line {
+                hi_col.min(line_width)
+            } else {
+                line_width
+            };
+            if !result.is_empty() {
+                result.push('\n');
             }
+            result.push_str(&crate::ui::utils::display_col_slice(
+                &entry.text,
+                start,
+                end,
+            ));
         }
         if result.is_empty() {
             None
@@ -623,26 +658,43 @@ impl Renderer {
 
             stdout.execute(MoveTo(0, visual_row))?;
 
-            let is_selected = self.selection_active
-                && if let (Some(s), Some(e)) = (self.selection_start, self.selection_end) {
-                    let lo = s.min(e);
-                    let hi = s.max(e);
-                    buf_idx >= lo && buf_idx <= hi
-                } else {
-                    false
-                };
+            // Character-level selection range within this line, if any:
+            // endpoints slice only the first/last lines, middle lines are
+            // fully covered.
+            let line_sel = self
+                .normalized_selection()
+                .and_then(|((lo_l, lo_c), (hi_l, hi_c))| {
+                    if !self.selection_active || buf_idx < lo_l || buf_idx > hi_l {
+                        return None;
+                    }
+                    let line_width = display_width(chunk);
+                    let start = if buf_idx == lo_l { lo_c } else { 0 };
+                    let end = if buf_idx == hi_l {
+                        hi_c.min(line_width)
+                    } else {
+                        line_width
+                    };
+                    (end > start).then(|| {
+                        (
+                            crate::ui::utils::byte_index_at_display_col(chunk, start),
+                            crate::ui::utils::byte_index_at_display_col(chunk, end),
+                        )
+                    })
+                });
 
             if let Some(bg) = self.chat_bg {
                 write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
             }
             self.write_chat_margin(&mut stdout)?;
-            if is_selected {
-                write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
-            }
             write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
-            write!(stdout, "{}", wrap_urls_osc8(chunk))?;
-            if is_selected {
+            if let Some((a, b)) = line_sel {
+                write!(stdout, "{}", wrap_urls_osc8(&chunk[..a]))?;
+                write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
+                write!(stdout, "{}", wrap_urls_osc8(&chunk[a..b]))?;
                 write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
+                write!(stdout, "{}", wrap_urls_osc8(&chunk[b..]))?;
+            } else {
+                write!(stdout, "{}", wrap_urls_osc8(chunk))?;
             }
             write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
             write!(stdout, "{}", ResetColor)?;

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -137,6 +137,32 @@ pub(crate) fn parse_color(s: &str) -> Option<Color> {
     }
 }
 
+/// Byte index of the first char whose display cell starts at or after
+/// display column `col` (`s.len()` when the string is narrower). Selection
+/// ranges are measured in display columns; this maps them back to byte
+/// offsets. A wide (CJK) char straddling `col` is excluded from the range.
+pub(crate) fn byte_index_at_display_col(s: &str, col: usize) -> usize {
+    if col == 0 {
+        return 0;
+    }
+    let mut width = 0;
+    for (i, c) in s.char_indices() {
+        if width >= col {
+            return i;
+        }
+        width += char_display_width(c);
+    }
+    s.len()
+}
+
+/// The substring of `s` covering display columns `[start_col, end_col)`.
+/// Columns are clamped and may be given in any order.
+pub(crate) fn display_col_slice(s: &str, start_col: usize, end_col: usize) -> String {
+    let a = byte_index_at_display_col(s, start_col.min(end_col));
+    let b = byte_index_at_display_col(s, start_col.max(end_col));
+    s[a..b].to_string()
+}
+
 /// Formats a tool call showing only the primary file/command parameter.
 pub(crate) fn format_tool_call_summary(name: &str, args: &serde_json::Value) -> String {
     let obj = match args {
@@ -221,5 +247,32 @@ pub(crate) fn suggest_pattern(tool: &str, input: &str) -> String {
             format!("{}*", first)
         }
         _ => "*".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_index_maps_display_cols() {
+        assert_eq!(byte_index_at_display_col("hello", 0), 0);
+        assert_eq!(byte_index_at_display_col("hello", 3), 3);
+        assert_eq!(byte_index_at_display_col("hello", 99), 5);
+        // Wide chars: '你' occupies cols 0-1, '好' cols 2-3.
+        assert_eq!(byte_index_at_display_col("你好x", 2), 3);
+        // col 1 straddles '你' — excluded, next boundary is '好' at byte 3.
+        assert_eq!(byte_index_at_display_col("你好x", 1), 3);
+    }
+
+    #[test]
+    fn display_col_slice_extracts_ranges() {
+        assert_eq!(display_col_slice("hello world", 0, 5), "hello");
+        assert_eq!(display_col_slice("hello world", 6, 11), "world");
+        assert_eq!(display_col_slice("hello", 3, 1), "el");
+        assert_eq!(display_col_slice("hello", 2, 99), "llo");
+        assert_eq!(display_col_slice("你好世界", 0, 4), "你好");
+        assert_eq!(display_col_slice("a你b", 1, 3), "你");
+        assert_eq!(display_col_slice("hello", 2, 2), "");
     }
 }


### PR DESCRIPTION
## Summary

Implements item 4 of the "Input and pickers" section of #186 (*"Support character-level selection: mouse drag and `y` copy currently select whole visual rows only"*) and fixes a UX bug where the selection disappeared the moment the mouse button was released.

## Changes

**Character-level selection**
- Selection endpoints are now `(visual_line, display_col)` points instead of whole-row `LineEntry` indices; `MouseDrag` honors the column it previously ignored.
- The viewport renders the selection as a partial-line reversed segment: first/last lines sliced to their columns, middle lines fully covered. Slicing is display-column based and CJK-aware (wide chars straddling a boundary are excluded), via new `byte_index_at_display_col` / `display_col_slice` helpers in `ui::utils`.
- `selected_text()` (and therefore `y` copy) extracts exactly the highlighted range, normalizing reversed/upward drags.

**Selection persists after mouse release, and is copied on release**
- Previously `MouseUp` copied to clipboard and immediately cleared the selection, so the highlight vanished on release. Now the drag ends (`selection_dragging` tracks the button state separately from `selection_active`) but the highlight stays: `y` copies again, `Esc` clears, the next click starts a new selection.
- The selection is also copied to the system clipboard on release via `copy_to_clipboard` (pbcopy/wl-copy/xclip/clip.exe): while mouse capture is enabled the terminal emulator has no native selection, so Cmd+C (macOS) / Ctrl+Shift+C (Linux) has nothing to grab — the app must write the pasteboard itself.

## Verification

- `cargo test` (720 passed), `cargo test --no-default-features` (605), `cargo clippy --all-features` and `--no-default-features` with `-D warnings` — all clean.
- New unit tests: display-column helpers (incl. CJK), char-level `selected_text` (first/last line slicing, reversed drag, empty point selection).
- Smoke-tested on a pty with synthetic SGR mouse events: partial-line reverse highlight renders, selection survives release, `y` copies it.

Refs #186

