### PR TITLE
feat(mcp): add timeouts, retries, auto-reconnect, and concurrent connect

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -745,6 +745,34 @@ override — global ones by name.
 }
 ```
 
+### Timeouts, retries, and auto-reconnect
+
+Both server kinds accept optional resilience fields:
+
+| Field                  | Default | Description                                                                 |
+| ---------------------- | ------- | --------------------------------------------------------------------------- |
+| `connect_timeout_secs` | `10`    | Timeout for establishing the connection and MCP handshake.                  |
+| `tool_timeout_secs`    | `20`    | Timeout for individual tool calls (and tool listing).                       |
+| `connect_retries`      | `1`     | How many times a failed connection attempt is retried (2 attempts total).   |
+
+```json
+{
+  "mcp_servers": {
+    "slow-server": {
+      "url": "https://example.com/mcp",
+      "connect_timeout_secs": 30,
+      "tool_timeout_secs": 60,
+      "connect_retries": 2
+    }
+  }
+}
+```
+
+All servers connect concurrently at startup, so one slow server does not delay
+the others. If a server's transport drops mid-session (child process exits,
+HTTP session is lost), the next tool call to that server automatically
+reconnects once and retries the call before reporting an error.
+
 ### OAuth for URL servers
 
 URL-based servers can authenticate with OAuth 2.0 (authorization code + PKCE).

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -515,6 +515,9 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
                 url: "https://mcp.exa.ai/mcp".to_string(),
                 headers,
                 oauth: None,
+                connect_timeout_secs: None,
+                tool_timeout_secs: None,
+                connect_retries: None,
             });
     } else {
         servers.remove("Exa Web Search");
@@ -531,6 +534,9 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
                 url: "https://mcp.context7.com/mcp".to_string(),
                 headers,
                 oauth: None,
+                connect_timeout_secs: None,
+                tool_timeout_secs: None,
+                connect_retries: None,
             });
     } else {
         servers.remove("Context7");
@@ -547,6 +553,9 @@ pub fn inject_mcp_defaults(cfg: &mut Config) {
                 url: "https://mcp.grep.app".to_string(),
                 headers,
                 oauth: None,
+                connect_timeout_secs: None,
+                tool_timeout_secs: None,
+                connect_retries: None,
             });
     } else {
         servers.remove("Grep.app");

--- a/src/extras/mcp/client.rs
+++ b/src/extras/mcp/client.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use compact_str::CompactString;
 use rmcp::service::{RoleClient, RunningService, serve_client};
@@ -10,6 +11,11 @@ use super::config::McpServerConfig;
 pub struct McpClientHandle {
     pub server_name: CompactString,
     pub running_service: RunningService<RoleClient, ()>,
+    /// Timeout applied to tool calls and tool listing on this server.
+    pub tool_timeout: Duration,
+    /// Server configuration, kept so the connection can be re-established
+    /// (e.g. after a transport drop) without looking it up again.
+    pub config: McpServerConfig,
 }
 
 impl McpClientHandle {
@@ -17,8 +23,42 @@ impl McpClientHandle {
         server_name: CompactString,
         config: &McpServerConfig,
     ) -> anyhow::Result<Self> {
+        let attempts = 1 + config.connect_retries();
+        let mut last_err = None;
+        for attempt in 1..=attempts {
+            match Self::connect_once(&server_name, config).await {
+                Ok(mut handle) => {
+                    handle.tool_timeout = config.tool_timeout();
+                    handle.config = config.clone();
+                    return Ok(handle);
+                }
+                Err(e) => {
+                    if attempt < attempts {
+                        tracing::debug!(
+                            "MCP server '{}' connect attempt {}/{} failed: {e}; retrying in {}s",
+                            server_name,
+                            attempt,
+                            attempts,
+                            attempt,
+                        );
+                        tokio::time::sleep(Duration::from_secs(attempt as u64)).await;
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.expect("at least one connect attempt"))
+    }
+
+    async fn connect_once(
+        server_name: &CompactString,
+        config: &McpServerConfig,
+    ) -> anyhow::Result<Self> {
+        let connect_timeout = config.connect_timeout();
         match config {
-            McpServerConfig::Command { command, args, env } => {
+            McpServerConfig::Command {
+                command, args, env, ..
+            } => {
                 tracing::debug!(
                     "MCP command transport: {} {:?} ({} env vars)",
                     command,
@@ -31,18 +71,30 @@ impl McpClientHandle {
                     cmd.env(k, v);
                 }
                 let transport = TokioChildProcess::new(cmd)?;
-                let running_service = serve_client((), transport).await.map_err(|e| {
-                    anyhow::anyhow!("MCP connection failed for '{server_name}': {e}")
-                })?;
+                let running_service =
+                    tokio::time::timeout(connect_timeout, serve_client((), transport))
+                        .await
+                        .map_err(|_| {
+                            anyhow::anyhow!(
+                                "MCP server '{server_name}' connection timed out after {}s",
+                                connect_timeout.as_secs()
+                            )
+                        })?
+                        .map_err(|e| {
+                            anyhow::anyhow!("MCP connection failed for '{server_name}': {e}")
+                        })?;
                 Ok(Self {
-                    server_name,
+                    server_name: server_name.clone(),
                     running_service,
+                    tool_timeout: config.tool_timeout(),
+                    config: config.clone(),
                 })
             }
             McpServerConfig::Url {
                 url,
                 headers,
                 oauth,
+                ..
             } => {
                 tracing::debug!(
                     "MCP HTTP transport: {} ({} headers, OAuth: {})",
@@ -57,25 +109,47 @@ impl McpClientHandle {
                 let oauth_settings = oauth.as_ref().and_then(|o| o.settings());
                 let running_service = if let Some(settings) = oauth_settings {
                     let auth_client =
-                        super::oauth::build_auth_client(&server_name, url, &settings).await?;
+                        super::oauth::build_auth_client(server_name.as_str(), url, &settings)
+                            .await?;
                     type AuthHttpClient = rmcp::transport::StreamableHttpClientTransport<
                         rmcp::transport::auth::AuthClient<reqwest::Client>,
                     >;
                     let transport = AuthHttpClient::with_client(auth_client, cfg);
-                    serve_client((), transport).await.map_err(|e| {
-                        anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
-                    })?
+                    tokio::time::timeout(connect_timeout, serve_client((), transport))
+                        .await
+                        .map_err(|_| {
+                            anyhow::anyhow!(
+                                "MCP server '{server_name}' connection timed out after {}s",
+                                connect_timeout.as_secs()
+                            )
+                        })?
+                        .map_err(|e| {
+                            anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
+                        })?
                 } else {
                     type HttpClient =
                         rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
-                    let transport = HttpClient::from_config(cfg);
-                    serve_client((), transport).await.map_err(|e| {
-                        anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
-                    })?
+                    let client = reqwest::Client::builder()
+                        .connect_timeout(connect_timeout)
+                        .build()?;
+                    let transport = HttpClient::with_client(client, cfg);
+                    tokio::time::timeout(connect_timeout, serve_client((), transport))
+                        .await
+                        .map_err(|_| {
+                            anyhow::anyhow!(
+                                "MCP server '{server_name}' connection timed out after {}s",
+                                connect_timeout.as_secs()
+                            )
+                        })?
+                        .map_err(|e| {
+                            anyhow::anyhow!("MCP HTTP connection failed for '{server_name}': {e}")
+                        })?
                 };
                 Ok(Self {
-                    server_name,
+                    server_name: server_name.clone(),
                     running_service,
+                    tool_timeout: config.tool_timeout(),
+                    config: config.clone(),
                 })
             }
         }
@@ -86,7 +160,14 @@ impl McpClientHandle {
     }
 
     pub async fn list_tools(&self) -> Result<Vec<rmcp::model::Tool>, rmcp::ServiceError> {
-        self.running_service.peer().list_all_tools().await
+        tokio::time::timeout(
+            self.tool_timeout,
+            self.running_service.peer().list_all_tools(),
+        )
+        .await
+        .map_err(|_| rmcp::ServiceError::Timeout {
+            timeout: self.tool_timeout,
+        })?
     }
 }
 

--- a/src/extras/mcp/config.rs
+++ b/src/extras/mcp/config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +12,15 @@ pub enum McpServerConfig {
         args: Vec<String>,
         #[serde(default)]
         env: HashMap<String, String>,
+        /// Timeout for the connection/handshake with the server, in seconds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connect_timeout_secs: Option<u64>,
+        /// Timeout for individual tool calls, in seconds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_timeout_secs: Option<u64>,
+        /// Number of times a failed connection attempt is retried.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connect_retries: Option<u32>,
     },
     Url {
         url: String,
@@ -18,7 +28,58 @@ pub enum McpServerConfig {
         headers: HashMap<String, String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         oauth: Option<OAuthConfig>,
+        /// Timeout for the connection/handshake with the server, in seconds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connect_timeout_secs: Option<u64>,
+        /// Timeout for individual tool calls, in seconds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_timeout_secs: Option<u64>,
+        /// Number of times a failed connection attempt is retried.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connect_retries: Option<u32>,
     },
+}
+
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+pub const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 20;
+pub const DEFAULT_CONNECT_RETRIES: u32 = 1;
+
+impl McpServerConfig {
+    fn timeout_fields(&self) -> (Option<u64>, Option<u64>, Option<u32>) {
+        match self {
+            McpServerConfig::Command {
+                connect_timeout_secs,
+                tool_timeout_secs,
+                connect_retries,
+                ..
+            }
+            | McpServerConfig::Url {
+                connect_timeout_secs,
+                tool_timeout_secs,
+                connect_retries,
+                ..
+            } => (*connect_timeout_secs, *tool_timeout_secs, *connect_retries),
+        }
+    }
+
+    /// Timeout for establishing the connection and MCP handshake.
+    pub fn connect_timeout(&self) -> Duration {
+        Duration::from_secs(
+            self.timeout_fields()
+                .0
+                .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS),
+        )
+    }
+
+    /// Timeout for individual tool calls and tool listing.
+    pub fn tool_timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_fields().1.unwrap_or(DEFAULT_TOOL_TIMEOUT_SECS))
+    }
+
+    /// Number of times a failed connection attempt is retried.
+    pub fn connect_retries(&self) -> u32 {
+        self.timeout_fields().2.unwrap_or(DEFAULT_CONNECT_RETRIES)
+    }
 }
 
 /// OAuth settings for a URL-based MCP server.

--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -4,15 +4,26 @@ pub mod oauth;
 pub mod tool;
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
 use compact_str::CompactString;
+use tokio::sync::RwLock;
 use tool::McpTool;
 
 use crate::permission::ask::AskSender;
 use crate::permission::checker::PermCheck;
 
+/// Shared reference to a server connection. Tools hold a clone so they can
+/// reconnect the server themselves after a transport drop.
+pub type SharedHandle = Arc<RwLock<client::McpClientHandle>>;
+
+/// Bound on shutting down a single server connection so a wedged service
+/// cannot hang application exit.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub struct McpClientManager {
-    pub handles: Vec<client::McpClientHandle>,
+    pub handles: Vec<SharedHandle>,
     /// Connection failures collected during `connect_all`, to be surfaced by the
     /// TUI via the renderer. We do NOT log these at `warn` because that writes to
     /// stderr, which corrupts the alt-screen TUI (overlapping the input box).
@@ -22,24 +33,27 @@ pub struct McpClientManager {
 impl McpClientManager {
     pub async fn connect_all(configs: &HashMap<String, config::McpServerConfig>) -> Self {
         tracing::debug!("MCP connecting to {} servers", configs.len());
+        let results = futures::future::join_all(configs.iter().map(|(name, cfg)| async move {
+            let connect_start = std::time::Instant::now();
+            let result =
+                client::McpClientHandle::connect(CompactString::new(name.clone()), cfg).await;
+            (name, connect_start.elapsed(), result)
+        }))
+        .await;
+
         let mut handles = Vec::new();
         let mut notices = Vec::new();
-        for (name, cfg) in configs {
-            let connect_start = std::time::Instant::now();
-            match client::McpClientHandle::connect(CompactString::new(name.clone()), cfg).await {
+        for (name, elapsed, result) in results {
+            match result {
                 Ok(handle) => {
-                    tracing::info!(
-                        "Connected to MCP server '{}' in {:?}",
-                        name,
-                        connect_start.elapsed()
-                    );
-                    handles.push(handle);
+                    tracing::info!("Connected to MCP server '{}' in {:?}", name, elapsed);
+                    handles.push(Arc::new(RwLock::new(handle)));
                 }
                 Err(e) => {
                     tracing::debug!(
                         "Failed to connect to MCP server '{}' after {:?}: {e}",
                         name,
-                        connect_start.elapsed()
+                        elapsed
                     );
                     notices.push(CompactString::new(format!(
                         "MCP server '{name}' not connected: {e}"
@@ -47,12 +61,23 @@ impl McpClientManager {
                 }
             }
         }
+        notices.sort();
         Self { handles, notices }
     }
 
     /// Drain and return any pending connection notices.
     pub fn take_notices(&mut self) -> Vec<CompactString> {
         std::mem::take(&mut self.notices)
+    }
+
+    /// Find the shared handle for a server by name.
+    pub async fn get_handle(&self, name: &str) -> Option<SharedHandle> {
+        for shared in &self.handles {
+            if shared.read().await.server_name == name {
+                return Some(shared.clone());
+            }
+        }
+        None
     }
 
     pub async fn collect_tools(
@@ -62,8 +87,8 @@ impl McpClientManager {
     ) -> Vec<McpTool> {
         tracing::debug!("MCP collecting tools from {} handles", self.handles.len());
         let mut all_tools = Vec::new();
-        for handle in &self.handles {
-            let peer = handle.peer();
+        for shared in &self.handles {
+            let handle = shared.read().await;
             let server_name = handle.server_name.clone();
             match handle.list_tools().await {
                 Ok(tools) => {
@@ -72,7 +97,7 @@ impl McpClientManager {
                         all_tools.push(McpTool {
                             server_name: server_name.clone(),
                             definition,
-                            peer: peer.clone(),
+                            handle: shared.clone(),
                             permission: permission.clone(),
                             ask_tx: ask_tx.clone(),
                         });
@@ -91,7 +116,9 @@ impl McpClientManager {
 
     /// (Re)connect a single server, replacing any existing handle for it.
     /// Used after an interactive OAuth login so the server's tools become
-    /// available without restarting the session.
+    /// available without restarting the session. When a handle already
+    /// exists its inner connection is swapped, so tools built from it pick
+    /// up the new connection.
     pub async fn reconnect(
         &mut self,
         name: &str,
@@ -99,20 +126,41 @@ impl McpClientManager {
     ) -> anyhow::Result<()> {
         tracing::info!("MCP reconnecting server '{}'", name);
         let handle = client::McpClientHandle::connect(CompactString::new(name), cfg).await?;
-        self.handles.retain(|h| h.server_name != name);
-        self.handles.push(handle);
+        if let Some(shared) = self.get_handle(name).await {
+            *shared.write().await = handle;
+        } else {
+            self.handles.push(Arc::new(RwLock::new(handle)));
+        }
         Ok(())
     }
 
     pub async fn shutdown(self) {
         tracing::debug!("MCP shutting down {} connections", self.handles.len());
-        for handle in self.handles {
-            let name = handle.server_name.clone();
-            // Explicitly shut down the running service so child processes and
-            // HTTP connections are cleaned up properly, rather than relying on
-            // Drop which may not await teardown.
-            let _ = handle.running_service.cancel().await;
-            tracing::debug!("Disconnected from MCP server '{}'", name);
+        for shared in self.handles {
+            // `cancel` consumes the service, so it is only possible when no
+            // tool still holds a reference to the handle. Otherwise the
+            // connection is left to Drop at process exit.
+            match Arc::try_unwrap(shared) {
+                Ok(lock) => {
+                    let handle = lock.into_inner();
+                    let name = handle.server_name.clone();
+                    // Explicitly shut down the running service so child
+                    // processes and HTTP connections are cleaned up properly,
+                    // rather than relying on Drop which may not await
+                    // teardown. Bounded so a wedged service cannot hang
+                    // application exit.
+                    let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, handle.running_service.cancel())
+                        .await;
+                    tracing::debug!("Disconnected from MCP server '{}'", name);
+                }
+                Err(shared) => {
+                    let name = shared.read().await.server_name.clone();
+                    tracing::debug!(
+                        "MCP server '{}' still referenced at shutdown, skipping cancel",
+                        name
+                    );
+                }
+            }
         }
     }
 }

--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -1,15 +1,22 @@
 use std::borrow::Cow;
 use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
 
 use compact_str::CompactString;
 use rig::tool::{ToolDyn, ToolError};
 use rig::wasm_compat::WasmBoxedFuture;
-use rmcp::model::{CallToolRequestParams, ContentBlock, JsonObject};
-use rmcp::service::{Peer, RoleClient};
+use rmcp::model::{
+    CallToolRequest, CallToolRequestParams, ClientRequest, ContentBlock, JsonObject, ServerResult,
+};
+use rmcp::service::{Peer, PeerRequestOptions, RoleClient, ServiceError};
+use tokio::sync::RwLock;
 
 use crate::agent::tools::check_perm;
 use crate::permission::ask::AskSender;
 use crate::permission::checker::PermCheck;
+
+use super::client::McpClientHandle;
 
 #[derive(Debug)]
 pub struct McpToolError(pub CompactString);
@@ -25,9 +32,41 @@ impl std::error::Error for McpToolError {}
 pub struct McpTool {
     pub server_name: CompactString,
     pub definition: rmcp::model::Tool,
-    pub peer: Peer<RoleClient>,
+    pub handle: Arc<RwLock<McpClientHandle>>,
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+}
+
+fn tool_err(msg: impl Into<String>) -> ToolError {
+    ToolError::ToolCallError(Box::new(McpToolError(CompactString::new(msg.into()))))
+}
+
+/// Map an rmcp service error to a user-facing message, spelling out timeouts.
+fn call_error_message(server_name: &str, tool_name: &str, e: &ServiceError) -> String {
+    match e {
+        ServiceError::Timeout { timeout } => format!(
+            "MCP tool '{tool_name}' on server '{server_name}' timed out after {}s",
+            timeout.as_secs()
+        ),
+        _ => format!("MCP tool error: {e}"),
+    }
+}
+
+async fn call_tool_with_timeout(
+    peer: &Peer<RoleClient>,
+    params: CallToolRequestParams,
+    timeout: Duration,
+) -> Result<rmcp::model::CallToolResult, ServiceError> {
+    let request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
+    let result = peer
+        .send_cancellable_request(request, PeerRequestOptions::with_timeout(timeout))
+        .await?
+        .await_response()
+        .await?;
+    match result {
+        ServerResult::CallToolResult(result) => Ok(result),
+        _ => Err(ServiceError::UnexpectedResponse),
+    }
 }
 
 impl ToolDyn for McpTool {
@@ -50,7 +89,7 @@ impl ToolDyn for McpTool {
     fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
         let server_name = self.server_name.clone();
         let tool_name = self.definition.name.to_string();
-        let peer = self.peer.clone();
+        let handle = self.handle.clone();
         let permission = self.permission.clone();
         let ask_tx = self.ask_tx.clone();
 
@@ -58,22 +97,42 @@ impl ToolDyn for McpTool {
             let perm_key = format!("mcp_tool:{server_name}:{tool_name}");
             let coaching = check_perm(&permission, &ask_tx, "mcp_tool", &perm_key)
                 .await
-                .map_err(|e| {
-                    ToolError::ToolCallError(Box::new(McpToolError(CompactString::new(
-                        e.to_string(),
-                    ))))
-                })?;
+                .map_err(|e| tool_err(e.to_string()))?;
 
             let arguments: Option<JsonObject> = serde_json::from_str(&args).unwrap_or_default();
             let params = arguments
                 .map(|a| CallToolRequestParams::new(tool_name.clone()).with_arguments(a))
                 .unwrap_or_else(|| CallToolRequestParams::new(tool_name.clone()));
 
-            let result = peer.call_tool(params).await.map_err(|e| {
-                ToolError::ToolCallError(Box::new(McpToolError(CompactString::new(format!(
-                    "MCP tool error: {e}"
-                )))))
-            })?;
+            let (peer, timeout) = {
+                let h = handle.read().await;
+                (h.peer(), h.tool_timeout)
+            };
+            let mut result = call_tool_with_timeout(&peer, params.clone(), timeout).await;
+
+            // The transport died (child process exited, HTTP session dropped):
+            // reconnect the server once and retry the call on the fresh peer.
+            if matches!(result, Err(ServiceError::TransportClosed)) {
+                tracing::info!(
+                    "MCP server '{}' transport closed, attempting reconnect",
+                    server_name
+                );
+                let mut h = handle.write().await;
+                match McpClientHandle::connect(server_name.clone(), &h.config).await {
+                    Ok(new_handle) => {
+                        *h = new_handle;
+                        result = call_tool_with_timeout(&h.peer(), params, h.tool_timeout).await;
+                    }
+                    Err(e) => {
+                        return Err(tool_err(format!(
+                            "MCP server '{server_name}' transport closed and reconnect failed: {e}"
+                        )));
+                    }
+                }
+            }
+
+            let result =
+                result.map_err(|e| tool_err(call_error_message(&server_name, &tool_name, &e)))?;
 
             if result.is_error.unwrap_or(false) {
                 let error_msg = result
@@ -90,9 +149,7 @@ impl ToolDyn for McpTool {
                 } else {
                     error_msg
                 };
-                return Err(ToolError::ToolCallError(Box::new(McpToolError(
-                    CompactString::new(msg),
-                ))));
+                return Err(tool_err(msg));
             }
 
             let mut content = String::new();

--- a/src/tests/config_tests.rs
+++ b/src/tests/config_tests.rs
@@ -551,6 +551,9 @@ fn local_override_merges_mcp_servers() {
             url: "https://global.example.com/mcp".to_string(),
             headers: HashMap::new(),
             oauth: None,
+            connect_timeout_secs: None,
+            tool_timeout_secs: None,
+            connect_retries: None,
         },
     );
     let base = Config {

--- a/src/tests/mcp_oauth_tests.rs
+++ b/src/tests/mcp_oauth_tests.rs
@@ -121,6 +121,9 @@ fn oauth_config_round_trips_through_serde() {
         url: "https://example.com/mcp".to_string(),
         headers: Default::default(),
         oauth: Some(OAuthConfig::Enabled(true)),
+        connect_timeout_secs: None,
+        tool_timeout_secs: None,
+        connect_retries: None,
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let back: McpServerConfig = serde_json::from_str(&json).unwrap();

--- a/src/tests/mcp_timeout_tests.rs
+++ b/src/tests/mcp_timeout_tests.rs
@@ -1,0 +1,198 @@
+//! Tests for MCP connection timeouts, retries, and the auto-reconnect path.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::extras::mcp::client::McpClientHandle;
+use crate::extras::mcp::config::{
+    DEFAULT_CONNECT_RETRIES, DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_TOOL_TIMEOUT_SECS,
+    McpServerConfig,
+};
+
+fn command_config(
+    command: &str,
+    args: Vec<String>,
+    connect_timeout_secs: Option<u64>,
+    tool_timeout_secs: Option<u64>,
+    connect_retries: Option<u32>,
+) -> McpServerConfig {
+    McpServerConfig::Command {
+        command: command.to_string(),
+        args,
+        env: HashMap::new(),
+        connect_timeout_secs,
+        tool_timeout_secs,
+        connect_retries,
+    }
+}
+
+#[test]
+fn timeout_defaults_apply_when_unset() {
+    let cfg = command_config("true", vec![], None, None, None);
+    assert_eq!(
+        cfg.connect_timeout(),
+        Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)
+    );
+    assert_eq!(
+        cfg.tool_timeout(),
+        Duration::from_secs(DEFAULT_TOOL_TIMEOUT_SECS)
+    );
+    assert_eq!(cfg.connect_retries(), DEFAULT_CONNECT_RETRIES);
+    assert_eq!(DEFAULT_CONNECT_TIMEOUT_SECS, 10);
+    assert_eq!(DEFAULT_TOOL_TIMEOUT_SECS, 20);
+    assert_eq!(DEFAULT_CONNECT_RETRIES, 1);
+}
+
+#[test]
+fn timeout_overrides_apply_when_set() {
+    let cfg = command_config("true", vec![], Some(3), Some(7), Some(5));
+    assert_eq!(cfg.connect_timeout(), Duration::from_secs(3));
+    assert_eq!(cfg.tool_timeout(), Duration::from_secs(7));
+    assert_eq!(cfg.connect_retries(), 5);
+}
+
+#[test]
+fn timeout_fields_parse_from_toml() {
+    let cfg: McpServerConfig = toml::from_str(
+        r#"
+command = "npx"
+args = ["-y", "some-mcp-server"]
+connect_timeout_secs = 4
+tool_timeout_secs = 9
+connect_retries = 2
+"#,
+    )
+    .unwrap();
+    assert_eq!(cfg.connect_timeout(), Duration::from_secs(4));
+    assert_eq!(cfg.tool_timeout(), Duration::from_secs(9));
+    assert_eq!(cfg.connect_retries(), 2);
+}
+
+#[test]
+fn timeout_fields_optional_in_toml_for_url_servers() {
+    let cfg: McpServerConfig = toml::from_str(r#"url = "https://example.com/mcp""#).unwrap();
+    assert_eq!(
+        cfg.connect_timeout(),
+        Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)
+    );
+    assert_eq!(
+        cfg.tool_timeout(),
+        Duration::from_secs(DEFAULT_TOOL_TIMEOUT_SECS)
+    );
+    assert_eq!(cfg.connect_retries(), DEFAULT_CONNECT_RETRIES);
+}
+
+#[test]
+fn timeout_fields_survive_serde_round_trip() {
+    let cfg = command_config("true", vec![], Some(2), Some(8), Some(3));
+    let json = serde_json::to_string(&cfg).unwrap();
+    let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.connect_timeout(), Duration::from_secs(2));
+    assert_eq!(back.tool_timeout(), Duration::from_secs(8));
+    assert_eq!(back.connect_retries(), 3);
+}
+
+#[tokio::test]
+async fn connect_times_out_on_unresponsive_server() {
+    // `sleep 60` never speaks the MCP protocol, so the handshake must be
+    // cut short by the connect timeout.
+    let cfg = command_config("sleep", vec!["60".to_string()], Some(1), None, Some(0));
+    let start = Instant::now();
+    let result = McpClientHandle::connect("slow-server".into(), &cfg).await;
+    let elapsed = start.elapsed();
+    let err = result.err().expect("connect must fail");
+    assert!(
+        err.to_string().contains("timed out"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "timeout took too long: {elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_retries_failed_attempts() {
+    // A command that fails instantly: every attempt runs it, so the marker
+    // file ends up with one line per attempt.
+    let dir = std::env::temp_dir().join(format!("zerostack-mcp-retry-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let marker = dir.join("attempts");
+    let _ = std::fs::remove_file(&marker);
+    let script = format!("echo attempt >> '{}'; exit 1", marker.display());
+    let cfg = command_config("sh", vec!["-c".to_string(), script], Some(1), None, Some(1));
+    let result = McpClientHandle::connect("flaky-server".into(), &cfg).await;
+    assert!(result.is_err(), "connect must fail after retries");
+    let attempts = std::fs::read_to_string(&marker).unwrap().lines().count();
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(attempts, 2, "expected 1 initial attempt + 1 retry");
+}
+
+#[tokio::test]
+async fn connect_retries_zero_means_single_attempt() {
+    let dir = std::env::temp_dir().join(format!("zerostack-mcp-noretry-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let marker = dir.join("attempts");
+    let _ = std::fs::remove_file(&marker);
+    // The child spawns, records the attempt, and exits immediately, so the
+    // handshake fails fast on every attempt.
+    let script = format!("echo attempt >> '{}'", marker.display());
+    let cfg = command_config("sh", vec!["-c".to_string(), script], Some(1), None, Some(0));
+    let result = McpClientHandle::connect("one-shot-server".into(), &cfg).await;
+    assert!(result.is_err(), "handshake must fail");
+    let attempts = std::fs::read_to_string(&marker).unwrap().lines().count();
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(attempts, 1, "connect_retries = 0 means a single attempt");
+}
+
+#[tokio::test]
+async fn tool_call_on_dead_server_reports_reconnect_failure() {
+    use std::sync::Arc;
+
+    use compact_str::CompactString;
+    use rig::tool::ToolDyn;
+    use tokio::sync::RwLock;
+
+    use crate::extras::mcp::tool::McpTool;
+
+    // Build a handle whose transport is already dead: spawn a process that
+    // exits immediately, and wait until the peer's channel is closed.
+    let cfg = command_config(
+        "sh",
+        vec!["-c".to_string(), "exit 0".to_string()],
+        Some(2),
+        Some(1),
+        Some(0),
+    );
+    let handle = match McpClientHandle::connect("dead-server".into(), &cfg).await {
+        Ok(h) => h,
+        // The handshake may already fail on a fast-exiting process; then the
+        // connect path itself is what we exercised and there is nothing more
+        // to test here.
+        Err(_) => return,
+    };
+    // Give the service task a moment to notice the dead child process.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let definition = rmcp::model::Tool::new(
+        "noop",
+        "noop",
+        std::sync::Arc::new(rmcp::model::JsonObject::new()),
+    );
+    let tool = McpTool {
+        server_name: CompactString::new("dead-server"),
+        definition,
+        handle: Arc::new(RwLock::new(handle)),
+        permission: None,
+        ask_tx: None,
+    };
+    let err = match tool.call("{}".to_string()).await {
+        Ok(out) => panic!("call on dead server must fail, got: {out}"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("dead-server"),
+        "error should name the server: {msg}"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -56,6 +56,8 @@ mod lsp_tests;
 mod markdown_tests;
 #[cfg(all(test, feature = "mcp"))]
 mod mcp_oauth_tests;
+#[cfg(all(test, feature = "mcp"))]
+mod mcp_timeout_tests;
 #[cfg(all(test, feature = "memory"))]
 mod memory_tests;
 #[cfg(test)]

--- a/src/ui/slash/settings.rs
+++ b/src/ui/slash/settings.rs
@@ -349,8 +349,8 @@ async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
     // `/mcp <server>` — list tools for one server.
     if parts.len() > 1 {
         let name = parts[1].trim();
-        if let Some(handle) = mgr.handles.iter().find(|h| h.server_name == name) {
-            match handle.list_tools().await {
+        if let Some(handle) = mgr.get_handle(name).await {
+            match handle.read().await.list_tools().await {
                 Ok(tools) => {
                     if tools.is_empty() {
                         write_ok(ctx.renderer, format!("server '{}' has no tools", name));
@@ -391,12 +391,8 @@ async fn handle_mcp(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
     let mut names: Vec<&String> = servers.keys().collect();
     names.sort();
     for name in names {
-        if let Some(handle) = mgr
-            .handles
-            .iter()
-            .find(|h| h.server_name.as_str() == name.as_str())
-        {
-            let label = match handle.list_tools().await {
+        if let Some(handle) = mgr.get_handle(name).await {
+            let label = match handle.read().await.list_tools().await {
                 Ok(tools) => format!("  + {name} ({} tools)", tools.len()),
                 Err(_) => format!("  + {name} (connected)"),
             };


### PR DESCRIPTION
## Summary

The MCP stack had **no timeouts and no recovery**: a hung server handshake could block startup (TUI first prompt and headless mode) forever, tool calls waited indefinitely, one transient connect failure killed a server for the whole session, and servers connected sequentially.

## Changes

- **Config** (`src/extras/mcp/config.rs`): new per-server fields on command and URL servers — `connect_timeout_secs` (default 10), `tool_timeout_secs` (default 20), `connect_retries` (default 1).
- **Connect** (`client.rs`): handshake bounded with `tokio::time::timeout`; failed attempts retried with backoff (1s, 2s, …); plain HTTP transport gets a reqwest `connect_timeout`; handles keep `tool_timeout` + `config` for reconnects.
- **Tool calls** (`tool.rs`): calls go through rmcp's `send_cancellable_request` with `PeerRequestOptions::with_timeout` (server receives a cancellation notice); timeout errors get a clear message; on `TransportClosed` the tool reconnects the server once and retries the call.
- **Manager** (`mod.rs`): `connect_all` connects concurrently via `join_all`; handles are `Arc<RwLock<…>>` shared with tools; `reconnect` (OAuth login path) swaps the inner handle so live tools pick it up; per-server shutdown bounded to 5s.
- **Tests**: 9 new tests in `src/tests/mcp_timeout_tests.rs` (config parsing/defaults, real connect-timeout against a hanging server, retry attempt counting, dead-server reconnect error path).
- **Docs**: `docs/CONFIG.md` documents the new fields and behavior.

## Verification

- `cargo fmt`
- `cargo test` — 724 passed, 0 failed
- `cargo install --path . --debug`