### PR TITLE
test(ui): headless integration tests for the TUI main loop (#186)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,10 +34,15 @@ Single crate, no workspace. All source under `src/`.
 - **`Session`** (`src/session/mod.rs:61`) — serializable state: messages, compactions, costs, permission allowlist, model/provider info.
 - **`PermissionChecker`** (`src/permission/checker.rs:29`) — dual-layer (glob + regex) rules, doom-loop detection, `SecurityMode` dispatch.
 - **`TerminalGuard`** (`src/ui/terminal.rs:10`) — RAII for raw mode, alt screen, mouse capture.
-- **`Renderer`** (`src/ui/renderer.rs:52`) — line-buffered viewport, markdown rendering, scroll/selection.
+- **`Renderer`** (`src/ui/renderer.rs:52`) — line-buffered viewport, markdown rendering, scroll/selection. All terminal I/O (ANSI writes, size reads) goes through the `RenderBackend` trait: `CrosstermBackend` in production, `FakeBackend` (fixed geometry, captures frames) in tests.
 - **`InputEditor`** (`src/ui/input/mod.rs:21`) — text buffer, cursor, history, kill-ring, picker integration.
 - **`ContextFiles`** (`src/context/mod.rs:57`) — loaded agents, prompts, themes, architecture docs.
 - **`HookDispatcher`** (`src/extras/hooks/dispatcher.rs:60`, feature `hooks`) — merges `PreToolUse` verdicts (`Allow`/`Defer`/`Ask`/`Deny`, most severe wins) and applies `PostToolUse`/lifecycle `Decision`s (`Continue`/`Block`/`Rewrite`). Wraps every tool via `wrap_from_global()` (`src/agent/builder.rs:276`), outside each tool's own `PermissionChecker` check.
+
+## Testing
+
+- Unit tests live in `src/tests/` (binary crate, so integration tests are in-crate too).
+- **Headless main-loop integration tests** (`src/tests/tui_loop_tests.rs`) drive the real TUI loop without a terminal or network: `App::new_headless()` skips `TerminalGuard` and the crossterm event thread, renders into a `FakeBackend`, and receives scripted `UserEvent`s via `App::inject`; the loop is pumped one iteration at a time with `App::step`. Agent runs use `AnyAgent::Mock` (rig's `MockCompletionModel`, see `src/tests/fake_model.rs`).
 
 ## Control Flow
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -620,6 +620,10 @@ pub enum AnyAgent {
     Anthropic(Agent<anthropic::completion::CompletionModel>),
     Gemini(Agent<gemini::completion::CompletionModel>),
     Ollama(Agent<ollama::CompletionModel>),
+    /// Scripted test double (`rig::test_utils::MockCompletionModel`), used by
+    /// headless main-loop integration tests; never constructed in production.
+    #[cfg(test)]
+    Mock(Agent<rig::test_utils::MockCompletionModel>),
 }
 
 /// Synthesizes an `AgentRunner` for a prompt blocked by a `UserPromptSubmit`
@@ -727,6 +731,19 @@ impl AnyAgent {
                 )
                 .await
             }
+            #[cfg(test)]
+            AnyAgent::Mock(a) => {
+                runner::run_print(
+                    a,
+                    prompt,
+                    pure_stdout,
+                    retry_config,
+                    history,
+                    #[cfg(feature = "hooks")]
+                    loop_info,
+                )
+                .await
+            }
         }
     }
 
@@ -757,6 +774,10 @@ impl AnyAgent {
                 runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
             }
             AnyAgent::Ollama(a) => {
+                runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
+            }
+            #[cfg(test)]
+            AnyAgent::Mock(a) => {
                 runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
             }
         }
@@ -833,6 +854,15 @@ impl AnyAgent {
                 #[cfg(feature = "hooks")]
                 loop_info,
             ),
+            #[cfg(test)]
+            AnyAgent::Mock(a) => runner::spawn_agent(
+                a,
+                prompt,
+                history,
+                retry_config,
+                #[cfg(feature = "hooks")]
+                loop_info,
+            ),
         }
     }
 
@@ -865,6 +895,8 @@ impl AnyAgent {
             AnyAgent::Ollama(a) => {
                 runner::spawn_btw(a, prompt, history, event_tx, id, retry_config)
             }
+            #[cfg(test)]
+            AnyAgent::Mock(a) => runner::spawn_btw(a, prompt, history, event_tx, id, retry_config),
         }
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -108,5 +108,7 @@ mod todo_tests;
 mod tools_filter_tests;
 #[cfg(test)]
 mod tools_mod_tests;
+#[cfg(test)]
+mod tui_loop_tests;
 #[cfg(all(test, feature = "git-worktree"))]
 mod worktree_tests;

--- a/src/tests/tui_loop_tests.rs
+++ b/src/tests/tui_loop_tests.rs
@@ -235,14 +235,7 @@ async fn slash_clear_resets_session_and_feed() {
     .await;
     assert!(app.feed_text().contains("hi there"));
 
-    // Typing "/" opens the command picker; the first Enter only completes the
-    // highlighted command into the buffer ("/clear "), the second submits it —
-    // same as the interactive flow.
-    for c in "/clear".chars() {
-        app.inject(char_key(c)).await;
-    }
-    app.inject(enter_key()).await;
-    app.inject(enter_key()).await;
+    type_slash_and_submit(&app, "/clear").await;
     step_until(&mut app, |a| {
         a.session().messages.is_empty() && !a.feed_text().contains("hi there")
     })
@@ -274,6 +267,186 @@ async fn fake_backend_captures_output_and_paste_fills_input() {
     app.inject(UserEvent::Paste("a\nb".to_string())).await;
     pump(&mut app).await;
     assert_eq!(app.input_buffer(), "a\nb");
+
+    app.teardown().await;
+}
+
+/// Submit a slash command through the command picker: typing "/" opens it, so
+/// the first Enter only completes the highlighted command into the buffer (or,
+/// when the query has args and matches nothing, just closes the picker) and a
+/// second Enter submits — same as the interactive flow.
+async fn type_slash_and_submit(app: &App<'static>, text: &str) {
+    for c in text.chars() {
+        app.inject(char_key(c)).await;
+    }
+    app.inject(enter_key()).await;
+    app.inject(enter_key()).await;
+}
+
+#[tokio::test]
+async fn ctrl_c_aborts_running_agent() {
+    let _guard = acquire();
+    let (mut app, model) = headless_app(vec![vec!["second answer"]]).await;
+
+    type_and_submit(&app, "hello").await;
+    // Ctrl-C lands in the same FIFO channel right behind the Enter, so it is
+    // processed while the run is active (the agent task is never polled until
+    // the injected events are drained).
+    app.inject(UserEvent::Key(KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::CONTROL,
+    )))
+    .await;
+
+    step_until(&mut app, |a| {
+        !a.is_running() && a.feed_text().contains("interrupted")
+    })
+    .await;
+
+    // The aborted runner never reached the model; the aborted turn keeps the
+    // user message but adds no assistant reply.
+    assert!(model.requests().is_empty());
+    let messages = &app.session().messages;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].role, MessageRole::User);
+
+    // The loop is still usable: a fresh prompt starts a new run.
+    type_and_submit(&app, "again").await;
+    step_until(&mut app, |a| {
+        !a.is_running() && a.session().messages.len() == 3
+    })
+    .await;
+    let messages = &app.session().messages;
+    assert_eq!(messages[1].content.as_str(), "again");
+    assert_eq!(messages[2].content.as_str(), "second answer");
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn slash_rejected_while_running() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["answer"]]).await;
+
+    type_and_submit(&app, "hello").await;
+    type_slash_and_submit(&app, "/help").await;
+
+    step_until(&mut app, |a| {
+        a.feed_text()
+            .contains("agent is running — wait for it to finish")
+    })
+    .await;
+
+    // The running turn is unaffected and completes normally.
+    step_until(&mut app, |a| {
+        !a.is_running() && a.session().messages.len() == 2
+    })
+    .await;
+    assert_eq!(app.session().messages[1].content.as_str(), "answer");
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn queue_commands_list_and_pop() {
+    let _guard = acquire();
+    let (mut app, model) = headless_app(vec![vec!["answer a"]]).await;
+
+    type_and_submit(&app, "a").await;
+    type_and_submit(&app, "b").await;
+    type_slash_and_submit(&app, "/queue ls").await;
+    type_slash_and_submit(&app, "/queue pop").await;
+
+    step_until(&mut app, |a| a.feed_text().contains("  1. b")).await;
+    step_until(&mut app, |a| a.feed_text().contains("unqueued: b")).await;
+    step_until(&mut app, |a| !a.is_running()).await;
+
+    let feed = app.feed_text();
+    assert!(feed.contains("queued: b"), "feed: {feed}");
+    assert!(feed.contains("queued (1):"), "feed: {feed}");
+
+    // The popped input never ran: one model call, one exchange.
+    assert_eq!(model.requests().len(), 1);
+    let messages = &app.session().messages;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].content.as_str(), "a");
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn paste_multiline_submits_as_one_message() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["got it"]]).await;
+
+    app.inject(UserEvent::Paste("line1\nline2".to_string()))
+        .await;
+    app.inject(enter_key()).await;
+
+    step_until(&mut app, |a| {
+        !a.is_running() && a.session().messages.len() == 2
+    })
+    .await;
+
+    let messages = &app.session().messages;
+    assert_eq!(messages[0].role, MessageRole::User);
+    assert_eq!(messages[0].content.as_str(), "line1\nline2");
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn ctrl_r_toggles_reasoning_visibility() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![]).await;
+
+    let ctrl_r = || UserEvent::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL));
+    app.inject(ctrl_r()).await;
+    step_until(&mut app, |a| {
+        a.feed_text().contains("reasoning visibility: on")
+    })
+    .await;
+
+    app.inject(ctrl_r()).await;
+    step_until(&mut app, |a| {
+        a.feed_text().contains("reasoning visibility: off")
+    })
+    .await;
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn scroll_and_resize_events() {
+    let _guard = acquire();
+    // A long response so the feed overflows the 80x24 fake terminal.
+    let long_response: String = (0..45)
+        .map(|i| format!("response line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (mut app, _model) = headless_app(vec![vec![long_response.as_str()]]).await;
+
+    type_and_submit(&app, "hello").await;
+    step_until(&mut app, |a| {
+        !a.is_running() && a.session().messages.len() == 2
+    })
+    .await;
+    assert!(!app.is_scrolling());
+
+    for _ in 0..3 {
+        app.inject(UserEvent::ScrollUp).await;
+    }
+    step_until(&mut app, |a| a.is_scrolling()).await;
+    assert!(
+        app.backend_output().contains("SCROLL"),
+        "scrolled viewport should paint a scroll indicator"
+    );
+
+    for _ in 0..3 {
+        app.inject(UserEvent::ScrollDown).await;
+    }
+    app.inject(UserEvent::Resize).await;
+    step_until(&mut app, |a| !a.is_scrolling()).await;
 
     app.teardown().await;
 }

--- a/src/tests/tui_loop_tests.rs
+++ b/src/tests/tui_loop_tests.rs
@@ -1,0 +1,279 @@
+//! Integration tests for the TUI main loop (`ui::app::App`), run headless:
+//!
+//! - **Fake `UserEvent` source**: no crossterm event thread; tests inject
+//!   events straight into the loop's channel via `App::inject`.
+//! - **Fake renderer backend**: `renderer::FakeBackend` pins a fixed 80x24
+//!   geometry and captures every emitted frame, so nothing touches a real
+//!   terminal (no raw mode, no alternate screen).
+//! - **Scripted agent**: `AnyAgent::Mock` wraps rig's `MockCompletionModel`
+//!   (see `fake_model.rs`), so a full user-prompt → agent-response round trip
+//!   runs with no network.
+//!
+//! The loop is pumped one iteration at a time via `App::step`, which makes
+//! assertions between event dispatch deterministic: on the current-thread
+//! runtime used by `#[tokio::test]`, injected user events are always drained
+//! before the freshly spawned agent task is first polled.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::context::ContextFiles;
+use crate::event::UserEvent;
+use crate::provider::AnyAgent;
+use crate::sandbox::Sandbox;
+use crate::session::{MessageRole, Session};
+use crate::tests::fake_model::{self, FakeModel};
+use crate::ui::app::App;
+use crate::ui::renderer::FakeBackend;
+use crate::ui::state::UiContext;
+
+/// Serializes every test in this file: they share process-global state
+/// (`ZS_DATA_DIR`/`ZS_CONFIG_DIR` env, the statusline `OnceLock`, the subagent
+/// event-sender singleton set by `runner::spawn_agent`, the model cache).
+static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn acquire() -> MutexGuard<'static, ()> {
+    let lock = LOCK.get_or_init(|| Mutex::new(()));
+    lock.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn isolate_data_dirs() {
+    let dir = std::env::temp_dir().join(format!("zerostack-tui-loop-tests-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    unsafe { std::env::set_var("ZS_DATA_DIR", &dir) };
+    unsafe { std::env::set_var("ZS_CONFIG_DIR", &dir) };
+}
+
+/// Build a headless `App` with a scripted mock agent. `turns` scripts one
+/// model response per agent run (plain text chunks per turn). Returns the app
+/// and the model (for inspecting the requests the loop sent).
+async fn headless_app(turns: Vec<Vec<&str>>) -> (App<'static>, FakeModel) {
+    isolate_data_dirs();
+    let cli: &'static Cli = Box::leak(Box::new(Cli {
+        api_key: Some("test-key".to_string()),
+        no_session: true,
+        no_color: true,
+        ..Default::default()
+    }));
+    let cfg: &'static Config = Box::leak(Box::new(Config::default()));
+    let session: &'static mut Session = Box::leak(Box::new(Session::new(
+        "anthropic",
+        "claude-sonnet-4-5",
+        200_000,
+        "tui-loop-test",
+    )));
+    let context: &'static mut ContextFiles = Box::leak(Box::new(crate::context::load(true)));
+    let client =
+        crate::provider::create_client("anthropic", Some("test-key"), &HashMap::new(), None)
+            .expect("create test client");
+    let ui = UiContext::new(
+        cli,
+        cfg,
+        session,
+        context,
+        client,
+        None,
+        None,
+        Sandbox::new(false, "bwrap"),
+        None,
+    );
+    let model = fake_model::text_turns(turns);
+    let agent = AnyAgent::Mock(rig::agent::AgentBuilder::new(model.clone()).build());
+    let app = App::new_headless(
+        ui,
+        Some(agent),
+        None,
+        None,
+        Box::new(FakeBackend::new(80, 24)),
+    )
+    .await
+    .expect("build headless app");
+    (app, model)
+}
+
+fn char_key(c: char) -> UserEvent {
+    UserEvent::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+}
+
+fn enter_key() -> UserEvent {
+    UserEvent::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+}
+
+/// Type `text` into the input editor and submit it with Enter.
+async fn type_and_submit(app: &App<'static>, text: &str) {
+    for c in text.chars() {
+        app.inject(char_key(c)).await;
+    }
+    app.inject(enter_key()).await;
+}
+
+/// Pump one iteration, treating an idle (event-less) loop as a no-op instead
+/// of blocking forever: `App::step`'s `select!` parks when no branch is ready,
+/// which is correct in production (the event thread always feeds it) but would
+/// hang a test whose condition can't be reached.
+async fn pump(app: &mut App<'static>) {
+    if let Ok(result) =
+        tokio::time::timeout(std::time::Duration::from_millis(250), app.step()).await
+    {
+        let _ = result.expect("step failed");
+    }
+    // Err(_) = idle timeout: no events pending, nothing running.
+}
+
+/// Pump the loop until `done` holds, bounded so a stuck loop fails instead of
+/// hanging the suite.
+async fn step_until(app: &mut App<'static>, mut done: impl FnMut(&App<'static>) -> bool) {
+    const MAX_STEPS: usize = 300;
+    for _ in 0..MAX_STEPS {
+        if done(app) {
+            return;
+        }
+        pump(app).await;
+    }
+    assert!(done(app), "condition not met within {MAX_STEPS} steps");
+}
+
+#[tokio::test]
+async fn submit_prompt_streams_response_and_updates_session() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["hi there"]]).await;
+
+    type_and_submit(&app, "hello").await;
+    step_until(&mut app, |a| a.is_running()).await;
+    step_until(&mut app, |a| !a.is_running()).await;
+
+    let messages = &app.session().messages;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, MessageRole::User);
+    assert_eq!(messages[0].content.as_str(), "hello");
+    assert_eq!(messages[1].role, MessageRole::Assistant);
+    assert_eq!(messages[1].content.as_str(), "hi there");
+
+    let feed = app.feed_text();
+    assert!(
+        feed.contains("> hello"),
+        "feed should echo the prompt: {feed}"
+    );
+    assert!(
+        feed.contains("hi there"),
+        "feed should show the response: {feed}"
+    );
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn queued_input_replays_after_current_run() {
+    let _guard = acquire();
+    let (mut app, model) = headless_app(vec![vec!["answer one"], vec!["answer two"]]).await;
+
+    // Inject everything up front: the injected events are drained before the
+    // freshly spawned agent task is ever polled, so "second" is submitted
+    // while the first run is still active and must be queued.
+    type_and_submit(&app, "first").await;
+    type_and_submit(&app, "second").await;
+
+    step_until(&mut app, |a| a.feed_text().contains("queued: second")).await;
+    step_until(&mut app, |a| {
+        a.is_running() && a.session().messages.len() >= 3
+    })
+    .await;
+    step_until(&mut app, |a| !a.is_running()).await;
+
+    assert_eq!(
+        model.requests().len(),
+        2,
+        "both turns should have reached the model"
+    );
+    let messages = &app.session().messages;
+    let roles: Vec<(MessageRole, &str)> = messages
+        .iter()
+        .map(|m| (m.role, m.content.as_str()))
+        .collect();
+    assert_eq!(
+        roles,
+        vec![
+            (MessageRole::User, "first"),
+            (MessageRole::Assistant, "answer one"),
+            (MessageRole::User, "second"),
+            (MessageRole::Assistant, "answer two"),
+        ]
+    );
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn ctrl_c_exits_main_loop_when_idle() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![]).await;
+
+    app.inject(UserEvent::Key(KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::CONTROL,
+    )))
+    .await;
+
+    // The full `run()` returns cleanly once the loop breaks on Ctrl-C.
+    app.run().await.expect("run should exit on Ctrl-C");
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn slash_clear_resets_session_and_feed() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["hi there"]]).await;
+
+    type_and_submit(&app, "hello").await;
+    step_until(&mut app, |a| {
+        !a.is_running() && a.session().messages.len() == 2
+    })
+    .await;
+    assert!(app.feed_text().contains("hi there"));
+
+    // Typing "/" opens the command picker; the first Enter only completes the
+    // highlighted command into the buffer ("/clear "), the second submits it —
+    // same as the interactive flow.
+    for c in "/clear".chars() {
+        app.inject(char_key(c)).await;
+    }
+    app.inject(enter_key()).await;
+    app.inject(enter_key()).await;
+    step_until(&mut app, |a| {
+        a.session().messages.is_empty() && !a.feed_text().contains("hi there")
+    })
+    .await;
+
+    assert!(app.session().messages.is_empty());
+    let feed = app.feed_text();
+    assert!(
+        feed.contains("zerostack"),
+        "cleared feed should show the fresh welcome block: {feed}"
+    );
+
+    app.teardown().await;
+}
+
+#[tokio::test]
+async fn fake_backend_captures_output_and_paste_fills_input() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![]).await;
+
+    // The startup render already went through the fake backend.
+    let captured = app.backend_output();
+    assert!(
+        captured.contains('\x1b'),
+        "backend should capture ANSI frames, got {} bytes",
+        captured.len()
+    );
+
+    app.inject(UserEvent::Paste("a\nb".to_string())).await;
+    pump(&mut app).await;
+    assert_eq!(app.input_buffer(), "a\nb");
+
+    app.teardown().await;
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -531,6 +531,11 @@ impl<'a> App<'a> {
         self.run.is_running
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_scrolling(&self) -> bool {
+        self.renderer.is_scrolling()
+    }
+
     /// All feed lines (wrapped to 80 cols) joined with newlines.
     #[cfg(test)]
     pub(crate) fn feed_text(&self) -> String {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -71,18 +71,66 @@ pub(crate) struct App<'a> {
     running: Arc<AtomicBool>,
     event_handle: Option<std::thread::JoinHandle<()>>,
     prebuild_rx: Option<mpsc::Receiver<PrebuildPayload>>,
-    _terminal_guard: TerminalGuard,
+    _terminal_guard: Option<TerminalGuard>,
 }
 
 impl<'a> App<'a> {
     pub(crate) async fn new(
-        mut ui: UiContext<'a>,
+        ui: UiContext<'a>,
         agent: Option<AnyAgent>,
         ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
         auto_trigger_msg: Option<String>,
         #[cfg(feature = "advisor")] handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
     ) -> anyhow::Result<Self> {
-        let _terminal_guard = TerminalGuard::new()?;
+        Self::create(
+            ui,
+            agent,
+            ask_rx,
+            auto_trigger_msg,
+            #[cfg(feature = "advisor")]
+            handoff_rx,
+            None,
+        )
+        .await
+    }
+
+    /// Headless constructor for integration tests: no terminal guard, no
+    /// crossterm event thread, and a fake render backend that captures output.
+    /// Events are fed through [`App::inject`] and the loop is pumped with
+    /// [`App::step`].
+    #[cfg(test)]
+    pub(crate) async fn new_headless(
+        ui: UiContext<'a>,
+        agent: Option<AnyAgent>,
+        ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
+        auto_trigger_msg: Option<String>,
+        backend: Box<dyn renderer_mod::RenderBackend>,
+    ) -> anyhow::Result<Self> {
+        Self::create(
+            ui,
+            agent,
+            ask_rx,
+            auto_trigger_msg,
+            #[cfg(feature = "advisor")]
+            None,
+            Some(backend),
+        )
+        .await
+    }
+
+    async fn create(
+        mut ui: UiContext<'a>,
+        agent: Option<AnyAgent>,
+        ask_rx: Option<mpsc::Receiver<crate::permission::ask::AskRequest>>,
+        auto_trigger_msg: Option<String>,
+        #[cfg(feature = "advisor")] handoff_rx: Option<crate::extras::advisor::HandoffReceiver>,
+        headless_backend: Option<Box<dyn renderer_mod::RenderBackend>>,
+    ) -> anyhow::Result<Self> {
+        let headless = headless_backend.is_some();
+        let _terminal_guard = match headless {
+            true => None,
+            false => Some(TerminalGuard::new()?),
+        };
 
         ui.session.show_cost_always = ui.cfg.resolve_show_cost_always();
         crate::ui::statusline::init(ui.cfg);
@@ -93,7 +141,10 @@ impl<'a> App<'a> {
         }
         let last_branch_check = std::time::Instant::now();
 
-        let mut renderer = Renderer::new()?;
+        let mut renderer = match headless_backend {
+            Some(backend) => Renderer::with_backend(backend),
+            None => Renderer::new()?,
+        };
         renderer.set_statusline_height(crate::ui::statusline::line_count());
         renderer.set_monochrome(ui.cli.no_color);
         renderer.set_chat_margin(ui.cfg.resolve_chat_left_margin());
@@ -184,16 +235,23 @@ impl<'a> App<'a> {
             let provider = ui.session.provider.to_string();
             let is_custom = ui.cfg.custom_providers_map().contains_key(&provider);
             let warm_start = std::time::Instant::now();
-            let ids = crate::ui::slash::warm_model_cache(
-                &provider, is_custom, &ui.client, ui.cli, ui.cfg,
-            )
-            .await;
-            tracing::debug!(
-                "startup: warm_model_cache('{}') took {:?} ({} models)",
-                provider,
-                warm_start.elapsed(),
-                ids.len()
-            );
+            // Headless tests skip the cache warm: it can reach the network for
+            // non-catalog providers and the model list is never exercised.
+            let ids = if headless {
+                Vec::new()
+            } else {
+                let ids = crate::ui::slash::warm_model_cache(
+                    &provider, is_custom, &ui.client, ui.cli, ui.cfg,
+                )
+                .await;
+                tracing::debug!(
+                    "startup: warm_model_cache('{}') took {:?} ({} models)",
+                    provider,
+                    warm_start.elapsed(),
+                    ids.len()
+                );
+                ids
+            };
             input.set_live_model_names(ids);
         }
 
@@ -294,7 +352,11 @@ impl<'a> App<'a> {
 
         let (user_tx, user_rx) = mpsc::channel::<UserEvent>(64);
         let running = Arc::new(AtomicBool::new(true));
-        let event_handle = Some(spawn_event_thread(user_tx.clone(), running.clone()));
+        // Headless tests drive the loop via `inject`, so no crossterm reader.
+        let event_handle = match headless {
+            true => None,
+            false => Some(spawn_event_thread(user_tx.clone(), running.clone())),
+        };
 
         let (prebuild_tx, prebuild_rx_raw) = mpsc::channel::<PrebuildPayload>(1);
         let prebuild_rx = Some(prebuild_rx_raw);
@@ -374,6 +436,22 @@ impl<'a> App<'a> {
 
     pub(crate) async fn run(&mut self) -> anyhow::Result<()> {
         loop {
+            match self.step().await? {
+                ControlFlow::Break(()) => break,
+                ControlFlow::Continue(()) => {}
+            }
+        }
+
+        self.handle_worktree_auto_merge().await?;
+        Ok(())
+    }
+
+    /// One iteration of the main loop: housekeeping (git branch refresh), one
+    /// round of the event `select!`, and the advisor handoff drain. Split out
+    /// from [`App::run`] so headless integration tests can pump the loop one
+    /// step at a time and assert on state in between.
+    pub(crate) async fn step(&mut self) -> anyhow::Result<ControlFlow<(), ()>> {
+        {
             self.ui.session.reasoning_enabled = self.slash.reasoning_enabled;
             if self.last_branch_check.elapsed() >= Duration::from_secs(1) {
                 self.ui.session.refresh_git_branch();
@@ -386,7 +464,7 @@ impl<'a> App<'a> {
             tokio::select! {
                 Some(ev) = self.user_rx.recv() => {
                     match self.handle_user_event(ev).await? {
-                        ControlFlow::Break(()) => break,
+                        ControlFlow::Break(()) => return Ok(ControlFlow::Break(())),
                         ControlFlow::Continue(()) => {}
                     }
                 }
@@ -435,8 +513,49 @@ impl<'a> App<'a> {
             }
         }
 
-        self.handle_worktree_auto_merge().await?;
-        Ok(())
+        Ok(ControlFlow::Continue(()))
+    }
+
+    // --- Headless-test helpers: a fake `UserEvent` source (events injected
+    // straight into the loop's channel) plus accessors over the state the loop
+    // mutated, so tests can pump `step` and assert in between. ---
+
+    /// Queue a fake user event, as if the crossterm event thread had sent it.
+    #[cfg(test)]
+    pub(crate) async fn inject(&self, ev: UserEvent) {
+        self.user_tx.send(ev).await.expect("event channel closed");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_running(&self) -> bool {
+        self.run.is_running
+    }
+
+    /// All feed lines (wrapped to 80 cols) joined with newlines.
+    #[cfg(test)]
+    pub(crate) fn feed_text(&self) -> String {
+        self.renderer
+            .feed()
+            .lines(80)
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_buffer(&self) -> String {
+        self.input.buffer.to_string()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_output(&self) -> String {
+        self.renderer.captured_output()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn session(&self) -> &crate::session::Session {
+        self.ui.session
     }
 
     pub(crate) async fn teardown(self) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -160,7 +160,13 @@ pub(crate) fn refresh_display(
     renderer.draw_bottom(&input.buffer, input.cursor, &statusline, run.is_running)?;
     if let Some(ref mut picker) = input.picker {
         let was_active = picker.active();
-        picker.draw()?;
+        // Pickers paint straight onto real stdout, bypassing the render
+        // backend; in headless test runs there is no usable terminal (and on
+        // CI stdout is a non-blocking pipe, so the burst of escape sequences
+        // fails with EAGAIN). Key handling is unaffected — only painting.
+        if !renderer.is_headless() {
+            picker.draw()?;
+        }
         if was_active {
             // The picker painted over the chat and bottom regions, which the
             // dirty-region tracking cannot see; force a full repaint next

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,4 @@
-mod app;
+pub(crate) mod app;
 mod event_handler;
 pub(crate) mod events;
 pub(crate) mod feed;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 use std::sync::LazyLock;
 
 use compact_str::CompactString;
-use crossterm::ExecutableCommand;
+use crossterm::QueueableCommand;
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::style::{
     Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
@@ -15,6 +15,85 @@ use super::feed::{BlockStyle, Feed, style_from_color};
 use super::markdown::word_wrap;
 use super::statusline::StatusSpan;
 use super::utils::{char_display_width, display_width, resolve_color};
+
+/// Terminal output sink for [`Renderer`]: every ANSI write and terminal-size
+/// read goes through this trait. Production uses [`CrosstermBackend`] (stdout
+/// plus the real terminal size); tests swap in [`FakeBackend`] to capture the
+/// emitted frames and pin a fixed geometry — this is what lets the main loop
+/// run headless in integration tests.
+pub(crate) trait RenderBackend: io::Write + Send {
+    fn size(&self) -> io::Result<(u16, u16)>;
+
+    /// Everything written so far, for test assertions. `None` on real backends.
+    #[cfg(test)]
+    fn captured(&self) -> Option<String> {
+        None
+    }
+}
+
+/// Production backend: plain stdout plus `crossterm::terminal::size`.
+pub(crate) struct CrosstermBackend {
+    stdout: io::Stdout,
+}
+
+impl io::Write for CrosstermBackend {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.stdout.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stdout.flush()
+    }
+}
+
+impl RenderBackend for CrosstermBackend {
+    fn size(&self) -> io::Result<(u16, u16)> {
+        crossterm::terminal::size()
+    }
+}
+
+/// Test backend: fixed terminal geometry, records every byte written so tests
+/// can assert on the frames the renderer emitted.
+#[cfg(test)]
+pub(crate) struct FakeBackend {
+    buf: Vec<u8>,
+    cols: u16,
+    rows: u16,
+}
+
+#[cfg(test)]
+impl FakeBackend {
+    pub(crate) fn new(cols: u16, rows: u16) -> Self {
+        Self {
+            buf: Vec::new(),
+            cols,
+            rows,
+        }
+    }
+}
+
+#[cfg(test)]
+impl io::Write for FakeBackend {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl RenderBackend for FakeBackend {
+    fn size(&self) -> io::Result<(u16, u16)> {
+        Ok((self.cols, self.rows))
+    }
+
+    fn captured(&self) -> Option<String> {
+        Some(String::from_utf8_lossy(&self.buf).into_owned())
+    }
+}
 
 static URL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"https?://[^\x00-\x1f\x7f\s<>]+").expect("compile URL regex"));
@@ -113,6 +192,7 @@ pub(crate) enum BottomRedrawPlan {
 }
 
 pub struct Renderer {
+    backend: Box<dyn RenderBackend>,
     spinner_frame: u8,
     feed: Feed,
     partial: CompactString,
@@ -159,7 +239,14 @@ pub struct Renderer {
 
 impl Renderer {
     pub fn new() -> io::Result<Self> {
-        Ok(Renderer {
+        Ok(Self::with_backend(Box::new(CrosstermBackend {
+            stdout: io::stdout(),
+        })))
+    }
+
+    pub(crate) fn with_backend(backend: Box<dyn RenderBackend>) -> Self {
+        Renderer {
+            backend,
             spinner_frame: 0,
             feed: Feed::new(),
             partial: CompactString::new(""),
@@ -193,7 +280,14 @@ impl Renderer {
             bottom_dirty: true,
             last_bottom_snapshot: None,
             bottom_cursor: None,
-        })
+        }
+    }
+
+    /// Queue a crossterm command to the backend and flush, mirroring
+    /// `ExecutableCommand::execute` semantics.
+    fn exec(&mut self, command: impl crossterm::Command) -> io::Result<()> {
+        self.backend.queue(command)?;
+        self.backend.flush()
     }
 
     /// Set the number of statusline rows (1-3). Call once at startup.
@@ -220,9 +314,9 @@ impl Renderer {
     /// Emit the chat left-margin gutter (spaces in the chat background) at the
     /// current cursor position. Caller has already positioned to column 0 and
     /// set the background.
-    fn write_chat_margin(&self, stdout: &mut impl Write) -> io::Result<()> {
-        if self.chat_margin > 0 {
-            write!(stdout, "{}", " ".repeat(self.chat_margin as usize))?;
+    fn write_chat_margin(margin: u16, stdout: &mut impl Write) -> io::Result<()> {
+        if margin > 0 {
+            write!(stdout, "{}", " ".repeat(margin as usize))?;
         }
         Ok(())
     }
@@ -243,7 +337,7 @@ impl Renderer {
     }
 
     fn terminal_size(&self) -> (u16, u16) {
-        crossterm::terminal::size().unwrap_or((80, 24))
+        self.backend.size().unwrap_or((80, 24))
     }
 
     fn max_line_width(&self) -> usize {
@@ -323,6 +417,13 @@ impl Renderer {
     #[cfg(test)]
     pub fn mark_chat_clean(&mut self) {
         self.record_chat_drawn();
+    }
+
+    /// Test helper: everything written to a [`FakeBackend`] so far (empty on
+    /// real backends).
+    #[cfg(test)]
+    pub(crate) fn captured_output(&self) -> String {
+        self.backend.captured().unwrap_or_default()
     }
 
     /// Mark both regions dirty, forcing a full repaint on the next frame.
@@ -584,8 +685,7 @@ impl Renderer {
         let visible = self.visible_lines();
         let buffer = self.chat_lines(max_width);
         let total = buffer.len();
-        let mut stdout = io::stdout();
-        write!(stdout, "{}", Hide)?;
+        write!(self.backend, "{}", Hide)?;
 
         let auto_scroll = self.scroll_offset == 0;
         let start = if auto_scroll {
@@ -603,12 +703,13 @@ impl Renderer {
         if auto_scroll && total < visible {
             let pad = visible - total;
             for _ in 0..pad {
-                stdout.execute(MoveTo(0, visual_row))?;
+                self.exec(MoveTo(0, visual_row))?;
                 if let Some(bg) = self.chat_bg {
-                    write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                    let bg = self.color(bg);
+                    write!(self.backend, "{}", SetBackgroundColor(bg))?;
                 }
-                write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-                write!(stdout, "{}", ResetColor)?;
+                write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+                write!(self.backend, "{}", ResetColor)?;
                 visual_row += 1;
             }
         }
@@ -621,7 +722,7 @@ impl Renderer {
                 break;
             }
 
-            stdout.execute(MoveTo(0, visual_row))?;
+            self.exec(MoveTo(0, visual_row))?;
 
             let is_selected = self.selection_active
                 && if let (Some(s), Some(e)) = (self.selection_start, self.selection_end) {
@@ -633,31 +734,34 @@ impl Renderer {
                 };
 
             if let Some(bg) = self.chat_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                let bg = self.color(bg);
+                write!(self.backend, "{}", SetBackgroundColor(bg))?;
             }
-            self.write_chat_margin(&mut stdout)?;
+            Self::write_chat_margin(self.chat_margin, &mut self.backend)?;
             if is_selected {
-                write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
+                write!(self.backend, "{}", SetAttribute(Attribute::Reverse))?;
             }
-            write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
-            write!(stdout, "{}", wrap_urls_osc8(chunk))?;
+            let fg = self.color(entry.color);
+            write!(self.backend, "{}", SetForegroundColor(fg))?;
+            write!(self.backend, "{}", wrap_urls_osc8(chunk))?;
             if is_selected {
-                write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
+                write!(self.backend, "{}", SetAttribute(Attribute::NoReverse))?;
             }
-            write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-            write!(stdout, "{}", ResetColor)?;
+            write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+            write!(self.backend, "{}", ResetColor)?;
 
             visual_row += 1;
             buf_idx += 1;
         }
 
         while (visual_row as usize) < visible {
-            stdout.execute(MoveTo(0, visual_row))?;
+            self.exec(MoveTo(0, visual_row))?;
             if let Some(bg) = self.chat_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                let bg = self.color(bg);
+                write!(self.backend, "{}", SetBackgroundColor(bg))?;
             }
-            write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-            write!(stdout, "{}", ResetColor)?;
+            write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+            write!(self.backend, "{}", ResetColor)?;
             visual_row += 1;
         }
 
@@ -669,20 +773,18 @@ impl Renderer {
             };
             let indicator = format!(" SCROLL {}% ", pct);
             let x = cols.saturating_sub(indicator.len() as u16);
-            stdout.execute(MoveTo(x, 0))?;
+            self.exec(MoveTo(x, 0))?;
             if let Some(bg) = self.chat_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                let bg = self.color(bg);
+                write!(self.backend, "{}", SetBackgroundColor(bg))?;
             }
-            write!(
-                stdout,
-                "{}",
-                SetForegroundColor(self.color(Color::DarkYellow))
-            )?;
-            write!(stdout, "{}", indicator)?;
-            write!(stdout, "{}", ResetColor)?;
+            let fg = self.color(Color::DarkYellow);
+            write!(self.backend, "{}", SetForegroundColor(fg))?;
+            write!(self.backend, "{}", indicator)?;
+            write!(self.backend, "{}", ResetColor)?;
         }
 
-        stdout.flush()?;
+        self.backend.flush()?;
         self.record_chat_drawn();
         Ok(())
     }
@@ -731,14 +833,14 @@ impl Renderer {
         self.partial.clear();
         self.scroll_offset = 0;
         self.clear_selection();
-        let mut stdout = io::stdout();
         if let Some(bg) = self.chat_bg {
-            write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            let bg = self.color(bg);
+            write!(self.backend, "{}", SetBackgroundColor(bg))?;
         }
-        stdout.execute(Clear(ClearType::All))?;
-        write!(stdout, "{}", ResetColor)?;
-        stdout.execute(MoveTo(0, 0))?;
-        stdout.flush()?;
+        self.exec(Clear(ClearType::All))?;
+        write!(self.backend, "{}", ResetColor)?;
+        self.exec(MoveTo(0, 0))?;
+        self.backend.flush()?;
         Ok(())
     }
 
@@ -751,7 +853,7 @@ impl Renderer {
         }
     }
 
-    fn clear_shrunk_rows(&self, old_height: usize, new_height: usize) -> io::Result<()> {
+    fn clear_shrunk_rows(&mut self, old_height: usize, new_height: usize) -> io::Result<()> {
         if new_height >= old_height {
             return Ok(());
         }
@@ -760,32 +862,29 @@ impl Renderer {
         let avail = rows.saturating_sub(reserve);
         let old_start = avail.saturating_sub(old_height as u16).saturating_add(1);
         let new_start = avail.saturating_sub(new_height as u16).saturating_add(1);
-        let mut stdout = io::stdout();
         for row in old_start..new_start {
-            stdout.execute(MoveTo(0, row))?;
+            self.exec(MoveTo(0, row))?;
             if let Some(bg) = self.input_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                let bg = self.color(bg);
+                write!(self.backend, "{}", SetBackgroundColor(bg))?;
             }
-            write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-            write!(stdout, "{}", ResetColor)?;
+            write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+            write!(self.backend, "{}", ResetColor)?;
         }
         Ok(())
     }
 
-    fn draw_separator(&self, row: u16, cols: u16) -> io::Result<()> {
-        let mut stdout = io::stdout();
-        stdout.execute(MoveTo(0, row))?;
+    fn draw_separator(&mut self, row: u16, cols: u16) -> io::Result<()> {
+        self.exec(MoveTo(0, row))?;
         if let Some(bg) = self.input_bg {
-            write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            let bg = self.color(bg);
+            write!(self.backend, "{}", SetBackgroundColor(bg))?;
         }
-        write!(
-            stdout,
-            "{}",
-            SetForegroundColor(self.color(Color::DarkGrey))
-        )?;
+        let fg = self.color(Color::DarkGrey);
+        write!(self.backend, "{}", SetForegroundColor(fg))?;
         let sep: String = "─".repeat(cols as usize);
-        write!(stdout, "{}", sep)?;
-        write!(stdout, "{}", ResetColor)?;
+        write!(self.backend, "{}", sep)?;
+        write!(self.backend, "{}", ResetColor)?;
         Ok(())
     }
 
@@ -793,7 +892,7 @@ impl Renderer {
     /// expand to fill remaining width. Fewer lines than `statusline_height` leaves
     /// the upper statusline rows blank.
     fn draw_statusline(
-        &self,
+        &mut self,
         statusline: &[Vec<StatusSpan>],
         cols: u16,
         is_scrolling: bool,
@@ -816,35 +915,33 @@ impl Renderer {
     }
 
     fn draw_statusline_row(
-        &self,
+        &mut self,
         screen_row: u16,
         spans: &[StatusSpan],
         prefix: &str,
         cols: u16,
     ) -> io::Result<()> {
-        let mut stdout = io::stdout();
-        stdout.execute(MoveTo(0, screen_row))?;
+        self.exec(MoveTo(0, screen_row))?;
         if let Some(bg) = self.status_bg {
-            write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            let bg = self.color(bg);
+            write!(self.backend, "{}", SetBackgroundColor(bg))?;
         }
-        write!(stdout, "{}", Clear(ClearType::CurrentLine))?;
-        stdout.execute(MoveTo(0, screen_row))?;
+        write!(self.backend, "{}", Clear(ClearType::CurrentLine))?;
+        self.exec(MoveTo(0, screen_row))?;
         if let Some(bg) = self.status_bg {
-            write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+            let bg = self.color(bg);
+            write!(self.backend, "{}", SetBackgroundColor(bg))?;
         }
 
         let total = cols as usize;
         let mut budget = total;
 
         if !prefix.is_empty() {
-            write!(
-                stdout,
-                "{}",
-                SetForegroundColor(self.color(Color::DarkYellow))
-            )?;
+            let fg = self.color(Color::DarkYellow);
+            write!(self.backend, "{}", SetForegroundColor(fg))?;
             let take = prefix.chars().take(budget).collect::<String>();
             budget -= display_width(&take);
-            write!(stdout, "{}", take)?;
+            write!(self.backend, "{}", take)?;
         }
 
         // Fixed width of all text spans; flex shares what is left.
@@ -870,16 +967,19 @@ impl Renderer {
                 StatusSpan::Text { text, fg, bg } => {
                     let bgc = bg.or(self.status_bg);
                     if let Some(c) = bgc {
-                        write!(stdout, "{}", SetBackgroundColor(self.color(c)))?;
+                        let c = self.color(c);
+                        write!(self.backend, "{}", SetBackgroundColor(c))?;
                     }
                     let fgc = fg.unwrap_or(Color::DarkGrey);
-                    write!(stdout, "{}", SetForegroundColor(self.color(fgc)))?;
+                    let fgc = self.color(fgc);
+                    write!(self.backend, "{}", SetForegroundColor(fgc))?;
                     let piece: String = text.chars().take(budget).collect();
                     budget = budget.saturating_sub(display_width(&piece));
-                    write!(stdout, "{}", piece)?;
-                    write!(stdout, "{}", ResetColor)?;
+                    write!(self.backend, "{}", piece)?;
+                    write!(self.backend, "{}", ResetColor)?;
                     if let Some(bg) = self.status_bg {
-                        write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                        let bg = self.color(bg);
+                        write!(self.backend, "{}", SetBackgroundColor(bg))?;
                     }
                 }
                 StatusSpan::Flex => {
@@ -897,13 +997,13 @@ impl Renderer {
                     let width = (base + extra).min(budget);
                     flex_left = flex_left.saturating_sub(width);
                     budget = budget.saturating_sub(width);
-                    write!(stdout, "{}", " ".repeat(width))?;
+                    write!(self.backend, "{}", " ".repeat(width))?;
                 }
             }
         }
 
-        write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-        write!(stdout, "{}", ResetColor)?;
+        write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+        write!(self.backend, "{}", ResetColor)?;
         Ok(())
     }
 
@@ -984,18 +1084,17 @@ impl Renderer {
 
     /// Re-place the terminal caret where the last full bottom draw left it.
     /// Needed after a statusline-only redraw, which moves the cursor.
-    fn restore_bottom_cursor(&self) -> io::Result<()> {
-        let mut stdout = io::stdout();
+    fn restore_bottom_cursor(&mut self) -> io::Result<()> {
         match self.bottom_cursor {
             Some((x, row)) => {
-                stdout.execute(MoveTo(x, row))?;
-                write!(stdout, "{}", Show)?;
+                self.exec(MoveTo(x, row))?;
+                write!(self.backend, "{}", Show)?;
             }
             None => {
-                write!(stdout, "{}", Hide)?;
+                write!(self.backend, "{}", Hide)?;
             }
         }
-        stdout.flush()
+        self.backend.flush()
     }
 
     pub fn draw_bottom(
@@ -1005,7 +1104,7 @@ impl Renderer {
         statusline: &[Vec<StatusSpan>],
         is_running: bool,
     ) -> io::Result<()> {
-        let (cols, rows) = crossterm::terminal::size()?;
+        let (cols, rows) = self.backend.size()?;
         let snapshot =
             self.bottom_snapshot(input_line, cursor_pos, statusline, is_running, cols, rows);
         match Self::bottom_redraw_plan(
@@ -1023,10 +1122,12 @@ impl Renderer {
             BottomRedrawPlan::Full => {}
         }
         let reserve = self.statusline_reserve();
-        let mut stdout = io::stdout();
 
-        if let Some(ref pp) = self.permission_prompt {
-            let perm_lines = [pp.tool.as_str(), pp.options.as_str()];
+        let permission_lines = self
+            .permission_prompt
+            .as_ref()
+            .map(|pp| [pp.tool.to_string(), pp.options.to_string()]);
+        if let Some(perm_lines) = permission_lines {
             let line_count = 2usize;
             let input_top = rows
                 .saturating_sub(reserve)
@@ -1044,14 +1145,15 @@ impl Renderer {
             let perm_color = self.color(Color::DarkYellow);
             for (i, line) in perm_lines.iter().enumerate() {
                 let render_row = input_top + i as u16;
-                stdout.execute(MoveTo(0, render_row))?;
+                self.exec(MoveTo(0, render_row))?;
                 if let Some(bg) = self.input_bg {
-                    write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                    let bg = self.color(bg);
+                    write!(self.backend, "{}", SetBackgroundColor(bg))?;
                 }
-                write!(stdout, "{}", SetForegroundColor(perm_color))?;
-                write!(stdout, "{}", line)?;
-                write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-                write!(stdout, "{}", ResetColor)?;
+                write!(self.backend, "{}", SetForegroundColor(perm_color))?;
+                write!(self.backend, "{}", line)?;
+                write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+                write!(self.backend, "{}", ResetColor)?;
             }
 
             let sep_below = rows.saturating_sub(reserve - 1);
@@ -1060,20 +1162,22 @@ impl Renderer {
             }
 
             self.draw_statusline(statusline, cols, false)?;
-            write!(stdout, "{}", Hide)?;
-            stdout.flush()?;
+            write!(self.backend, "{}", Hide)?;
+            self.backend.flush()?;
             self.bottom_cursor = None;
             self.record_bottom_drawn(snapshot);
             return Ok(());
         }
 
-        if let Some(ref cp) = self.chain_prompt {
-            let question = cp.question.as_str();
+        let chain_lines = self.chain_prompt.as_ref().map(|cp| {
             let options = if self.chain_but_mode {
                 "[Enter] send  [Esc] cancel"
             } else {
                 "[Y] Yes  [N] No  [B] yes, But (add instruction)"
             };
+            [cp.question.to_string(), options.to_string()]
+        });
+        if let Some(render_lines) = chain_lines {
             let line_count = 2usize;
             let input_top = rows
                 .saturating_sub(reserve)
@@ -1089,17 +1193,17 @@ impl Renderer {
             }
 
             let chain_color = self.color(Color::DarkYellow);
-            let render_lines = [question, options];
             for (i, line) in render_lines.iter().enumerate() {
                 let render_row = input_top + i as u16;
-                stdout.execute(MoveTo(0, render_row))?;
+                self.exec(MoveTo(0, render_row))?;
                 if let Some(bg) = self.input_bg {
-                    write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                    let bg = self.color(bg);
+                    write!(self.backend, "{}", SetBackgroundColor(bg))?;
                 }
-                write!(stdout, "{}", SetForegroundColor(chain_color))?;
-                write!(stdout, "{}", line)?;
-                write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-                write!(stdout, "{}", ResetColor)?;
+                write!(self.backend, "{}", SetForegroundColor(chain_color))?;
+                write!(self.backend, "{}", line)?;
+                write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+                write!(self.backend, "{}", ResetColor)?;
             }
 
             let sep_below = rows.saturating_sub(reserve - 1);
@@ -1108,8 +1212,8 @@ impl Renderer {
             }
 
             self.draw_statusline(statusline, cols, false)?;
-            write!(stdout, "{}", Hide)?;
-            stdout.flush()?;
+            write!(self.backend, "{}", Hide)?;
+            self.backend.flush()?;
             self.bottom_cursor = None;
             self.record_bottom_drawn(snapshot);
             return Ok(());
@@ -1223,22 +1327,20 @@ impl Renderer {
         {
             let render_row = (rows.saturating_sub(reserve) - visible_line_count as u16 + 1)
                 + (i - first_visible) as u16;
-            stdout.execute(MoveTo(0, render_row))?;
+            self.exec(MoveTo(0, render_row))?;
 
             if let Some(bg) = self.input_bg {
-                write!(stdout, "{}", SetBackgroundColor(self.color(bg)))?;
+                let bg = self.color(bg);
+                write!(self.backend, "{}", SetBackgroundColor(bg))?;
             }
 
             if i == first_visible {
-                write!(
-                    stdout,
-                    "{}",
-                    SetForegroundColor(self.color(Color::DarkYellow))
-                )?;
-                write!(stdout, "{}", prompt)?;
-                write!(stdout, "{}", SetForegroundColor(Color::Reset))?;
+                let fg = self.color(Color::DarkYellow);
+                write!(self.backend, "{}", SetForegroundColor(fg))?;
+                write!(self.backend, "{}", prompt)?;
+                write!(self.backend, "{}", SetForegroundColor(Color::Reset))?;
             } else {
-                write!(stdout, "{}", " ".repeat(prompt_width))?;
+                write!(self.backend, "{}", " ".repeat(prompt_width))?;
             }
 
             let line_chars: SmallVec<[char; 64]> = line.chars().collect();
@@ -1263,9 +1365,9 @@ impl Renderer {
                 .skip(skip_chars)
                 .take(visible_width)
                 .collect();
-            write!(stdout, "{}", display)?;
-            write!(stdout, "{}", Clear(ClearType::UntilNewLine))?;
-            write!(stdout, "{}", ResetColor)?;
+            write!(self.backend, "{}", display)?;
+            write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
+            write!(self.backend, "{}", ResetColor)?;
         }
 
         // Thin separator line below input
@@ -1286,9 +1388,9 @@ impl Renderer {
         let cursor_row = (rows.saturating_sub(reserve) - visible_line_count as u16 + 1)
             + cursor_render_idx as u16;
         let cursor_x = (prompt_width + cursor_display_col.saturating_sub(h_scroll)) as u16;
-        stdout.execute(MoveTo(cursor_x, cursor_row))?;
-        write!(stdout, "{}", Show)?;
-        stdout.flush()?;
+        self.exec(MoveTo(cursor_x, cursor_row))?;
+        write!(self.backend, "{}", Show)?;
+        self.backend.flush()?;
         self.bottom_cursor = Some((cursor_x, cursor_row));
         // The draw itself settles `input_vscroll_offset` (cursor follow /
         // clamping); record the settled value so the next identical frame is

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -426,6 +426,21 @@ impl Renderer {
         self.backend.captured().unwrap_or_default()
     }
 
+    /// Whether the renderer drives a headless test backend instead of a real
+    /// terminal. Used to skip code paths that bypass the backend abstraction
+    /// and write straight to stdout (e.g. the pickers), which break on CI
+    /// where stdout is a non-blocking pipe.
+    pub(crate) fn is_headless(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.backend.captured().is_some()
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+
     /// Mark both regions dirty, forcing a full repaint on the next frame.
     /// Used when something painted over the screen outside the tracked paths
     /// (e.g. an active picker overlay).


### PR DESCRIPTION
Implements the **Tests** checklist item of #186: *"Add integration tests for the main loop using a fake UserEvent source and a fake renderer backend."*

## What changed

**Enabling refactors (production behavior unchanged):**

- `src/ui/renderer.rs` — new `RenderBackend` trait; every ANSI write and terminal-size read now goes through it. `CrosstermBackend` preserves the exact production behavior (stdout + real terminal size); `FakeBackend` (test-only) pins a fixed 80x24 geometry and captures all emitted frames. Also routes `draw_bottom`'s direct `crossterm::terminal::size()` call through the backend.
- `src/ui/app.rs` — the `App::run()` loop body is extracted into a pumpable `App::step()`; new `App::new_headless()` skips `TerminalGuard`, the crossterm event thread, and the model-cache warm; test helpers `inject` / `feed_text` / `input_buffer` / `backend_output` / `session` / `is_running` / `is_scrolling`.
- `src/provider.rs` — `#[cfg(test)] AnyAgent::Mock` wrapping rig's `MockCompletionModel` (same infra as `src/tests/fake_model.rs`), with arms in all four dispatch sites, so scripted agent turns flow through the real loop with no network.

**Tests** (`src/tests/tui_loop_tests.rs`, 11 tests, serialized against process-global state):

1. prompt → streaming response round trip (session + feed updated)
2. queued input replays after the current run
3. Ctrl-C exits the main loop when idle
4. `/clear` via the command picker resets session and feed
5. fake backend captures ANSI frames; paste fills the input buffer
6. Ctrl-C aborts a running agent (loop stays usable afterwards)
7. slash commands are rejected while a run is active
8. `/queue ls` / `/queue pop` manage queued input mid-run
9. multi-line paste submits as a single user message
10. Ctrl-R toggles reasoning visibility
11. scroll + resize events move the viewport and paint the scroll indicator

All tests are deterministic: on the current-thread runtime, injected user events are always drained before the freshly spawned agent task is first polled. The test harness pumps `step()` with a timeout because the loop's `select!` parks when idle (correct in production).

Deliberately not covered: `/btw` (builds its side agent from the real provider client — would need mock injection there too), `/undo` (blocking read on real stdin), agent-error rollback (`MockStreamEvent` has no error variant), mouse selection/copy (real clipboard).

## Verification

- `cargo test`: **746 passed, 0 failed** (735 pre-existing + 11 new)
- `cargo fmt` applied
- `ARCHITECTURE.md` documents the backend trait and the headless testing setup