### PR TITLE
fix: stop MCP server stderr from corrupting the TUI

### DIFF
--- a/src/extras/mcp/client.rs
+++ b/src/extras/mcp/client.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
+use std::process::Stdio;
 
 use compact_str::CompactString;
 use rmcp::service::{RoleClient, RunningService, serve_client};
 use rmcp::transport::child_process::TokioChildProcess;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use super::config::McpServerConfig;
@@ -30,7 +32,23 @@ impl McpClientHandle {
                 for (k, v) in env {
                     cmd.env(k, v);
                 }
-                let transport = TokioChildProcess::new(cmd)?;
+                // rmcp's child-process builder defaults stderr to `inherit`,
+                // so a chatty server's logs write straight over the
+                // alt-screen TUI. Pipe it and drain into tracing (log file)
+                // instead — draining also keeps a verbose server from
+                // deadlocking on a full pipe buffer.
+                let (transport, stderr) = TokioChildProcess::builder(cmd)
+                    .stderr(Stdio::piped())
+                    .spawn()?;
+                if let Some(stderr) = stderr {
+                    let name = server_name.clone();
+                    tokio::spawn(async move {
+                        let mut lines = BufReader::new(stderr).lines();
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            tracing::debug!("[mcp {name}] {line}");
+                        }
+                    });
+                }
                 let running_service = serve_client((), transport).await.map_err(|e| {
                     anyhow::anyhow!("MCP connection failed for '{server_name}': {e}")
                 })?;


### PR DESCRIPTION
## Summary

A chatty MCP server (e.g. `codebase-memory-mcp`) floods the terminal with its debug logs and breaks the TUI display.

## Root cause

`TokioChildProcess`'s builder defaults the child's stderr to `Stdio::inherit()`, so anything an MCP server writes to stderr goes straight to the user's terminal and paints over the alt-screen TUI. (`stdout` is the JSON-RPC protocol channel and is unaffected.)

## Fix

Spawn command-transport MCP servers with `stderr: Stdio::piped()` and drain the pipe into `tracing` (debug level, prefixed with the server name), which writes to zerostack's log file instead of the terminal. Draining also keeps a very verbose server from deadlocking on a full pipe buffer, and preserves diagnostics for MCP troubleshooting.

## Verification

- `cargo test` (715 passed), `cargo test --no-default-features` (600), `cargo clippy --all-features` and `--no-default-features` with `-D warnings` — all clean.
- Live pty test with a fake MCP server spamming 50 stderr lines at startup: zero lines leaked into the TUI after the fix (all leaked before).
