### PR TITLE
feat(sandbox): mask credential directories inside the bwrap sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ into a guarantee: bash commands are refused whenever the backend is unavailable,
 and the rest of the session keeps working. See [SECURITY.md](SECURITY.md) for
 what the sandbox does and does not protect against.
 
+With the `bwrap` backend, well-known credential directories (`~/.ssh`,
+`~/.aws`, `~/.gnupg`, `~/.kube`, `~/.docker`, and the `gh`, `gcloud`, `op` and
+`sops/age` directories under the config base) are masked by default, so
+sandboxed commands read them as empty rather than as your keys and tokens,
+and the advertised ssh-agent is unreachable. `sandbox-expose` (config key or
+repeatable `--sandbox-expose <path>` flag) restores read-only access to one
+entry or a subpath of one. See [docs/CONFIG.md](docs/CONFIG.md) for the key
+and [SECURITY.md](SECURITY.md) for the full threat model.
+
 ## Quick start
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,16 +69,36 @@ With the `bwrap` backend:
   not hidden, so everything under `$HOME` is visible inside the sandbox except
   the nine credential directories masked by default: `~/.ssh`, `~/.aws`,
   `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.config/gh`, `~/.config/gcloud`,
-  `~/.config/op`, `~/.config/sops/age`. Each of these, when present on the
+  `~/.config/op`, `~/.config/sops/age` (the last four follow
+  `$XDG_CONFIG_HOME` instead of `~/.config` when that variable is set to an
+  absolute path, which is where those tools look). Each of these, when present on the
   host, is covered by a tmpfs, so a sandboxed command sees it as an empty
-  directory rather than reading your keys and tokens. Use `sandbox-expose`
+  directory rather than reading your keys and tokens. That tmpfs is a normal
+  writable filesystem owned by the sandboxed user, not a read-only view, so a
+  command that writes into a masked directory succeeds and then loses the
+  write when the sandbox exits: `ssh-keygen -f ~/.ssh/id_x`, `gh auth login`,
+  and `aws configure` all exit `0` having silently discarded whatever they
+  wrote, and because the exit status is zero, the hint that names a masked
+  path on a failed command never fires for these. A read-only mask is
+  possible (bwrap supports `--remount-ro`), but it would make any tool that
+  writes into its own credential directory fail hard instead of silently
+  losing the write, which is why the mask stays writable by default today.
+  Use `sandbox-expose`
   (config key or repeatable `--sandbox-expose <path>` flag) to restore
   read-only access to a masked entry or a subpath of one when a command
-  legitimately needs it; see `docs/CONFIG.md`. Two gaps remain: single-file
+  legitimately needs it; see `docs/CONFIG.md`. Three gaps remain: single-file
   credentials such as `~/.netrc` and `~/.npmrc` have no clean bwrap
-  file-hiding primitive and are not masked, and everything else under `$HOME`
+  file-hiding primitive and are not masked; everything else under `$HOME`
   outside the nine directories above (`.env` files, browser profiles, shell
-  history) stays fully readable.
+  history) stays fully readable; and live IPC credential endpoints are not
+  touched by directory masking at all. The sandbox environment allowlist
+  still forwards `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR`, and `/run`
+  stays readable through the read-only root bind, so the freedesktop secret
+  service (gnome-keyring, KWallet) remains reachable from inside the sandbox,
+  and tools built on it, such as `secret-tool`, `git-credential-libsecret`,
+  `docker-credential-secretservice`, and the Python `keyring` package, can
+  still read stored tokens. Masking directories does not address this, and it
+  is not addressed by this change.
 - **The whole user cache directory is writable.** `~/.cache` (or
   `$XDG_CACHE_HOME`) is bind mounted read write so that build tooling works.
   Anything cached there, including tool caches other programs trust, can be
@@ -90,9 +110,15 @@ With the `bwrap` backend:
   reconstructing the variable by hand. This targets the socket the host
   advertises: a secondary agent socket running elsewhere (for example a
   systemd `ssh-agent.socket` alongside gnome-keyring) can remain reachable
-  under `/run/user`. The gpg-agent SSH socket under `~/.gnupg` is covered by
-  the directory mask above. There is no in-sandbox switch to re-enable the
-  agent; recovery paths are `sandbox-expose ~/.ssh` for direct key-file auth
+  under `/run/user`. The gpg-agent SSH socket is covered the same way as any
+  other advertised agent: whatever socket `SSH_AUTH_SOCK` points to gets the
+  `/dev/null` bind regardless of where it lives. The `~/.gnupg` directory
+  mask additionally hides a gpg-agent socket when the socket file itself sits
+  inside `~/.gnupg`, which is not the case on mainstream systemd
+  distributions, where GnuPG's socket directory is `/run/user/$UID/gnupg`
+  instead (confirm with `gpgconf --list-dirs socketdir`). There is no
+  in-sandbox switch to re-enable the agent; recovery paths are
+  `sandbox-expose ~/.ssh` for direct key-file auth
   (passphrase-less keys) and the `!` prefix, which runs the command outside
   the sandbox with the agent intact.
 - **Kernel level escapes are out of scope of this design.** bubblewrap uses user

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,16 +65,36 @@ With the `bwrap` backend:
   network, which means it can exfiltrate anything it can read. The `zerobox`
   backend behaves differently here: it denies network access by default under
   its own policy.
-- **Your home directory is readable.** `/` is mounted read only, not hidden, so
-  everything under `$HOME` is visible inside the sandbox: SSH keys, cloud
-  credentials, `.env` files, browser profiles, shell history.
+- **Most of your home directory is still readable.** `/` is mounted read only,
+  not hidden, so everything under `$HOME` is visible inside the sandbox except
+  the nine credential directories masked by default: `~/.ssh`, `~/.aws`,
+  `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.config/gh`, `~/.config/gcloud`,
+  `~/.config/op`, `~/.config/sops/age`. Each of these, when present on the
+  host, is covered by a tmpfs, so a sandboxed command sees it as an empty
+  directory rather than reading your keys and tokens. Use `sandbox-expose`
+  (config key or repeatable `--sandbox-expose <path>` flag) to restore
+  read-only access to a masked entry or a subpath of one when a command
+  legitimately needs it; see `docs/CONFIG.md`. Two gaps remain: single-file
+  credentials such as `~/.netrc` and `~/.npmrc` have no clean bwrap
+  file-hiding primitive and are not masked, and everything else under `$HOME`
+  outside the nine directories above (`.env` files, browser profiles, shell
+  history) stays fully readable.
 - **The whole user cache directory is writable.** `~/.cache` (or
   `$XDG_CACHE_HOME`) is bind mounted read write so that build tooling works.
   Anything cached there, including tool caches other programs trust, can be
   modified.
-- **A running SSH agent stays reachable.** The environment allowlist includes
-  `SSH_AUTH_SOCK` and `SSH_AGENT_PID`, so a sandboxed command can sign with the
-  keys your agent holds.
+- **The advertised agent socket is masked, not every possible agent.**
+  `SSH_AUTH_SOCK` and `SSH_AGENT_PID` are removed from the sandbox environment
+  allowlist, and the socket path the host's `SSH_AUTH_SOCK` points to is bound
+  over with `/dev/null`, so a sandboxed command cannot reach the agent even by
+  reconstructing the variable by hand. This targets the socket the host
+  advertises: a secondary agent socket running elsewhere (for example a
+  systemd `ssh-agent.socket` alongside gnome-keyring) can remain reachable
+  under `/run/user`. The gpg-agent SSH socket under `~/.gnupg` is covered by
+  the directory mask above. There is no in-sandbox switch to re-enable the
+  agent; recovery paths are `sandbox-expose ~/.ssh` for direct key-file auth
+  (passphrase-less keys) and the `!` prefix, which runs the command outside
+  the sandbox with the agent intact.
 - **Kernel level escapes are out of scope of this design.** bubblewrap uses user
   namespaces; a kernel vulnerability, or a host configured to grant more than the
   usual namespace privileges, can defeat the isolation.
@@ -103,8 +123,8 @@ a container with the network and credentials you are willing to expose.
 
 | Backend | Isolation |
 | --- | --- |
-| `bwrap` (default) | Linux only. The bubblewrap mounts and namespaces described above, with the network left open. |
-| `zerobox` | macOS and Linux. Denies writes, network access, and environment variables by default, with per-domain network allowances. zerostack invokes `zerobox --allow-write <cwd> -- <shell> -c <command>`, so the working directory is writable and the rest of the policy is whatever zerobox enforces. |
+| `bwrap` (default) | Linux only. The bubblewrap mounts and namespaces described above, with the network left open. The nine built-in credential directories are masked by default and the advertised ssh-agent socket is cut off; see above. |
+| `zerobox` | macOS and Linux. Denies writes, network access, and environment variables by default, with per-domain network allowances. zerostack invokes `zerobox --allow-write <cwd> -- <shell> -c <command>`, so the working directory is writable and the rest of the policy is whatever zerobox enforces. Credential masking does not apply here: zerobox exposes no mount-policy surface to inject it, and whether its own defaults limit reads under `$HOME` has not been verified. |
 | none | With the sandbox off (the default), bash commands run directly as your user with no isolation at all. The permission system is the only gate. |
 
 ## Best effort versus guarantee

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -198,7 +198,7 @@ Accepted top-level keys:
 | `sandbox`                 | boolean | Run bash commands in the sandbox. Best effort: if the selected backend binary is missing, commands still run unsandboxed and a warning is logged. See `SECURITY.md` in the repository for what the sandbox does and does not protect against. Default: `false`. |
 | `sandbox-backend`         | string  | Sandbox backend: `bwrap` (default, Linux only) or `zerobox` (macOS and Linux).                                                                                              |
 | `sandbox-required`        | boolean | Refuse to run bash commands when the sandbox backend is unavailable, instead of falling back to running them unsandboxed. Implies `sandbox`. Default: `false`.               |
-| `sandbox-expose`          | array   | Bwrap backend only. Restores read-only access to a masked credential directory or a subpath of one. `~` expansion supported. Repeatable CLI flag `--sandbox-expose <path>`; when passed, it replaces this list wholesale. Values that are not a masked entry or a subpath of one are warned about once at startup and ignored. Default: `[]` (nothing exposed). See Sandbox credential masking below. |
+| `sandbox-expose`          | array   | Bwrap backend only. Restores read-only access to a masked credential directory or a subpath of one. `~` and `$HOME` expansion supported. Repeatable CLI flag `--sandbox-expose <path>`; when passed, it replaces this list wholesale. Values that are not a masked entry or a subpath of one, and values containing `..`, are warned about once at startup and ignored. Default: `[]` (nothing exposed). See Sandbox credential masking below. |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Accepts: `standard` (default), `restrictive`, `readonly`, `guarded`, `yolo`.                                          |
 | `show_tool_details`       | boolean or integer | Show tool-result previews in the TUI. `false` hides output, `true` shows all lines, an integer limits to that many lines (e.g. `3`). Default: `3`. |
 | `show_reasoning`          | boolean | Show streamed reasoning text in the TUI. Can still be toggled at runtime with `Ctrl+R` or `/reasoning`. Default: `false`. |
@@ -238,16 +238,32 @@ masked):
 | `~/.config/op` | 1Password CLI session state |
 | `~/.config/sops/age` | sops/age decryption keys |
 
-Use `sandbox-expose` (config key, string array, `~` expansion) or the
-repeatable `--sandbox-expose <path>` CLI flag to restore read-only access to a
-masked entry or a subpath of one (for example `~/.ssh/known_hosts` without the
-private keys). When `--sandbox-expose` is passed at least once on the command
-line, it replaces the config list wholesale, following the usual CLI-over-config
-convention; otherwise the config list is used. A value is valid only when,
-after `~` expansion, it equals one of the entries above or is a subpath of
-one; anything else is warned about once at startup, quoting the value, and
-ignored. Because the restore is a read-only bind on top of the mask,
-`sandbox-expose` can never grant write access. Masking, the ssh-agent cutoff,
+The last four are relative to the XDG config base: when `$XDG_CONFIG_HOME` is
+set to an absolute path, they are `$XDG_CONFIG_HOME/gh`, `.../gcloud`,
+`.../op` and `.../sops/age` instead, since that is where those tools read
+their credentials.
+
+The tmpfs is a normal writable filesystem, not a read-only view: a command
+that writes into a masked directory (`ssh-keygen -f ~/.ssh/id_x`,
+`gh auth login`, `aws configure`) succeeds and exits `0`, then loses whatever
+it wrote when the sandbox exits. A read-only mask is possible (bwrap supports
+`--remount-ro`), but it is not the default, since it would make those same
+tools fail hard instead of silently losing their output.
+
+Use `sandbox-expose` (config key, string array, `~` and `$HOME` expansion) or
+the repeatable `--sandbox-expose <path>` CLI flag to restore read-only access
+to a masked entry or a subpath of one (for example `~/.ssh/known_hosts` without
+the private keys). When `--sandbox-expose` is passed at least once on the
+command line, it replaces the config list wholesale, following the usual
+CLI-over-config convention; otherwise the config list is used. A value is valid
+only when, after expansion, it equals one of the entries above or is a subpath
+of one, and contains no `..` component (`~/.ssh/..` names the whole home
+directory, not a masked entry); anything else is warned about once at startup,
+quoting the value, and ignored. Because the restore is a read-only bind on top of the mask,
+`sandbox-expose` can never grant write access. Like any other config key,
+`sandbox-expose` can be set from a project-local `.zerostack/config.toml`,
+trusted exactly like the global config, so review it in untrusted checkouts
+as noted above (see Project-local override). Masking, the ssh-agent cutoff,
 and `sandbox-expose` all apply to the `bwrap` backend only; see `SECURITY.md`
 for the full gap list, including what remains readable and the ssh-agent
 recovery paths.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -198,6 +198,7 @@ Accepted top-level keys:
 | `sandbox`                 | boolean | Run bash commands in the sandbox. Best effort: if the selected backend binary is missing, commands still run unsandboxed and a warning is logged. See `SECURITY.md` in the repository for what the sandbox does and does not protect against. Default: `false`. |
 | `sandbox-backend`         | string  | Sandbox backend: `bwrap` (default, Linux only) or `zerobox` (macOS and Linux).                                                                                              |
 | `sandbox-required`        | boolean | Refuse to run bash commands when the sandbox backend is unavailable, instead of falling back to running them unsandboxed. Implies `sandbox`. Default: `false`.               |
+| `sandbox-expose`          | array   | Bwrap backend only. Restores read-only access to a masked credential directory or a subpath of one. `~` expansion supported. Repeatable CLI flag `--sandbox-expose <path>`; when passed, it replaces this list wholesale. Values that are not a masked entry or a subpath of one are warned about once at startup and ignored. Default: `[]` (nothing exposed). See Sandbox credential masking below. |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Accepts: `standard` (default), `restrictive`, `readonly`, `guarded`, `yolo`.                                          |
 | `show_tool_details`       | boolean or integer | Show tool-result previews in the TUI. `false` hides output, `true` shows all lines, an integer limits to that many lines (e.g. `3`). Default: `3`. |
 | `show_reasoning`          | boolean | Show streamed reasoning text in the TUI. Can still be toggled at runtime with `Ctrl+R` or `/reasoning`. Default: `false`. |
@@ -217,6 +218,39 @@ Accepted top-level keys:
 | `acp_host`                | string  | TCP bind host for ACP server mode (equivalent to `--acp-host`).                                                                                                              |
 | `acp_port`                | integer | TCP bind port for ACP server mode (equivalent to `--acp-port`, default: 7243).                                                                                               |
 | `colors`                  | object  | Background color overrides for the TUI. See the colors section below.                                                                                                       |
+
+## Sandbox credential masking
+
+On the `bwrap` backend, nine well-known credential directories are masked with
+a tmpfs by default, so sandboxed bash commands see each one as empty rather
+than reading your keys and tokens (only entries that exist on the host are
+masked):
+
+| Directory | Why it is masked |
+| --- | --- |
+| `~/.ssh` | SSH private keys and `known_hosts` |
+| `~/.aws` | AWS credentials and config |
+| `~/.gnupg` | GPG keyrings and the gpg-agent SSH socket |
+| `~/.kube` | Kubernetes cluster credentials |
+| `~/.docker` | Docker registry auth tokens |
+| `~/.config/gh` | GitHub CLI OAuth token |
+| `~/.config/gcloud` | Google Cloud credentials |
+| `~/.config/op` | 1Password CLI session state |
+| `~/.config/sops/age` | sops/age decryption keys |
+
+Use `sandbox-expose` (config key, string array, `~` expansion) or the
+repeatable `--sandbox-expose <path>` CLI flag to restore read-only access to a
+masked entry or a subpath of one (for example `~/.ssh/known_hosts` without the
+private keys). When `--sandbox-expose` is passed at least once on the command
+line, it replaces the config list wholesale, following the usual CLI-over-config
+convention; otherwise the config list is used. A value is valid only when,
+after `~` expansion, it equals one of the entries above or is a subpath of
+one; anything else is warned about once at startup, quoting the value, and
+ignored. Because the restore is a read-only bind on top of the mask,
+`sandbox-expose` can never grant write access. Masking, the ssh-agent cutoff,
+and `sandbox-expose` all apply to the `bwrap` backend only; see `SECURITY.md`
+for the full gap list, including what remains readable and the ssh-agent
+recovery paths.
 
 ## System Prompt Suffix (`SUFFIX.md`)
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -164,6 +164,7 @@ If you want to use zerostack from scripts, from other programs, or if you just w
 | `--yolo` | No limitations given to the agent |
 | `--sandbox` | Run the agent inside a sandbox (Experimental) |
 | `--sandbox-required` | Refuse bash commands when the sandbox backend is unavailable (implies `--sandbox`) |
+| `--sandbox-expose <path>` | Restore read-only access to a masked credential path or subpath (repeatable) |
 | `--worktree` | Run the agent inside a git worktree (Experimental) |
 | `--parallel` | Run the agent inside a self-managed git worktree (Experimental) |
 | `--load-prompt <prompt>` | Use a specific prompt |

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -5,7 +5,7 @@ use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm}
 #[cfg(feature = "rtk")]
 use crate::extras::rtk::Rtk;
 use crate::extras::truncate::head_lines;
-use crate::sandbox::Sandbox;
+use crate::sandbox::{Sandbox, mask_hint};
 
 pub(crate) fn split_bash_commands(input: &str) -> Vec<String> {
     let mut result = Vec::new();
@@ -76,6 +76,23 @@ pub(crate) fn split_bash_commands(input: &str) -> Vec<String> {
     }
 
     result
+}
+
+/// Gates `sandbox::mask_hint` on the exit status: a masked-path hint belongs
+/// in a tool result only when the command actually failed. Kept as its own
+/// function so that gate is testable on its own, separately from the
+/// substring-matching logic inside `mask_hint`.
+pub(crate) fn mask_hint_for_exit(
+    exit_code: i32,
+    command: &str,
+    stderr: &str,
+    masked_roots: &[std::path::PathBuf],
+    home: &std::path::Path,
+) -> Option<String> {
+    if exit_code == 0 {
+        return None;
+    }
+    mask_hint(command, stderr, masked_roots, home)
 }
 
 pub struct BashTool {
@@ -231,6 +248,20 @@ impl Tool for BashTool {
 
         let result = match coaching {
             Some(msg) => format!("{}\n\n{}", msg, result),
+            None => result,
+        };
+        // Append last, after truncation and coaching, so a masked-path hint
+        // always survives at the end of the tool result the model sees.
+        let result = match dirs::home_dir().and_then(|home| {
+            mask_hint_for_exit(
+                exit_code,
+                &command,
+                &stderr,
+                &self.sandbox.masked_paths(),
+                &home,
+            )
+        }) {
+            Some(hint) => format!("{result}\n{hint}"),
             None => result,
         };
         tracing::debug!(

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -78,21 +78,27 @@ pub(crate) fn split_bash_commands(input: &str) -> Vec<String> {
     result
 }
 
-/// Gates `sandbox::mask_hint` on the exit status: a masked-path hint belongs
-/// in a tool result only when the command actually failed. Kept as its own
-/// function so that gate is testable on its own, separately from the
-/// substring-matching logic inside `mask_hint`.
+/// The masked-path hint for a finished command, or `None`. A hint belongs in a
+/// tool result only when the command actually failed, and this is the only
+/// place that gate exists: the caller invokes this unconditionally, so there
+/// is no second copy of the predicate to disagree with, and the branch under
+/// test here is the branch production takes.
+///
+/// The mask list is taken as a `&Sandbox` rather than resolved by the caller
+/// so the work behind it stays on the failing side of the gate: a successful
+/// command pays for neither `dirs::home_dir()` nor the up-to-nine `exists()`
+/// stat calls in `Sandbox::masked_roots`.
 pub(crate) fn mask_hint_for_exit(
     exit_code: i32,
     command: &str,
     stderr: &str,
-    masked_roots: &[std::path::PathBuf],
-    home: &std::path::Path,
+    sandbox: &Sandbox,
 ) -> Option<String> {
     if exit_code == 0 {
         return None;
     }
-    mask_hint(command, stderr, masked_roots, home)
+    let home = dirs::home_dir()?;
+    mask_hint(command, stderr, &sandbox.masked_roots(), &home)
 }
 
 pub struct BashTool {
@@ -251,16 +257,10 @@ impl Tool for BashTool {
             None => result,
         };
         // Append last, after truncation and coaching, so a masked-path hint
-        // always survives at the end of the tool result the model sees.
-        let result = match dirs::home_dir().and_then(|home| {
-            mask_hint_for_exit(
-                exit_code,
-                &command,
-                &stderr,
-                &self.sandbox.masked_paths(),
-                &home,
-            )
-        }) {
+        // always survives at the end of the tool result the model sees. The
+        // exit-code gate lives inside `mask_hint_for_exit`, which is also what
+        // keeps a successful command from paying for the mask list.
+        let result = match mask_hint_for_exit(exit_code, &command, &stderr, &self.sandbox) {
             Some(hint) => format!("{result}\n{hint}"),
             None => result,
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,6 +146,13 @@ pub struct Cli {
     pub sandbox_required: bool,
 
     #[arg(
+        long = "sandbox-expose",
+        action = clap::ArgAction::Append,
+        help = "Restore read-only access to a masked credential path or subpath (repeatable)"
+    )]
+    pub sandbox_expose: Vec<String>,
+
+    #[arg(
         long = "shell",
         help = "Shell binary to use for bash tool (default: bash)"
     )]
@@ -388,6 +395,18 @@ impl Cli {
             .clone()
             .or_else(|| cfg.sandbox_backend.clone())
             .unwrap_or_else(|| "bwrap".to_string())
+    }
+
+    /// Raw `sandbox-expose` values, unexpanded and unvalidated: a non-empty
+    /// CLI list replaces the config list wholesale, following the existing
+    /// CLI-over-config resolution convention. `~` expansion and validation
+    /// against the mask list happen in `sandbox::partition_expose`.
+    pub fn resolve_sandbox_expose(&self, cfg: &config::Config) -> Vec<String> {
+        if !self.sandbox_expose.is_empty() {
+            self.sandbox_expose.clone()
+        } else {
+            cfg.sandbox_expose.clone().unwrap_or_default()
+        }
     }
 
     pub fn resolve_shell(&self, cfg: &config::Config) -> String {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,6 +117,8 @@ pub struct Config {
     pub sandbox_backend: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "sandbox-required")]
     pub sandbox_required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "sandbox-expose")]
+    pub sandbox_expose: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_all_mcp_calls: Option<bool>,
     #[cfg(feature = "mcp")]

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -191,6 +191,20 @@ async fn handle_new_session(
             "sandbox is set to false but sandbox-required is set, enabling the sandbox anyway"
         );
     }
+    // Rejected-value warnings are emitted once per session, so they live here
+    // and not in run_prompt (which runs on every prompt).
+    let sandbox_expose_raw = state.cli.resolve_sandbox_expose(&state.cfg);
+    let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
+    let (_, sandbox_expose_rejected) = crate::sandbox::partition_expose(
+        &sandbox_expose_raw,
+        &crate::sandbox::builtin_mask_roots(),
+        &sandbox_expose_home,
+    );
+    for value in &sandbox_expose_rejected {
+        tracing::warn!(
+            "sandbox-expose value '{value}' is not a masked path or subpath of one, ignoring it"
+        );
+    }
     if let Some(root) = Sandbox::new(
         state.cli.resolve_sandbox(&state.cfg),
         &state.cli.resolve_sandbox_backend(&state.cfg),
@@ -287,12 +301,20 @@ async fn run_prompt(
     let model = client.completion_model(model_str.to_string());
 
     let (permission, ask_tx) = build_acp_permission(state);
+    let sandbox_expose_raw = state.cli.resolve_sandbox_expose(&state.cfg);
+    let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
+    let (sandbox_expose, _) = crate::sandbox::partition_expose(
+        &sandbox_expose_raw,
+        &crate::sandbox::builtin_mask_roots(),
+        &sandbox_expose_home,
+    );
     let sandbox = Sandbox::new(
         state.cli.resolve_sandbox(&state.cfg),
         &state.cli.resolve_sandbox_backend(&state.cfg),
     )
     .with_required(state.cli.resolve_sandbox_required(&state.cfg))
-    .with_shell(&state.cli.resolve_shell(&state.cfg));
+    .with_shell(&state.cli.resolve_shell(&state.cfg))
+    .with_expose(sandbox_expose);
 
     // Track session history for future context persistence
     let _extra_messages = {

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -191,6 +191,17 @@ async fn handle_new_session(
             "sandbox is set to false but sandbox-required is set, enabling the sandbox anyway"
         );
     }
+    if let Some(root) = Sandbox::new(
+        state.cli.resolve_sandbox(&state.cfg),
+        &state.cli.resolve_sandbox_backend(&state.cfg),
+    )
+    .shadowed_mask_root(&req.cwd)
+    {
+        tracing::warn!(
+            "sandbox: the session directory is inside {}, so the project bind partially shadows the mask on it",
+            root.display()
+        );
+    }
 
     state.sessions.lock().await.insert(
         session_id.clone(),

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -17,7 +17,7 @@ use crate::event::AgentEvent;
 use crate::permission::SecurityMode;
 use crate::permission::ask::AskSender;
 use crate::permission::checker::{PermCheck, PermissionChecker};
-use crate::sandbox::Sandbox;
+use crate::sandbox::{SandboxSettings, SandboxSetup};
 
 const AGENT_VERSION: &str = "1.0.5";
 
@@ -30,6 +30,20 @@ struct AcpState {
     cfg: Config,
     context: ContextFiles,
     sessions: Mutex<HashMap<SessionId, SessionState>>,
+}
+
+/// The session sandbox and the warnings building it produced, from this
+/// server's resolved settings. Shared by `handle_new_session` (which logs the
+/// warnings once) and `run_prompt` (which needs the sandbox on every prompt),
+/// so the two can never disagree about what is masked or exposed.
+fn sandbox_setup(state: &AcpState) -> SandboxSetup {
+    crate::sandbox::build_sandbox(&SandboxSettings {
+        enabled: state.cli.resolve_sandbox(&state.cfg),
+        required: state.cli.resolve_sandbox_required(&state.cfg),
+        backend: &state.cli.resolve_sandbox_backend(&state.cfg),
+        shell: &state.cli.resolve_shell(&state.cfg),
+        expose: &state.cli.resolve_sandbox_expose(&state.cfg),
+    })
 }
 
 // --- TCP Transport ---
@@ -191,30 +205,14 @@ async fn handle_new_session(
             "sandbox is set to false but sandbox-required is set, enabling the sandbox anyway"
         );
     }
-    // Rejected-value warnings are emitted once per session, so they live here
-    // and not in run_prompt (which runs on every prompt).
-    let sandbox_expose_raw = state.cli.resolve_sandbox_expose(&state.cfg);
-    let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
-    let (_, sandbox_expose_rejected) = crate::sandbox::partition_expose(
-        &sandbox_expose_raw,
-        &crate::sandbox::builtin_mask_roots(),
-        &sandbox_expose_home,
-    );
-    for value in &sandbox_expose_rejected {
-        tracing::warn!(
-            "sandbox-expose value '{value}' is not a masked path or subpath of one, ignoring it"
-        );
-    }
-    if let Some(root) = Sandbox::new(
-        state.cli.resolve_sandbox(&state.cfg),
-        &state.cli.resolve_sandbox_backend(&state.cfg),
-    )
-    .shadowed_mask_root(&req.cwd)
-    {
-        tracing::warn!(
-            "sandbox: the session directory is inside {}, so the project bind partially shadows the mask on it",
-            root.display()
-        );
+    // Sandbox warnings are emitted once per session, so they live here and not
+    // in run_prompt (which runs on every prompt). The sandbox itself is rebuilt
+    // per prompt from the same settings; building it here is what makes the
+    // warnings describe the sandbox that will actually run, including the
+    // directory it binds, which is this process's working directory and not
+    // `req.cwd` (the ACP server never chdirs to it).
+    for warning in &sandbox_setup(state).warnings {
+        tracing::warn!("{warning}");
     }
 
     state.sessions.lock().await.insert(
@@ -301,20 +299,9 @@ async fn run_prompt(
     let model = client.completion_model(model_str.to_string());
 
     let (permission, ask_tx) = build_acp_permission(state);
-    let sandbox_expose_raw = state.cli.resolve_sandbox_expose(&state.cfg);
-    let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
-    let (sandbox_expose, _) = crate::sandbox::partition_expose(
-        &sandbox_expose_raw,
-        &crate::sandbox::builtin_mask_roots(),
-        &sandbox_expose_home,
-    );
-    let sandbox = Sandbox::new(
-        state.cli.resolve_sandbox(&state.cfg),
-        &state.cli.resolve_sandbox_backend(&state.cfg),
-    )
-    .with_required(state.cli.resolve_sandbox_required(&state.cfg))
-    .with_shell(&state.cli.resolve_shell(&state.cfg))
-    .with_expose(sandbox_expose);
+    // Warnings are dropped here on purpose: handle_new_session already logged
+    // them once for this session.
+    let sandbox = sandbox_setup(state).sandbox;
 
     // Track session history for future context persistence
     let _extra_messages = {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -133,7 +133,17 @@ async fn resolve_symlink_target(path: &Path) -> PathBuf {
 }
 
 pub fn expand_tilde(s: &str) -> String {
-    let home = || dirs::home_dir().map(|p| p.to_string_lossy().to_string());
+    expand_tilde_with_home(s, dirs::home_dir().as_deref())
+}
+
+/// Core of [`expand_tilde`] with the home directory supplied by the caller, so
+/// code that already knows which home it is expanding against (the sandbox
+/// mask/expose validation, which is pure by design) does not have to re-derive
+/// it from process state. `None` models a host with no home directory: every
+/// `~`/`$HOME` form is then returned unchanged, which is what the callers of
+/// [`expand_tilde`] have always seen in that situation.
+pub fn expand_tilde_with_home(s: &str, home: Option<&Path>) -> String {
+    let home = || home.map(|p| p.to_string_lossy().to_string());
 
     if s == "~" || s == "$HOME" {
         if let Some(h) = home() {

--- a/src/print.rs
+++ b/src/print.rs
@@ -76,6 +76,12 @@ pub(crate) fn print_config(cli: &cli::Cli, cfg: &config::Config) {
     let sandbox = cli.resolve_sandbox(cfg);
     let sandbox_required = cli.resolve_sandbox_required(cfg);
     let sandbox_backend = cli.resolve_sandbox_backend(cfg);
+    let sandbox_expose = cli.resolve_sandbox_expose(cfg);
+    let sandbox_expose_display = if sandbox_expose.is_empty() {
+        "(none)".to_string()
+    } else {
+        sandbox_expose.join(", ")
+    };
     let shell = cli.resolve_shell(cfg);
     let edit_system = cli.resolve_edit_system(cfg);
     let compact = cfg.resolve_compact_enabled();
@@ -179,6 +185,7 @@ pub(crate) fn print_config(cli: &cli::Cli, cfg: &config::Config) {
             ("sandbox", sandbox.to_string()),
             ("sandbox-backend", sandbox_backend),
             ("sandbox-required", sandbox_required.to_string()),
+            ("sandbox-expose", sandbox_expose_display),
             ("no-tools", no_tools.to_string()),
             ("tools", tools_allowlist),
             ("no-context-files", no_context_files.to_string()),

--- a/src/print.rs
+++ b/src/print.rs
@@ -2,6 +2,16 @@ use crate::cli;
 use crate::config;
 use crate::session;
 
+/// Renders the resolved `sandbox-expose` values for the `--print-config`
+/// table: `(none)` when nothing is exposed, otherwise a comma-joined list.
+pub(crate) fn format_sandbox_expose_display(sandbox_expose: &[String]) -> String {
+    if sandbox_expose.is_empty() {
+        "(none)".to_string()
+    } else {
+        sandbox_expose.join(", ")
+    }
+}
+
 pub(crate) fn print_section(title: &str, entries: &[(&str, String)]) {
     println!("{}:", title);
     let width = entries.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
@@ -76,12 +86,19 @@ pub(crate) fn print_config(cli: &cli::Cli, cfg: &config::Config) {
     let sandbox = cli.resolve_sandbox(cfg);
     let sandbox_required = cli.resolve_sandbox_required(cfg);
     let sandbox_backend = cli.resolve_sandbox_backend(cfg);
-    let sandbox_expose = cli.resolve_sandbox_expose(cfg);
-    let sandbox_expose_display = if sandbox_expose.is_empty() {
-        "(none)".to_string()
-    } else {
-        sandbox_expose.join(", ")
-    };
+    let sandbox_expose_raw = cli.resolve_sandbox_expose(cfg);
+    let home = dirs::home_dir().unwrap_or_default();
+    let (sandbox_expose, _rejected) = crate::sandbox::partition_expose(
+        &sandbox_expose_raw,
+        &crate::sandbox::builtin_mask_roots(),
+        Some(&home),
+    );
+    let sandbox_expose_display = format_sandbox_expose_display(
+        &sandbox_expose
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+    );
     let shell = cli.resolve_shell(cfg);
     let edit_system = cli.resolve_edit_system(cfg);
     let compact = cfg.resolve_compact_enabled();

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -24,6 +24,10 @@ pub struct Sandbox {
     // Already-validated `sandbox-expose` paths (see `partition_expose`),
     // restored read-only on top of the masks.
     expose: Vec<std::path::PathBuf>,
+    // `ssh_auth_sock` replaces the host `SSH_AUTH_SOCK` env read: `None` means
+    // "use the real env var", `Some(None)` means "pretend it is unset",
+    // `Some(Some(path))` pins the socket path a test masks.
+    ssh_auth_sock: Option<Option<std::path::PathBuf>>,
     active_groups: Arc<Mutex<HashSet<u32>>>,
 }
 
@@ -156,6 +160,7 @@ impl Sandbox {
             cache_dir: None,
             mask_roots: None,
             expose: Vec::new(),
+            ssh_auth_sock: None,
             active_groups: Arc::new(Mutex::new(HashSet::new())),
         }
     }
@@ -215,6 +220,15 @@ impl Sandbox {
         self
     }
 
+    /// Overrides the host `SSH_AUTH_SOCK` read: `Some(path)` pins the socket
+    /// path the agent-cutoff mask targets, `None` models a host with no
+    /// ssh-agent running.
+    #[cfg(test)]
+    pub fn with_ssh_auth_sock(mut self, sock: Option<std::path::PathBuf>) -> Self {
+        self.ssh_auth_sock = Some(sock);
+        self
+    }
+
     /// Credential directories this sandbox masks, narrowed to what exists on
     /// the host: bwrap creates every `--tmpfs` mountpoint, and creating one on
     /// the read-only `/` bind aborts the whole launch.
@@ -236,6 +250,17 @@ impl Sandbox {
         self.enabled
             && self.backend_binary() == "bwrap"
             && (self.backend_available() || self.backend_available_now())
+    }
+
+    /// The host's advertised ssh-agent socket, if any: the path
+    /// `SSH_AUTH_SOCK` points to, which the bwrap branch masks with
+    /// `/dev/null` so the agent stays unreachable even if a command
+    /// reconstructs the variable by hand.
+    fn ssh_auth_sock(&self) -> Option<std::path::PathBuf> {
+        if let Some(sock) = &self.ssh_auth_sock {
+            return sock.clone();
+        }
+        std::env::var_os("SSH_AUTH_SOCK").map(std::path::PathBuf::from)
     }
 
     /// The mask root `cwd` sits under, if any. The working directory is bound
@@ -355,6 +380,13 @@ impl Sandbox {
         for root in self.masked_paths() {
             cmd.arg("--tmpfs");
             cmd.arg(root.as_os_str());
+        }
+        // The advertised ssh-agent socket is masked too, so a command that
+        // reconstructs SSH_AUTH_SOCK by hand still cannot reach the agent.
+        if let Some(sock) = self.ssh_auth_sock() {
+            cmd.arg("--ro-bind-try");
+            cmd.arg("/dev/null");
+            cmd.arg(sock.as_os_str());
         }
         // Expose re-opens holes in the masks above, read-only: `--ro-bind-try`
         // can never grant write access, which is what turns "only shrink,
@@ -510,7 +542,11 @@ pub(crate) fn kill_process_group(pid: u32) {
     }
 }
 
-fn essential_env() -> Vec<(&'static str, String)> {
+// SSH_AUTH_SOCK and SSH_AGENT_PID are deliberately absent: forwarding them
+// would keep a running ssh-agent reachable from inside the sandbox, which the
+// agent-socket mask above closes even against a command that reconstructs
+// SSH_AUTH_SOCK by hand.
+pub(crate) fn essential_env() -> Vec<(&'static str, String)> {
     let preserve = [
         "PATH",
         "HOME",
@@ -520,8 +556,6 @@ fn essential_env() -> Vec<(&'static str, String)> {
         "TERM",
         "LANG",
         "LC_ALL",
-        "SSH_AUTH_SOCK",
-        "SSH_AGENT_PID",
         "SSH_ASKPASS",
         "GIT_ASKPASS",
         "DISPLAY",

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -21,6 +21,9 @@ pub struct Sandbox {
     backend_installed_now: Option<bool>,
     cache_dir: Option<std::path::PathBuf>,
     mask_roots: Option<Vec<std::path::PathBuf>>,
+    // Already-validated `sandbox-expose` paths (see `partition_expose`),
+    // restored read-only on top of the masks.
+    expose: Vec<std::path::PathBuf>,
     active_groups: Arc<Mutex<HashSet<u32>>>,
 }
 
@@ -39,11 +42,44 @@ const MASK_DIRS: [&str; 9] = [
     ".config/sops/age",
 ];
 
-fn builtin_mask_roots() -> Vec<std::path::PathBuf> {
+pub(crate) fn builtin_mask_roots() -> Vec<std::path::PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
     MASK_DIRS.iter().map(|rel| home.join(rel)).collect()
+}
+
+/// Splits raw `sandbox-expose` values into ones that restore read-only access
+/// to a masked entry and ones to reject. A value is valid when, after `~`
+/// expansion against `home`, it equals a `mask_roots` entry or is a subpath of
+/// one; `Path::starts_with` compares whole components, so `~/.ssh2` is never
+/// mistaken for a subpath of `~/.ssh`. Pure: no warnings, no I/O.
+pub(crate) fn partition_expose(
+    raw: &[String],
+    mask_roots: &[std::path::PathBuf],
+    home: &std::path::Path,
+) -> (Vec<std::path::PathBuf>, Vec<String>) {
+    let mut valid = Vec::new();
+    let mut rejected = Vec::new();
+    for value in raw {
+        let expanded = expand_tilde(value, home);
+        if mask_roots.iter().any(|root| expanded.starts_with(root)) {
+            valid.push(expanded);
+        } else {
+            rejected.push(value.clone());
+        }
+    }
+    (valid, rejected)
+}
+
+fn expand_tilde(value: &str, home: &std::path::Path) -> std::path::PathBuf {
+    if let Some(rest) = value.strip_prefix("~/") {
+        home.join(rest)
+    } else if value == "~" {
+        home.to_path_buf()
+    } else {
+        std::path::PathBuf::from(value)
+    }
 }
 
 static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -119,6 +155,7 @@ impl Sandbox {
             backend_installed_now: None,
             cache_dir: None,
             mask_roots: None,
+            expose: Vec::new(),
             active_groups: Arc::new(Mutex::new(HashSet::new())),
         }
     }
@@ -141,6 +178,14 @@ impl Sandbox {
     /// unsandboxed if the backend binary is missing.
     pub fn with_required(mut self, required: bool) -> Self {
         self.required = required;
+        self
+    }
+
+    /// Already-validated `sandbox-expose` paths (see `partition_expose`).
+    /// Each is restored read-only on top of the masks via `--ro-bind-try`, so
+    /// expose can never grant write access.
+    pub fn with_expose(mut self, expose: Vec<std::path::PathBuf>) -> Self {
+        self.expose = expose;
         self
     }
 
@@ -310,6 +355,14 @@ impl Sandbox {
         for root in self.masked_paths() {
             cmd.arg("--tmpfs");
             cmd.arg(root.as_os_str());
+        }
+        // Expose re-opens holes in the masks above, read-only: `--ro-bind-try`
+        // can never grant write access, which is what turns "only shrink,
+        // never widen" from policy into mechanism.
+        for path in &self.expose {
+            cmd.arg("--ro-bind-try");
+            cmd.arg(path.as_os_str());
+            cmd.arg(path.as_os_str());
         }
         cmd.arg("--bind");
         cmd.arg(cwd.as_os_str());

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -31,43 +31,73 @@ pub struct Sandbox {
     active_groups: Arc<Mutex<HashSet<u32>>>,
 }
 
-/// Well-known credential stores, relative to the home directory. Each is
-/// covered by a tmpfs inside the bwrap sandbox, so sandboxed commands read them
-/// as empty rather than as the user's keys and tokens.
-const MASK_DIRS: [&str; 9] = [
-    ".ssh",
-    ".aws",
-    ".gnupg",
-    ".kube",
-    ".docker",
-    ".config/gh",
-    ".config/gcloud",
-    ".config/op",
-    ".config/sops/age",
-];
+/// Well-known credential stores that live directly under the home directory.
+/// Each is covered by a tmpfs inside the bwrap sandbox, so sandboxed commands
+/// read them as empty rather than as the user's keys and tokens.
+const HOME_MASK_DIRS: [&str; 5] = [".ssh", ".aws", ".gnupg", ".kube", ".docker"];
+
+/// The same, relative to the XDG config base rather than to the home
+/// directory: `XDG_CONFIG_HOME` is forwarded into the sandbox by
+/// `essential_env`, so a host that relocates its config base would otherwise
+/// have these four masked in a place nothing reads and left readable (and
+/// reachable) where the tools actually look.
+const CONFIG_MASK_DIRS: [&str; 4] = ["gh", "gcloud", "op", "sops/age"];
+
+/// The built-in mask list for a given home and XDG config base. Pure, so the
+/// list can be asserted on without racing other tests over the process
+/// environment. `xdg_config` is honored only when absolute, matching the XDG
+/// spec (a relative `XDG_CONFIG_HOME` is invalid and must be ignored); note it
+/// is deliberately *not* `dirs::config_dir()`, which resolves to
+/// `~/Library/Application Support` on macOS, where none of these tools store
+/// their credentials.
+pub(crate) fn mask_roots_for(
+    home: &std::path::Path,
+    xdg_config: Option<&std::path::Path>,
+) -> Vec<std::path::PathBuf> {
+    let config_base = match xdg_config {
+        Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+        _ => home.join(".config"),
+    };
+    HOME_MASK_DIRS
+        .iter()
+        .map(|rel| home.join(rel))
+        .chain(CONFIG_MASK_DIRS.iter().map(|rel| config_base.join(rel)))
+        .collect()
+}
 
 pub(crate) fn builtin_mask_roots() -> Vec<std::path::PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
-    MASK_DIRS.iter().map(|rel| home.join(rel)).collect()
+    let xdg_config = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from);
+    mask_roots_for(&home, xdg_config.as_deref())
 }
 
 /// Splits raw `sandbox-expose` values into ones that restore read-only access
-/// to a masked entry and ones to reject. A value is valid when, after `~`
-/// expansion against `home`, it equals a `mask_roots` entry or is a subpath of
-/// one; `Path::starts_with` compares whole components, so `~/.ssh2` is never
-/// mistaken for a subpath of `~/.ssh`. Pure: no warnings, no I/O.
+/// to a masked entry and ones to reject. A value is valid when, after `~` and
+/// `$HOME` expansion against `home`, it equals a `mask_roots` entry or is a
+/// subpath of one; `Path::starts_with` compares whole components, so `~/.ssh2`
+/// is never mistaken for a subpath of `~/.ssh`. Values containing a `..`
+/// component are rejected outright: `~/.ssh/..` passes the subpath test while
+/// naming the whole home directory, which would re-bind everything the masks
+/// hide. `home` is `None` on a host with no home directory, in which case
+/// `~`/`$HOME` forms are left unexpanded (see `expand_tilde_with_home`) and so
+/// never match a `mask_roots` entry. Pure: no warnings, no I/O.
 pub(crate) fn partition_expose(
     raw: &[String],
     mask_roots: &[std::path::PathBuf],
-    home: &std::path::Path,
+    home: Option<&std::path::Path>,
 ) -> (Vec<std::path::PathBuf>, Vec<String>) {
     let mut valid = Vec::new();
     let mut rejected = Vec::new();
     for value in raw {
-        let expanded = expand_tilde(value, home);
-        if mask_roots.iter().any(|root| expanded.starts_with(root)) {
+        let expanded = expand_expose(value, home);
+        let escapes = expanded
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir));
+        if !escapes && mask_roots.iter().any(|root| expanded.starts_with(root)) {
             valid.push(expanded);
         } else {
             rejected.push(value.clone());
@@ -76,14 +106,13 @@ pub(crate) fn partition_expose(
     (valid, rejected)
 }
 
-fn expand_tilde(value: &str, home: &std::path::Path) -> std::path::PathBuf {
-    if let Some(rest) = value.strip_prefix("~/") {
-        home.join(rest)
-    } else if value == "~" {
-        home.to_path_buf()
-    } else {
-        std::path::PathBuf::from(value)
-    }
+/// `~`/`$HOME` expansion against an explicit home, so expose validation stays
+/// pure while accepting exactly the spellings every other path-taking config
+/// key accepts. `home` is forwarded to `expand_tilde_with_home` as-is, so the
+/// no-home case (`None`) takes its documented "leave `~` forms unchanged"
+/// path instead of one manufactured from an empty path.
+fn expand_expose(value: &str, home: Option<&std::path::Path>) -> std::path::PathBuf {
+    std::path::PathBuf::from(crate::fs::expand_tilde_with_home(value, home))
 }
 
 static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -188,8 +217,12 @@ impl Sandbox {
 
     /// Already-validated `sandbox-expose` paths (see `partition_expose`).
     /// Each is restored read-only on top of the masks via `--ro-bind-try`, so
-    /// expose can never grant write access.
-    pub fn with_expose(mut self, expose: Vec<std::path::PathBuf>) -> Self {
+    /// expose can never grant write access. `pub(crate)` rather than `pub`:
+    /// construction is meant to go through `build_sandbox`, the one place
+    /// that pairs this with `partition_expose`, so a caller outside the crate
+    /// cannot hand it unvalidated paths and bind them read-only over the
+    /// masks.
+    pub(crate) fn with_expose(mut self, expose: Vec<std::path::PathBuf>) -> Self {
         self.expose = expose;
         self
     }
@@ -232,7 +265,7 @@ impl Sandbox {
     /// Credential directories this sandbox masks, narrowed to what exists on
     /// the host: bwrap creates every `--tmpfs` mountpoint, and creating one on
     /// the read-only `/` bind aborts the whole launch.
-    pub fn masked_paths(&self) -> Vec<std::path::PathBuf> {
+    pub(crate) fn masked_roots(&self) -> Vec<std::path::PathBuf> {
         if !self.masking_active() {
             return Vec::new();
         }
@@ -245,30 +278,55 @@ impl Sandbox {
     }
 
     /// Masking is a bwrap mount policy, so it needs the sandbox enabled, the
-    /// bwrap backend, and a backend that will actually run.
+    /// bwrap backend, and a backend that will actually run. The availability
+    /// question is asked exactly the way `wrap_command` asks it, by sharing
+    /// `backend_will_run` with it. Both directions of a mismatch hurt: a
+    /// looser probe here would tell the model a path was masked while the
+    /// command ran bare and read it fine, and a stricter one would leave a
+    /// `sandbox-required` session running under bwrap with no masks emitted at
+    /// all, which is the mount policy silently switching itself off for the
+    /// user who asked for it hardest.
     fn masking_active(&self) -> bool {
-        self.enabled
-            && self.backend_binary() == "bwrap"
-            && (self.backend_available() || self.backend_available_now())
+        self.backend_will_run() && self.backend_binary() == "bwrap"
     }
 
     /// The host's advertised ssh-agent socket, if any: the path
     /// `SSH_AUTH_SOCK` points to, which the bwrap branch masks with
     /// `/dev/null` so the agent stays unreachable even if a command
-    /// reconstructs the variable by hand.
+    /// reconstructs the variable by hand. Empty and stale values (a socket
+    /// whose agent has since died, routine in long-lived tmux sessions) are
+    /// dropped for the same reason `masked_roots` filters by `exists`: bwrap
+    /// would have to create the bind destination on the read-only `/` bind,
+    /// which fails and aborts every sandboxed command.
     fn ssh_auth_sock(&self) -> Option<std::path::PathBuf> {
-        if let Some(sock) = &self.ssh_auth_sock {
-            return sock.clone();
-        }
-        std::env::var_os("SSH_AUTH_SOCK").map(std::path::PathBuf::from)
+        let advertised = match &self.ssh_auth_sock {
+            Some(sock) => sock.clone(),
+            None => std::env::var_os("SSH_AUTH_SOCK").map(std::path::PathBuf::from),
+        };
+        advertised.filter(|sock| !sock.as_os_str().is_empty() && sock.exists())
     }
 
     /// The mask root `cwd` sits under, if any. The working directory is bound
     /// after the masks, so it shadows that mask for its own subtree.
-    pub fn shadowed_mask_root(&self, cwd: &std::path::Path) -> Option<std::path::PathBuf> {
-        self.masked_paths()
+    pub(crate) fn shadowed_mask_root(&self, cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+        self.masked_roots()
             .into_iter()
-            .find(|root| cwd.starts_with(root))
+            .find(|root| contained_in(cwd, root))
+    }
+
+    /// The once-per-session warning for a working directory that sits inside a
+    /// masked credential directory, if it does. The directory is read from the
+    /// process rather than taken as an argument because that is exactly what
+    /// `wrap_command` binds: an ACP client's session directory is not the
+    /// directory the sandbox mounts (the ACP server never chdirs), so warning
+    /// about it would both fire spuriously and stay silent on the real case.
+    pub(crate) fn shadowed_mask_warning(&self) -> Option<String> {
+        let cwd = std::env::current_dir().ok()?;
+        let root = self.shadowed_mask_root(&cwd)?;
+        Some(format!(
+            "sandbox: the working directory is inside {}, so the project bind partially shadows the mask on it",
+            root.display()
+        ))
     }
 
     /// Binary this sandbox probes for. Anything other than `zerobox` uses the
@@ -299,6 +357,20 @@ impl Sandbox {
             return available;
         }
         which_cmd(self.backend_binary())
+    }
+
+    /// Whether a command will actually be launched under the backend. This is
+    /// the one predicate `wrap_command` branches on, and the one anything that
+    /// describes what the sandbox does to a command (masking, and the hints
+    /// built on it) has to ask: the sandbox is on, and either the cached PATH
+    /// probe found the backend, or the sandbox is required and a fresh probe
+    /// finds it. That second case is a backend installed after the
+    /// process-wide probe ran, which `refusal_reason` already re-probes for,
+    /// so a required sandbox launches on the fresh answer rather than the
+    /// stale one.
+    fn backend_will_run(&self) -> bool {
+        self.enabled
+            && (self.backend_available() || (self.required && self.backend_available_now()))
     }
 
     /// `Some(reason)` when the sandbox is required but its backend is missing,
@@ -332,7 +404,11 @@ impl Sandbox {
             return Err(std::io::Error::new(std::io::ErrorKind::NotFound, reason));
         }
 
-        if !self.required && !self.backend_available() {
+        // Not refused and not launching means the sandbox is optional and its
+        // backend is missing; `backend_will_run` is shared with
+        // `masking_active` so the two can never disagree about which probe
+        // decides that.
+        if !self.backend_will_run() {
             tracing::warn!(
                 "sandbox: {} not found, running unsandboxed",
                 self.backend_binary()
@@ -374,34 +450,19 @@ impl Sandbox {
         }
         // must bind /etc/resolv.conf before /.
         cmd.args(["--ro-bind", "/", "/"]);
-        // Masks shadow the read-only root, and the cwd bind below in turn
-        // shadows any mask it falls under, so a project living inside a masked
-        // directory stays usable.
-        for root in self.masked_paths() {
-            cmd.arg("--tmpfs");
-            cmd.arg(root.as_os_str());
-        }
-        // The advertised ssh-agent socket is masked too, so a command that
-        // reconstructs SSH_AUTH_SOCK by hand still cannot reach the agent.
-        if let Some(sock) = self.ssh_auth_sock() {
-            cmd.arg("--ro-bind-try");
-            cmd.arg("/dev/null");
-            cmd.arg(sock.as_os_str());
-        }
-        // Expose re-opens holes in the masks above, read-only: `--ro-bind-try`
-        // can never grant write access, which is what turns "only shrink,
-        // never widen" from policy into mechanism.
-        for path in &self.expose {
-            cmd.arg("--ro-bind-try");
-            cmd.arg(path.as_os_str());
-            cmd.arg(path.as_os_str());
-        }
+        // Masks shadow the read-only root. The cwd bind below is allowed to
+        // shadow a mask it falls *under*, so a project living inside a masked
+        // directory stays usable; every other collision the read-write binds
+        // cause is undone by the second mask layer further down.
+        let masks = self.masked_roots();
+        push_mask_layer(&mut cmd, &masks, &self.expose);
         cmd.arg("--bind");
         cmd.arg(cwd.as_os_str());
         cmd.arg(cwd.as_os_str());
         // Bind ~/.cache (or $XDG_CACHE_HOME) as writable after "/" bind
-        if let Some(cache_dir) = self.cache_dir.clone().or_else(dirs::cache_dir) {
-            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+        let cache_dir = self.cache_dir.clone().or_else(dirs::cache_dir);
+        if let Some(cache_dir) = &cache_dir {
+            if let Err(e) = std::fs::create_dir_all(cache_dir) {
                 tracing::warn!(
                     "sandbox: failed to create cache dir {}: {e}",
                     cache_dir.display()
@@ -410,6 +471,43 @@ impl Sandbox {
             cmd.arg("--bind");
             cmd.arg(cache_dir.as_os_str());
             cmd.arg(cache_dir.as_os_str());
+        }
+        // Both binds above are read-write and land after the mask layer, so
+        // every mask root *inside* one of them just came back, writable:
+        // running zerostack from `$HOME` would otherwise hand the sandbox a
+        // writable `~/.ssh`. Re-emit the mask layer for exactly those roots,
+        // in the same mask-then-expose order, so what was exposed under them
+        // stays visible read-only. Roots that *contain* the working directory
+        // are deliberately left shadowed: the project bind keeps the last word
+        // on its own subtree, which is what makes a project living inside a
+        // masked directory usable.
+        let reopened: Vec<std::path::PathBuf> = masks
+            .iter()
+            .filter(|root| {
+                let root = root.as_path();
+                std::iter::once(&cwd)
+                    .chain(cache_dir.iter())
+                    .any(|bind| contained_in(root, bind) && !same_dir(root, bind))
+            })
+            .cloned()
+            .collect();
+        let reopened_expose: Vec<std::path::PathBuf> = self
+            .expose
+            .iter()
+            .filter(|path| reopened.iter().any(|root| path.starts_with(root)))
+            .cloned()
+            .collect();
+        push_mask_layer(&mut cmd, &reopened, &reopened_expose);
+        // The advertised ssh-agent socket goes last of all, after every bind
+        // that could re-open it: an exposed `~/.gnupg` restores the gpg-agent
+        // SSH socket, and a bind whose subtree contains the socket restores it
+        // too. Masking it here means a command that reconstructs SSH_AUTH_SOCK
+        // by hand still cannot reach the agent, with no configuration able to
+        // undo it.
+        if let Some(sock) = self.ssh_auth_sock() {
+            cmd.arg("--ro-bind-try");
+            cmd.arg("/dev/null");
+            cmd.arg(sock.as_os_str());
         }
         cmd.args([
             "--ro-bind",
@@ -486,11 +584,109 @@ impl Sandbox {
     }
 }
 
+/// Symlink-resolved containment: whether `inner` is `outer` or lives under it.
+/// The mount policy turns on this question twice (which masks a read-write
+/// bind re-opens, and whether the project bind shadows a mask), and comparing
+/// the paths as written answers a different one. `cwd` comes from `getcwd(3)`
+/// and is therefore fully resolved, while mask roots are built from `$HOME` as
+/// the environment spells it, and bwrap resolves both at mount time. So
+/// `~/.ssh -> ~/dotfiles/ssh` with the project at `~/dotfiles`, or a
+/// `/home -> /data/home` layout with the project at `$HOME`, look unrelated
+/// lexically while the kernel puts one inside the other, and the mask would be
+/// left shadowed by a read-write bind: readable *and* writable, with no
+/// warning.
+///
+/// A path that cannot be canonicalized (it went away after the `exists`
+/// filter, or a parent denies traversal) counts as contained. Both callers use
+/// containment to decide whether to mask *more*, so an unresolvable path errs
+/// toward hiding credentials or warning about them; answering "not contained"
+/// would be the silently permissive direction, which is the one that leaks.
+fn contained_in(inner: &std::path::Path, outer: &std::path::Path) -> bool {
+    if inner.starts_with(outer) {
+        return true;
+    }
+    match (inner.canonicalize(), outer.canonicalize()) {
+        (Ok(inner), Ok(outer)) => inner.starts_with(outer),
+        _ => true,
+    }
+}
+
+/// Whether two paths name the same directory once resolved, so a mask root a
+/// read-write bind *is* can be told apart from one it *contains*: the former
+/// is the project living inside a masked directory, where the bind keeps the
+/// last word by design. Unresolvable paths are reported as different, which
+/// leads to the same re-mask as `contained_in`'s fallback.
+fn same_dir(a: &std::path::Path, b: &std::path::Path) -> bool {
+    a == b || matches!((a.canonicalize(), b.canonicalize()), (Ok(a), Ok(b)) if a == b)
+}
+
+/// One layer of the credential mask: a tmpfs over each root, then the exposed
+/// paths restored on top of them read-only. `--ro-bind-try` can never grant
+/// write access, which is what turns expose's "only shrink, never widen" rule
+/// from policy into mechanism, and the mask-before-expose order is what lets
+/// expose re-open a hole at all. `wrap_command` emits this twice: once over
+/// the read-only root, once over the read-write binds that follow it.
+fn push_mask_layer(cmd: &mut Command, roots: &[std::path::PathBuf], expose: &[std::path::PathBuf]) {
+    for root in roots {
+        cmd.arg("--tmpfs");
+        cmd.arg(root.as_os_str());
+    }
+    for path in expose {
+        cmd.arg("--ro-bind-try");
+        cmd.arg(path.as_os_str());
+        cmd.arg(path.as_os_str());
+    }
+}
+
+/// A session's sandbox plus the warnings building it produced. The warnings
+/// are returned rather than logged so the rule they follow stays enforceable:
+/// they are emitted once per session, from `init_features` and from ACP
+/// `handle_new_session`, and never from a resolver or from per-prompt code.
+pub(crate) struct SandboxSetup {
+    pub sandbox: Sandbox,
+    pub warnings: Vec<String>,
+}
+
+/// Already-resolved sandbox settings, as the CLI-over-config resolvers hand
+/// them over.
+pub(crate) struct SandboxSettings<'a> {
+    pub enabled: bool,
+    pub required: bool,
+    pub backend: &'a str,
+    pub shell: &'a str,
+    /// Raw `sandbox-expose` values, unexpanded and unvalidated.
+    pub expose: &'a [String],
+}
+
+/// Single construction path for the session sandbox, shared by every entry
+/// point (startup and ACP), so expose validation and the warnings about it
+/// cannot drift apart between them.
+pub(crate) fn build_sandbox(settings: &SandboxSettings<'_>) -> SandboxSetup {
+    let home = dirs::home_dir();
+    let (expose, rejected) =
+        partition_expose(settings.expose, &builtin_mask_roots(), home.as_deref());
+    let sandbox = Sandbox::new(settings.enabled, settings.backend)
+        .with_required(settings.required)
+        .with_shell(settings.shell)
+        .with_expose(expose);
+    let mut warnings: Vec<String> = rejected
+        .iter()
+        .map(|value| {
+            format!(
+                "sandbox-expose value '{value}' is not a masked path or subpath of one, ignoring it"
+            )
+        })
+        .collect();
+    warnings.extend(sandbox.shadowed_mask_warning());
+    SandboxSetup { sandbox, warnings }
+}
+
 /// One-line-per-root guidance for a failed sandboxed command: names every
 /// masked root that `command` or `stderr` mentions, in either the `~/`
 /// spelling or the absolute spelling under `home`. Pure and best-effort
 /// (string containment, not path parsing), so it is safe to call on every
-/// failure; `bash.rs` gates the call itself on a non-zero exit status.
+/// failure; its only caller, `bash::mask_hint_for_exit`, holds the exit-code
+/// gate.
 pub(crate) fn mask_hint(
     command: &str,
     stderr: &str,
@@ -512,7 +708,7 @@ pub(crate) fn mask_hint(
         if mentioned {
             let display = tilde.unwrap_or_else(|| absolute.into_owned());
             lines.push(format!(
-                "note: {display} is masked by sandbox; add to sandbox-expose to allow"
+                "note: {display} is masked by the sandbox; ask the user whether it should be exposed"
             ));
         }
     }
@@ -579,11 +775,20 @@ pub(crate) fn kill_process_group(pid: u32) {
     }
 }
 
-// SSH_AUTH_SOCK and SSH_AGENT_PID are deliberately absent: forwarding them
-// would keep a running ssh-agent reachable from inside the sandbox, which the
-// agent-socket mask above closes even against a command that reconstructs
-// SSH_AUTH_SOCK by hand.
-pub(crate) fn essential_env() -> Vec<(&'static str, String)> {
+/// The environment forwarded into the sandbox, read through `lookup` rather
+/// than from the process. That is the seam: `std::env::set_var` is a data race
+/// against every sibling test that reads the environment (this module reads it
+/// for `SSH_AUTH_SOCK`, `XDG_CONFIG_HOME` and `PATH`), so the test that proves
+/// the ssh-agent variables are dropped hands over an environment of its own
+/// instead.
+///
+/// SSH_AUTH_SOCK and SSH_AGENT_PID are deliberately absent from the list:
+/// forwarding them would keep a running ssh-agent reachable from inside the
+/// sandbox, which the agent-socket mask closes even against a command that
+/// reconstructs SSH_AUTH_SOCK by hand.
+pub(crate) fn essential_env_from(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Vec<(&'static str, String)> {
     let preserve = [
         "PATH",
         "HOME",
@@ -619,9 +824,13 @@ pub(crate) fn essential_env() -> Vec<(&'static str, String)> {
     ];
     let mut vars = Vec::with_capacity(preserve.len());
     for name in &preserve {
-        if let Ok(val) = std::env::var(name) {
+        if let Some(val) = lookup(name) {
             vars.push((*name, val));
         }
     }
     vars
+}
+
+fn essential_env() -> Vec<(&'static str, String)> {
+    essential_env_from(|name| std::env::var(name).ok())
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -486,6 +486,43 @@ impl Sandbox {
     }
 }
 
+/// One-line-per-root guidance for a failed sandboxed command: names every
+/// masked root that `command` or `stderr` mentions, in either the `~/`
+/// spelling or the absolute spelling under `home`. Pure and best-effort
+/// (string containment, not path parsing), so it is safe to call on every
+/// failure; `bash.rs` gates the call itself on a non-zero exit status.
+pub(crate) fn mask_hint(
+    command: &str,
+    stderr: &str,
+    masked_roots: &[std::path::PathBuf],
+    home: &std::path::Path,
+) -> Option<String> {
+    let mut lines = Vec::new();
+    for root in masked_roots {
+        let absolute = root.to_string_lossy();
+        let tilde = root
+            .strip_prefix(home)
+            .ok()
+            .map(|rel| format!("~/{}", rel.display()));
+        let mentioned = command.contains(absolute.as_ref())
+            || stderr.contains(absolute.as_ref())
+            || tilde
+                .as_deref()
+                .is_some_and(|t| command.contains(t) || stderr.contains(t));
+        if mentioned {
+            let display = tilde.unwrap_or_else(|| absolute.into_owned());
+            lines.push(format!(
+                "note: {display} is masked by sandbox; add to sandbox-expose to allow"
+            ));
+        }
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
 fn spawn_pipe_reader(
     pipe: Option<impl tokio::io::AsyncRead + Send + Unpin + 'static>,
 ) -> (

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -13,12 +13,37 @@ pub struct Sandbox {
     shell: String,
     // Test seams: `backend_available` replaces the cached PATH probe for the
     // backend binary (and `backend_installed_now` the fresh one) so tests
-    // behave the same on hosts with and without bwrap, while `cache_dir` keeps
-    // the bwrap arg builder away from the real user cache.
+    // behave the same on hosts with and without bwrap, `cache_dir` keeps the
+    // bwrap arg builder away from the real user cache, and `mask_roots`
+    // replaces the built-in credential list with temp dirs so mask assertions
+    // do not depend on the developer's home.
     backend_available: Option<bool>,
     backend_installed_now: Option<bool>,
     cache_dir: Option<std::path::PathBuf>,
+    mask_roots: Option<Vec<std::path::PathBuf>>,
     active_groups: Arc<Mutex<HashSet<u32>>>,
+}
+
+/// Well-known credential stores, relative to the home directory. Each is
+/// covered by a tmpfs inside the bwrap sandbox, so sandboxed commands read them
+/// as empty rather than as the user's keys and tokens.
+const MASK_DIRS: [&str; 9] = [
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".kube",
+    ".docker",
+    ".config/gh",
+    ".config/gcloud",
+    ".config/op",
+    ".config/sops/age",
+];
+
+fn builtin_mask_roots() -> Vec<std::path::PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    MASK_DIRS.iter().map(|rel| home.join(rel)).collect()
 }
 
 static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -93,6 +118,7 @@ impl Sandbox {
             backend_available: None,
             backend_installed_now: None,
             cache_dir: None,
+            mask_roots: None,
             active_groups: Arc::new(Mutex::new(HashSet::new())),
         }
     }
@@ -136,6 +162,43 @@ impl Sandbox {
     pub fn with_cache_dir(mut self, dir: std::path::PathBuf) -> Self {
         self.cache_dir = Some(dir);
         self
+    }
+
+    #[cfg(test)]
+    pub fn with_mask_roots(mut self, roots: Vec<std::path::PathBuf>) -> Self {
+        self.mask_roots = Some(roots);
+        self
+    }
+
+    /// Credential directories this sandbox masks, narrowed to what exists on
+    /// the host: bwrap creates every `--tmpfs` mountpoint, and creating one on
+    /// the read-only `/` bind aborts the whole launch.
+    pub fn masked_paths(&self) -> Vec<std::path::PathBuf> {
+        if !self.masking_active() {
+            return Vec::new();
+        }
+        self.mask_roots
+            .clone()
+            .unwrap_or_else(builtin_mask_roots)
+            .into_iter()
+            .filter(|root| root.exists())
+            .collect()
+    }
+
+    /// Masking is a bwrap mount policy, so it needs the sandbox enabled, the
+    /// bwrap backend, and a backend that will actually run.
+    fn masking_active(&self) -> bool {
+        self.enabled
+            && self.backend_binary() == "bwrap"
+            && (self.backend_available() || self.backend_available_now())
+    }
+
+    /// The mask root `cwd` sits under, if any. The working directory is bound
+    /// after the masks, so it shadows that mask for its own subtree.
+    pub fn shadowed_mask_root(&self, cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+        self.masked_paths()
+            .into_iter()
+            .find(|root| cwd.starts_with(root))
     }
 
     /// Binary this sandbox probes for. Anything other than `zerobox` uses the
@@ -240,7 +303,15 @@ impl Sandbox {
             }
         }
         // must bind /etc/resolv.conf before /.
-        cmd.args(["--ro-bind", "/", "/", "--bind"]);
+        cmd.args(["--ro-bind", "/", "/"]);
+        // Masks shadow the read-only root, and the cwd bind below in turn
+        // shadows any mask it falls under, so a project living inside a masked
+        // directory stays usable.
+        for root in self.masked_paths() {
+            cmd.arg("--tmpfs");
+            cmd.arg(root.as_os_str());
+        }
+        cmd.arg("--bind");
         cmd.arg(cwd.as_os_str());
         cmd.arg(cwd.as_os_str());
         // Bind ~/.cache (or $XDG_CACHE_HOME) as writable after "/" bind

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -434,6 +434,14 @@ impl Startup {
                 );
             }
         }
+        if let Ok(cwd) = std::env::current_dir()
+            && let Some(root) = self.sandbox.shadowed_mask_root(&cwd)
+        {
+            tracing::warn!(
+                "sandbox: the working directory is inside {}, so the project bind partially shadows the mask on it",
+                root.display()
+            );
+        }
         let edit_system = self.cli.resolve_edit_system(&self.cfg);
         tools::set_edit_system(edit_system);
         tools::set_deny_repeated_reads(self.cfg.deny_repeated_reads.unwrap_or(true));

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -415,9 +415,22 @@ impl Startup {
         let sandbox_enabled = self.cli.resolve_sandbox(&self.cfg);
         let sandbox_required = self.cli.resolve_sandbox_required(&self.cfg);
         let sandbox_backend = self.cli.resolve_sandbox_backend(&self.cfg);
+        let sandbox_expose_raw = self.cli.resolve_sandbox_expose(&self.cfg);
+        let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
+        let (sandbox_expose, sandbox_expose_rejected) = crate::sandbox::partition_expose(
+            &sandbox_expose_raw,
+            &crate::sandbox::builtin_mask_roots(),
+            &sandbox_expose_home,
+        );
+        for value in &sandbox_expose_rejected {
+            tracing::warn!(
+                "sandbox-expose value '{value}' is not a masked path or subpath of one, ignoring it"
+            );
+        }
         self.sandbox = Sandbox::new(sandbox_enabled, &sandbox_backend)
             .with_required(sandbox_required)
-            .with_shell(&self.cli.resolve_shell(&self.cfg));
+            .with_shell(&self.cli.resolve_shell(&self.cfg))
+            .with_expose(sandbox_expose);
         if self.cli.sandbox_setting_conflict(&self.cfg) {
             tracing::warn!(
                 "sandbox is set to false but sandbox-required is set, enabling the sandbox anyway"

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -416,21 +416,17 @@ impl Startup {
         let sandbox_required = self.cli.resolve_sandbox_required(&self.cfg);
         let sandbox_backend = self.cli.resolve_sandbox_backend(&self.cfg);
         let sandbox_expose_raw = self.cli.resolve_sandbox_expose(&self.cfg);
-        let sandbox_expose_home = dirs::home_dir().unwrap_or_default();
-        let (sandbox_expose, sandbox_expose_rejected) = crate::sandbox::partition_expose(
-            &sandbox_expose_raw,
-            &crate::sandbox::builtin_mask_roots(),
-            &sandbox_expose_home,
-        );
-        for value in &sandbox_expose_rejected {
-            tracing::warn!(
-                "sandbox-expose value '{value}' is not a masked path or subpath of one, ignoring it"
-            );
+        let sandbox_setup = crate::sandbox::build_sandbox(&crate::sandbox::SandboxSettings {
+            enabled: sandbox_enabled,
+            required: sandbox_required,
+            backend: &sandbox_backend,
+            shell: &self.cli.resolve_shell(&self.cfg),
+            expose: &sandbox_expose_raw,
+        });
+        self.sandbox = sandbox_setup.sandbox;
+        for warning in &sandbox_setup.warnings {
+            tracing::warn!("{warning}");
         }
-        self.sandbox = Sandbox::new(sandbox_enabled, &sandbox_backend)
-            .with_required(sandbox_required)
-            .with_shell(&self.cli.resolve_shell(&self.cfg))
-            .with_expose(sandbox_expose);
         if self.cli.sandbox_setting_conflict(&self.cfg) {
             tracing::warn!(
                 "sandbox is set to false but sandbox-required is set, enabling the sandbox anyway"
@@ -446,14 +442,6 @@ impl Startup {
                     "sandbox is enabled but backend '{sandbox_backend}' was not found, commands will run unsandboxed"
                 );
             }
-        }
-        if let Ok(cwd) = std::env::current_dir()
-            && let Some(root) = self.sandbox.shadowed_mask_root(&cwd)
-        {
-            tracing::warn!(
-                "sandbox: the working directory is inside {}, so the project bind partially shadows the mask on it",
-                root.display()
-            );
         }
         let edit_system = self.cli.resolve_edit_system(&self.cfg);
         tools::set_edit_system(edit_system);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -81,6 +81,8 @@ mod resumed_history_tests;
 #[cfg(all(test, feature = "rtk"))]
 mod rtk_tests;
 #[cfg(test)]
+mod sandbox_agent_cutoff_tests;
+#[cfg(test)]
 mod sandbox_expose_tests;
 #[cfg(test)]
 mod sandbox_mask_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -71,6 +71,8 @@ mod paste_burst_tests;
 #[cfg(test)]
 mod picker_tests;
 #[cfg(test)]
+mod print_config_tests;
+#[cfg(test)]
 mod prompt_mode_tests;
 #[cfg(test)]
 mod provider_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -81,6 +81,8 @@ mod resumed_history_tests;
 #[cfg(all(test, feature = "rtk"))]
 mod rtk_tests;
 #[cfg(test)]
+mod sandbox_mask_tests;
+#[cfg(test)]
 mod sandbox_required_tests;
 #[cfg(all(test, feature = "export"))]
 mod session_export_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -81,6 +81,8 @@ mod resumed_history_tests;
 #[cfg(all(test, feature = "rtk"))]
 mod rtk_tests;
 #[cfg(test)]
+mod sandbox_expose_tests;
+#[cfg(test)]
 mod sandbox_mask_tests;
 #[cfg(test)]
 mod sandbox_required_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -85,6 +85,8 @@ mod sandbox_agent_cutoff_tests;
 #[cfg(test)]
 mod sandbox_expose_tests;
 #[cfg(test)]
+mod sandbox_hint_tests;
+#[cfg(test)]
 mod sandbox_mask_tests;
 #[cfg(test)]
 mod sandbox_required_tests;

--- a/src/tests/print_config_tests.rs
+++ b/src/tests/print_config_tests.rs
@@ -1,0 +1,69 @@
+use crate::print::format_sandbox_expose_display;
+use crate::sandbox::partition_expose;
+
+#[test]
+fn sandbox_expose_display_empty() {
+    assert_eq!(format_sandbox_expose_display(&[]), "(none)");
+}
+
+#[test]
+fn sandbox_expose_display_multi_value() {
+    let values = vec!["~/.ssh/known_hosts".to_string(), "~/.aws".to_string()];
+    assert_eq!(
+        format_sandbox_expose_display(&values),
+        "~/.ssh/known_hosts, ~/.aws"
+    );
+}
+
+/// `--print-config` must report the *effective* sandbox-expose list, the
+/// same one `build_sandbox` would actually apply, not the raw CLI/config
+/// values: a value that is not a masked entry or subpath of one (and so gets
+/// rejected by `partition_expose`) must never appear in the printed row,
+/// even though it is still present in the unvalidated input.
+#[test]
+fn sandbox_expose_display_omits_rejected_values() {
+    let home = std::env::temp_dir().join(format!(
+        "zerostack-print-config-expose-{}",
+        std::process::id()
+    ));
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh".to_string(), "/etc".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), Some(&home));
+    let display = format_sandbox_expose_display(
+        &valid
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+    );
+
+    assert_eq!(display, ssh.display().to_string());
+    assert_eq!(
+        rejected,
+        vec!["/etc".to_string()],
+        "the rejected value must still be reported to whoever logs the startup warning"
+    );
+}
+
+/// When every raw value is rejected, the row must fall back to the same
+/// `(none)` rendering as an empty list, not print the rejected values as if
+/// they were in effect.
+#[test]
+fn sandbox_expose_display_all_rejected_renders_none() {
+    let home = std::env::temp_dir().join(format!(
+        "zerostack-print-config-expose-none-{}",
+        std::process::id()
+    ));
+    let ssh = home.join(".ssh");
+    let raw = vec!["/etc".to_string()];
+
+    let (valid, _rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), Some(&home));
+    let display = format_sandbox_expose_display(
+        &valid
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+    );
+
+    assert_eq!(display, "(none)");
+}

--- a/src/tests/sandbox_agent_cutoff_tests.rs
+++ b/src/tests/sandbox_agent_cutoff_tests.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use tokio::process::Command;
 
-use crate::sandbox::{Sandbox, essential_env};
+use crate::sandbox::{Sandbox, essential_env_from};
 
 fn scratch_dir(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
@@ -34,14 +35,22 @@ fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize>
 
 #[test]
 fn test_essential_env_excludes_ssh_agent_vars_even_when_set() {
-    unsafe { std::env::set_var("SSH_AUTH_SOCK", "/tmp/zerostack-test-agent.sock") };
-    unsafe { std::env::set_var("SSH_AGENT_PID", "12345") };
+    // Through the seam, not `set_var`: libtest runs these on a thread pool
+    // where sibling tests read the process environment (`SSH_AUTH_SOCK`,
+    // `XDG_CONFIG_HOME`, `PATH`), and mutating it under them is the data race
+    // `set_var` is unsafe for, on top of clobbering whatever the developer had
+    // set.
+    let env: HashMap<&str, &str> = HashMap::from([
+        ("SSH_AUTH_SOCK", "/tmp/zerostack-test-agent.sock"),
+        ("SSH_AGENT_PID", "12345"),
+        ("PATH", "/usr/bin:/bin"),
+    ]);
+    let vars = essential_env_from(|name| env.get(name).map(|value| value.to_string()));
 
-    let vars = essential_env();
-
-    unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
-    unsafe { std::env::remove_var("SSH_AGENT_PID") };
-
+    assert!(
+        vars.contains(&("PATH", "/usr/bin:/bin".to_string())),
+        "sanity: the seam forwards what is on the list, or the assertions below are vacuous: {vars:?}"
+    );
     assert!(
         !vars.iter().any(|(k, _)| *k == "SSH_AUTH_SOCK"),
         "SSH_AUTH_SOCK must never reach the sandbox environment: {vars:?}"
@@ -52,9 +61,19 @@ fn test_essential_env_excludes_ssh_agent_vars_even_when_set() {
     );
 }
 
+/// Creates a stand-in for a live agent socket: `wrap_command` only masks a
+/// socket path that exists on the host, so the file has to be real.
+fn touch_socket(dir: &std::path::Path, name: &str) -> PathBuf {
+    std::fs::create_dir_all(dir).unwrap();
+    let sock = dir.join(name);
+    std::fs::write(&sock, b"").unwrap();
+    sock
+}
+
 #[test]
 fn test_ssh_auth_sock_seam_emits_dev_null_bind_after_root_bind() {
-    let sock = scratch_dir("sock").join("agent.sock");
+    let sock_dir = scratch_dir("sock");
+    let sock = touch_socket(&sock_dir, "agent.sock");
     let cache_dir = scratch_dir("sock-cache");
     let sandbox = Sandbox::new(true, "bwrap")
         .with_backend_available(true)
@@ -73,6 +92,83 @@ fn test_ssh_auth_sock_seam_emits_dev_null_bind_after_root_bind() {
         "the agent socket mask must come after the `/` ro-bind: {args:?}"
     );
 
+    let _ = std::fs::remove_dir_all(&sock_dir);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_stale_ssh_auth_sock_emits_no_dev_null_bind() {
+    // A dead agent leaves SSH_AUTH_SOCK pointing at a path that no longer
+    // exists (routine in long-lived tmux sessions). Binding over it would make
+    // bwrap create the destination on the read-only `/` bind, which fails with
+    // EROFS and aborts every command in the session.
+    let sock = scratch_dir("stale").join("agent.sock");
+    let _ = std::fs::remove_dir_all(scratch_dir("stale"));
+    let cache_dir = scratch_dir("stale-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(Vec::new())
+        .with_ssh_auth_sock(Some(sock.clone()));
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    assert!(
+        triple_at(&args, "--ro-bind-try", "/dev/null", &sock.to_string_lossy()).is_none(),
+        "a socket path missing on the host must not be bound over: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_empty_ssh_auth_sock_emits_no_dev_null_bind() {
+    // `SSH_AUTH_SOCK=` is a common way to disable forwarding; it names no path
+    // at all, so there is nothing to mask.
+    let cache_dir = scratch_dir("empty-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(Vec::new())
+        .with_ssh_auth_sock(Some(PathBuf::new()));
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    assert!(
+        !args.iter().any(|a| a == "/dev/null"),
+        "an empty SSH_AUTH_SOCK names no socket, so no bind should be emitted: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_agent_socket_mask_survives_exposing_the_directory_holding_it() {
+    // `sandbox-expose ~/.gnupg` re-binds the host directory on top of the
+    // mask, which brings the gpg-agent SSH socket inside it back: the agent
+    // cutoff has no re-enable switch, so the socket bind must come after every
+    // expose bind that could re-open it.
+    let gnupg = scratch_dir("gnupg");
+    let sock = touch_socket(&gnupg, "S.gpg-agent.ssh");
+    let cache_dir = scratch_dir("gnupg-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(vec![gnupg.clone()])
+        .with_expose(vec![gnupg.clone()])
+        .with_ssh_auth_sock(Some(sock.clone()));
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let gnupg_str = gnupg.to_string_lossy();
+    let expose = triple_at(&args, "--ro-bind-try", &gnupg_str, &gnupg_str)
+        .unwrap_or_else(|| panic!("expected the exposed directory to be re-bound: {args:?}"));
+    let agent_bind = triple_at(&args, "--ro-bind-try", "/dev/null", &sock.to_string_lossy())
+        .unwrap_or_else(|| panic!("expected /dev/null bound over the agent socket: {args:?}"));
+
+    assert!(
+        expose < agent_bind,
+        "the agent socket mask must be the last word, after the expose bind: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&gnupg);
     let _ = std::fs::remove_dir_all(&cache_dir);
 }
 

--- a/src/tests/sandbox_agent_cutoff_tests.rs
+++ b/src/tests/sandbox_agent_cutoff_tests.rs
@@ -1,0 +1,95 @@
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use crate::sandbox::{Sandbox, essential_env};
+
+fn scratch_dir(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "zerostack-agent-cutoff-{}-{}",
+        name,
+        std::process::id()
+    ))
+}
+
+fn args_of(cmd: &Command) -> Vec<String> {
+    cmd.as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
+/// answers a question asked about `--tmpfs <mask root>`.
+fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
+    args.windows(2).position(|w| w[0] == flag && w[1] == value)
+}
+
+/// Index of `flag` in an adjacent `flag src dst` triple, matching the
+/// `--ro-bind-try <src> <dst>` shape the agent-socket mask emits.
+fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize> {
+    args.windows(3)
+        .position(|w| w[0] == flag && w[1] == src && w[2] == dst)
+}
+
+#[test]
+fn test_essential_env_excludes_ssh_agent_vars_even_when_set() {
+    unsafe { std::env::set_var("SSH_AUTH_SOCK", "/tmp/zerostack-test-agent.sock") };
+    unsafe { std::env::set_var("SSH_AGENT_PID", "12345") };
+
+    let vars = essential_env();
+
+    unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
+    unsafe { std::env::remove_var("SSH_AGENT_PID") };
+
+    assert!(
+        !vars.iter().any(|(k, _)| *k == "SSH_AUTH_SOCK"),
+        "SSH_AUTH_SOCK must never reach the sandbox environment: {vars:?}"
+    );
+    assert!(
+        !vars.iter().any(|(k, _)| *k == "SSH_AGENT_PID"),
+        "SSH_AGENT_PID must never reach the sandbox environment: {vars:?}"
+    );
+}
+
+#[test]
+fn test_ssh_auth_sock_seam_emits_dev_null_bind_after_root_bind() {
+    let sock = scratch_dir("sock").join("agent.sock");
+    let cache_dir = scratch_dir("sock-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(Vec::new())
+        .with_ssh_auth_sock(Some(sock.clone()));
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let sock_str = sock.to_string_lossy();
+    let root_bind = pair_at(&args, "--ro-bind", "/").expect("`/` should be ro-bound");
+    let agent_bind = triple_at(&args, "--ro-bind-try", "/dev/null", &sock_str)
+        .unwrap_or_else(|| panic!("expected /dev/null bound over the agent socket: {args:?}"));
+
+    assert!(
+        root_bind < agent_bind,
+        "the agent socket mask must come after the `/` ro-bind: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_no_host_ssh_auth_sock_emits_no_dev_null_bind() {
+    let cache_dir = scratch_dir("none-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(Vec::new())
+        .with_ssh_auth_sock(None);
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    assert!(
+        !args.iter().any(|a| a == "/dev/null"),
+        "no host SSH_AUTH_SOCK, so no /dev/null bind should be emitted: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}

--- a/src/tests/sandbox_expose_tests.rs
+++ b/src/tests/sandbox_expose_tests.rs
@@ -1,0 +1,195 @@
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::sandbox::{Sandbox, partition_expose};
+
+fn scratch_dir(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("zerostack-expose-{}-{}", name, std::process::id()))
+}
+
+fn args_of(cmd: &Command) -> Vec<String> {
+    cmd.as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
+/// answers a question asked about `--tmpfs <mask root>`.
+fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
+    args.windows(2).position(|w| w[0] == flag && w[1] == value)
+}
+
+/// Index of `flag` in an adjacent `flag src dst` triple, matching the
+/// `--ro-bind-try <path> <path>` shape expose emits.
+fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize> {
+    args.windows(3)
+        .position(|w| w[0] == flag && w[1] == src && w[2] == dst)
+}
+
+// --- Resolver: CLI replaces config wholesale ---
+
+#[test]
+fn test_resolve_sandbox_expose_cli_replaces_config_wholesale() {
+    let cli = Cli {
+        sandbox_expose: vec!["~/.ssh".to_string()],
+        ..Default::default()
+    };
+    let cfg = Config {
+        sandbox_expose: Some(vec!["~/.aws".to_string()]),
+        ..Default::default()
+    };
+    assert_eq!(
+        cli.resolve_sandbox_expose(&cfg),
+        vec!["~/.ssh".to_string()],
+        "a non-empty CLI list must replace the config list wholesale, not merge with it"
+    );
+}
+
+#[test]
+fn test_resolve_sandbox_expose_falls_back_to_config() {
+    let cli = Cli::default();
+    let cfg = Config {
+        sandbox_expose: Some(vec!["~/.aws".to_string()]),
+        ..Default::default()
+    };
+    assert_eq!(cli.resolve_sandbox_expose(&cfg), vec!["~/.aws".to_string()]);
+}
+
+#[test]
+fn test_resolve_sandbox_expose_defaults_to_empty() {
+    let cli = Cli::default();
+    let cfg = Config::default();
+    assert!(cli.resolve_sandbox_expose(&cfg).is_empty());
+}
+
+// --- Partition: validation against the mask list ---
+
+#[test]
+fn test_partition_accepts_exact_mask_root() {
+    let home = scratch_dir("home-exact");
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), &home);
+
+    assert_eq!(valid, vec![ssh]);
+    assert!(
+        rejected.is_empty(),
+        "exact mask root must be accepted: {rejected:?}"
+    );
+}
+
+#[test]
+fn test_partition_accepts_subpath_of_mask_root() {
+    let home = scratch_dir("home-subpath");
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh/known_hosts".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+
+    assert_eq!(valid, vec![home.join(".ssh/known_hosts")]);
+    assert!(
+        rejected.is_empty(),
+        "a subpath of a mask root must be accepted: {rejected:?}"
+    );
+}
+
+#[test]
+fn test_partition_rejects_path_outside_mask_list() {
+    let home = scratch_dir("home-outside");
+    let ssh = home.join(".ssh");
+    let raw = vec!["/etc".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+
+    assert!(
+        valid.is_empty(),
+        "a path outside the mask list must not be exposed: {valid:?}"
+    );
+    assert_eq!(rejected, vec!["/etc".to_string()]);
+}
+
+#[test]
+fn test_partition_rejects_sibling_component_trap() {
+    // Component-wise containment, not string prefixes: `~/.ssh2` is not under
+    // `~/.ssh`, even though the string "~/.ssh" is a text prefix of it.
+    let home = scratch_dir("home-sibling");
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh2".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+
+    assert!(
+        valid.is_empty(),
+        "`~/.ssh2` must not pass as a subpath of `~/.ssh`: {valid:?}"
+    );
+    assert_eq!(rejected, vec!["~/.ssh2".to_string()]);
+}
+
+// --- Arg assembly: --ro-bind-try after masks, before the cwd bind ---
+
+#[test]
+fn test_expose_emits_ro_bind_try_between_masks_and_cwd_bind() {
+    let root = scratch_dir("expose-arg-assembly");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("expose-arg-assembly-cache");
+
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(vec![root.clone()])
+        .with_expose(vec![root.clone()]);
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let root_str = root.to_string_lossy();
+    let cwd = std::env::current_dir().unwrap();
+
+    let mask = pair_at(&args, "--tmpfs", &root_str)
+        .unwrap_or_else(|| panic!("expected the mask tmpfs to still be emitted: {args:?}"));
+    let expose = triple_at(&args, "--ro-bind-try", &root_str, &root_str)
+        .unwrap_or_else(|| panic!("expected --ro-bind-try for the exposed path: {args:?}"));
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+
+    assert!(
+        mask < expose,
+        "expose must come after the mask tmpfs: {args:?}"
+    );
+    assert!(
+        expose < cwd_bind,
+        "expose must come before the cwd bind: {args:?}"
+    );
+    assert!(
+        pair_at(&args, "--bind", &root_str).is_none(),
+        "expose must never grant write access via plain --bind: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_no_expose_emits_no_ro_bind_try() {
+    let root = scratch_dir("no-expose");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("no-expose-cache");
+
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(vec![root.clone()]);
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let root_str = root.to_string_lossy();
+    assert!(
+        triple_at(&args, "--ro-bind-try", &root_str, &root_str).is_none(),
+        "no expose configured, so no --ro-bind-try for the mask root should appear: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}

--- a/src/tests/sandbox_expose_tests.rs
+++ b/src/tests/sandbox_expose_tests.rs
@@ -74,7 +74,7 @@ fn test_partition_accepts_exact_mask_root() {
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh".to_string()];
 
-    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), &home);
+    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), Some(&home));
 
     assert_eq!(valid, vec![ssh]);
     assert!(
@@ -89,7 +89,7 @@ fn test_partition_accepts_subpath_of_mask_root() {
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh/known_hosts".to_string()];
 
-    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+    let (valid, rejected) = partition_expose(&raw, &[ssh], Some(&home));
 
     assert_eq!(valid, vec![home.join(".ssh/known_hosts")]);
     assert!(
@@ -104,7 +104,7 @@ fn test_partition_rejects_path_outside_mask_list() {
     let ssh = home.join(".ssh");
     let raw = vec!["/etc".to_string()];
 
-    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+    let (valid, rejected) = partition_expose(&raw, &[ssh], Some(&home));
 
     assert!(
         valid.is_empty(),
@@ -121,13 +121,155 @@ fn test_partition_rejects_sibling_component_trap() {
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh2".to_string()];
 
-    let (valid, rejected) = partition_expose(&raw, &[ssh], &home);
+    let (valid, rejected) = partition_expose(&raw, &[ssh], Some(&home));
 
     assert!(
         valid.is_empty(),
         "`~/.ssh2` must not pass as a subpath of `~/.ssh`: {valid:?}"
     );
     assert_eq!(rejected, vec!["~/.ssh2".to_string()]);
+}
+
+#[test]
+fn test_partition_accepts_dollar_home_spelling() {
+    // Every other path-taking config key accepts `$HOME/...`; expose rejecting
+    // it would be a trap with no reason behind it.
+    let home = scratch_dir("home-dollar");
+    let ssh = home.join(".ssh");
+    let raw = vec!["$HOME/.ssh".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&ssh), Some(&home));
+
+    assert_eq!(valid, vec![ssh]);
+    assert!(
+        rejected.is_empty(),
+        "`$HOME/.ssh` names the same directory as `~/.ssh`: {rejected:?}"
+    );
+}
+
+#[test]
+fn test_partition_rejects_parent_dir_escape_to_home() {
+    // `~/.ssh/..` passes a component-wise subpath test while naming the whole
+    // home directory, which would re-bind everything the masks hide.
+    let home = scratch_dir("home-escape");
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh/..".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], Some(&home));
+
+    assert!(
+        valid.is_empty(),
+        "a `..` component must never be exposed: {valid:?}"
+    );
+    assert_eq!(rejected, raw);
+}
+
+#[test]
+fn test_partition_rejects_parent_dir_escape_into_a_sibling_mask() {
+    let home = scratch_dir("home-escape-sibling");
+    let ssh = home.join(".ssh");
+    let aws = home.join(".aws");
+    let raw = vec!["~/.ssh/../.aws".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh, aws], Some(&home));
+
+    assert!(
+        valid.is_empty(),
+        "the direct spelling is the way to expose another mask root: {valid:?}"
+    );
+    assert_eq!(rejected, raw);
+}
+
+#[test]
+fn test_partition_rejects_parent_dir_escape_out_of_home() {
+    let home = scratch_dir("home-escape-out");
+    let ssh = home.join(".ssh");
+    let raw = vec!["~/.ssh/../../../etc".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], Some(&home));
+
+    assert!(
+        valid.is_empty(),
+        "climbing out of the mask list must be rejected like any other outside value: {valid:?}"
+    );
+    assert_eq!(rejected, raw);
+}
+
+#[test]
+fn test_partition_expose_with_no_home_leaves_tilde_form_unexpanded() {
+    // `home: None` models a host with no home directory. Per
+    // `expand_tilde_with_home`'s documented behavior, a `~` form must be
+    // returned unchanged rather than expanded against a manufactured empty
+    // path, so it can never accidentally satisfy a `mask_roots` entry.
+    let ssh = PathBuf::from("/nonexistent-home/.ssh");
+    let raw = vec!["~/.ssh".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, &[ssh], None);
+
+    assert!(
+        valid.is_empty(),
+        "a `~` form must not expand against a missing home: {valid:?}"
+    );
+    assert_eq!(rejected, raw);
+}
+
+#[test]
+fn test_partition_expose_with_no_home_still_accepts_an_absolute_mask_root() {
+    // The `None` home only affects `~`/`$HOME` expansion; an already-absolute
+    // value must still validate normally, so `None` is not a blanket
+    // rejection of everything.
+    let root = PathBuf::from("/nonexistent-home/.ssh");
+    let raw = vec!["/nonexistent-home/.ssh".to_string()];
+
+    let (valid, rejected) = partition_expose(&raw, std::slice::from_ref(&root), None);
+
+    assert_eq!(valid, vec![root]);
+    assert!(
+        rejected.is_empty(),
+        "an absolute path needs no home to validate: {rejected:?}"
+    );
+}
+
+// --- Shared construction: one validation path for every entry point ---
+
+#[test]
+fn test_build_sandbox_returns_the_rejected_value_warning() {
+    let setup = crate::sandbox::build_sandbox(&crate::sandbox::SandboxSettings {
+        enabled: true,
+        required: false,
+        backend: "bwrap",
+        shell: "bash",
+        expose: &["/etc".to_string()],
+    });
+
+    assert!(
+        setup
+            .warnings
+            .iter()
+            .any(|w| w.contains("sandbox-expose value '/etc'")),
+        "the out-of-list value must be reported verbatim to whoever logs it: {:?}",
+        setup.warnings
+    );
+}
+
+#[test]
+fn test_build_sandbox_is_quiet_without_expose_values() {
+    let setup = crate::sandbox::build_sandbox(&crate::sandbox::SandboxSettings {
+        enabled: true,
+        required: false,
+        backend: "bwrap",
+        shell: "bash",
+        expose: &[],
+    });
+
+    assert!(
+        !setup
+            .warnings
+            .iter()
+            .any(|w| w.contains("sandbox-expose value")),
+        "no expose values, so nothing to warn about: {:?}",
+        setup.warnings
+    );
 }
 
 // --- Arg assembly: --ro-bind-try after masks, before the cwd bind ---

--- a/src/tests/sandbox_hint_tests.rs
+++ b/src/tests/sandbox_hint_tests.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+
+use crate::agent::tools::bash::mask_hint_for_exit;
+use crate::sandbox::mask_hint;
+
+fn home() -> PathBuf {
+    PathBuf::from("/home/tester")
+}
+
+fn ssh_root() -> PathBuf {
+    home().join(".ssh")
+}
+
+fn aws_root() -> PathBuf {
+    home().join(".aws")
+}
+
+#[test]
+fn test_masked_file_read_failure_hints() {
+    let hint = mask_hint(
+        "cat ~/.ssh/id_ed25519",
+        "cat: /home/tester/.ssh/id_ed25519: No such file or directory",
+        &[ssh_root()],
+        &home(),
+    );
+    assert_eq!(
+        hint,
+        Some("note: ~/.ssh is masked by sandbox; add to sandbox-expose to allow".to_string())
+    );
+}
+
+#[test]
+fn test_absolute_path_only_in_stderr_hints() {
+    // The command string uses a shell variable, so only the shell-expanded
+    // absolute path in stderr names the masked root.
+    let hint = mask_hint(
+        "cat $CRED_FILE",
+        "cat: /home/tester/.aws/credentials: No such file or directory",
+        &[aws_root()],
+        &home(),
+    );
+    assert_eq!(
+        hint,
+        Some("note: ~/.aws is masked by sandbox; add to sandbox-expose to allow".to_string())
+    );
+}
+
+#[test]
+fn test_multiple_hits_name_each_root_once() {
+    let hint = mask_hint(
+        "cat ~/.ssh/id_ed25519 ~/.ssh/id_rsa ~/.aws/credentials",
+        "",
+        &[ssh_root(), aws_root()],
+        &home(),
+    );
+    assert_eq!(
+        hint,
+        Some(
+            "note: ~/.ssh is masked by sandbox; add to sandbox-expose to allow\n\
+note: ~/.aws is masked by sandbox; add to sandbox-expose to allow"
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn test_unrelated_failure_never_hints() {
+    let hint = mask_hint(
+        "cat missing.txt",
+        "cat: missing.txt: No such file or directory",
+        &[ssh_root(), aws_root()],
+        &home(),
+    );
+    assert_eq!(hint, None);
+}
+
+#[test]
+fn test_exit_zero_never_hints_even_when_masked_path_is_mentioned() {
+    // Same command/stderr that would hint on a failure must stay silent on
+    // success: this exercises the wiring predicate's exit-code gate, not just
+    // `mask_hint` itself, since a bug that dropped the gate would still pass
+    // every `mask_hint`-only assertion above.
+    let command = "cat ~/.ssh/id_ed25519";
+    let stderr = "";
+    assert_eq!(
+        mask_hint_for_exit(0, command, stderr, &[ssh_root()], &home()),
+        None,
+        "exit code 0 must never produce a hint"
+    );
+    assert!(
+        mask_hint_for_exit(1, command, stderr, &[ssh_root()], &home()).is_some(),
+        "sanity: the same inputs must hint on a non-zero exit"
+    );
+}

--- a/src/tests/sandbox_hint_tests.rs
+++ b/src/tests/sandbox_hint_tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::agent::tools::bash::mask_hint_for_exit;
-use crate::sandbox::mask_hint;
+use crate::sandbox::{Sandbox, mask_hint};
 
 fn home() -> PathBuf {
     PathBuf::from("/home/tester")
@@ -25,7 +25,10 @@ fn test_masked_file_read_failure_hints() {
     );
     assert_eq!(
         hint,
-        Some("note: ~/.ssh is masked by sandbox; add to sandbox-expose to allow".to_string())
+        Some(
+            "note: ~/.ssh is masked by the sandbox; ask the user whether it should be exposed"
+                .to_string()
+        )
     );
 }
 
@@ -41,7 +44,10 @@ fn test_absolute_path_only_in_stderr_hints() {
     );
     assert_eq!(
         hint,
-        Some("note: ~/.aws is masked by sandbox; add to sandbox-expose to allow".to_string())
+        Some(
+            "note: ~/.aws is masked by the sandbox; ask the user whether it should be exposed"
+                .to_string()
+        )
     );
 }
 
@@ -56,8 +62,8 @@ fn test_multiple_hits_name_each_root_once() {
     assert_eq!(
         hint,
         Some(
-            "note: ~/.ssh is masked by sandbox; add to sandbox-expose to allow\n\
-note: ~/.aws is masked by sandbox; add to sandbox-expose to allow"
+            "note: ~/.ssh is masked by the sandbox; ask the user whether it should be exposed\n\
+note: ~/.aws is masked by the sandbox; ask the user whether it should be exposed"
                 .to_string()
         )
     );
@@ -74,21 +80,61 @@ fn test_unrelated_failure_never_hints() {
     assert_eq!(hint, None);
 }
 
+/// A sandbox that really masks `root`, so `mask_hint_for_exit` is exercised
+/// the way `bash.rs` calls it: the mask list comes out of the sandbox rather
+/// than from the test, which is what puts the whole hint path (the exit-code
+/// gate, the mask list, the substring match) under one call.
+fn masking_sandbox(root: &std::path::Path) -> Sandbox {
+    Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.to_path_buf()])
+}
+
 #[test]
 fn test_exit_zero_never_hints_even_when_masked_path_is_mentioned() {
-    // Same command/stderr that would hint on a failure must stay silent on
-    // success: this exercises the wiring predicate's exit-code gate, not just
-    // `mask_hint` itself, since a bug that dropped the gate would still pass
-    // every `mask_hint`-only assertion above.
-    let command = "cat ~/.ssh/id_ed25519";
-    let stderr = "";
+    // The same command that hints on a failure must stay silent on success.
+    // The gate lives in the function under test and the tool calls it
+    // unconditionally, so this is the branch production takes, and the cost it
+    // guards (the sandbox's `exists()` walk over the mask list) is on the
+    // other side of it.
+    let root = std::env::temp_dir().join(format!("zerostack-hint-{}/.ssh", std::process::id()));
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = masking_sandbox(&root);
+    let command = format!("cat {}/id_ed25519", root.display());
+
     assert_eq!(
-        mask_hint_for_exit(0, command, stderr, &[ssh_root()], &home()),
+        mask_hint_for_exit(0, &command, "", &sandbox),
         None,
         "exit code 0 must never produce a hint"
     );
+    let hint = mask_hint_for_exit(1, &command, "", &sandbox)
+        .expect("a failed command naming a masked root must hint");
     assert!(
-        mask_hint_for_exit(1, command, stderr, &[ssh_root()], &home()).is_some(),
-        "sanity: the same inputs must hint on a non-zero exit"
+        hint.contains(&root.display().to_string()) && hint.contains("ask the user"),
+        "the hint should name the masked root and route the decision to the user: {hint}"
     );
+
+    let _ = std::fs::remove_dir_all(root.parent().unwrap());
+}
+
+#[test]
+fn test_unsandboxed_command_never_hints() {
+    // Nothing was masked, so nothing can be blamed on the mask: the mask list
+    // the function pulls from the sandbox is empty when the backend is not
+    // going to run.
+    let root =
+        std::env::temp_dir().join(format!("zerostack-hint-bare-{}/.ssh", std::process::id()));
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(false)
+        .with_mask_roots(vec![root.clone()]);
+    let command = format!("cat {}/id_ed25519", root.display());
+
+    assert_eq!(
+        mask_hint_for_exit(1, &command, "", &sandbox),
+        None,
+        "a command that ran unsandboxed read the real file, so a mask hint would be a lie"
+    );
+
+    let _ = std::fs::remove_dir_all(root.parent().unwrap());
 }

--- a/src/tests/sandbox_mask_tests.rs
+++ b/src/tests/sandbox_mask_tests.rs
@@ -1,11 +1,23 @@
-use std::path::PathBuf;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
 
-use crate::sandbox::Sandbox;
+use crate::sandbox::{Sandbox, mask_roots_for};
 
 fn scratch_dir(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("zerostack-mask-{}-{}", name, std::process::id()))
+}
+
+/// A scratch directory *inside* the working directory, which is the directory
+/// `wrap_command` binds read-write: a mask root under it is the case where
+/// that bind would otherwise re-open the mask. `target/` keeps the churn out
+/// of the tracked tree.
+fn cwd_scratch_dir(name: &str) -> PathBuf {
+    std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join(format!("zerostack-mask-{}-{}", name, std::process::id()))
 }
 
 fn bwrap_sandbox(masks: Vec<PathBuf>, cache_dir: PathBuf) -> Sandbox {
@@ -26,6 +38,36 @@ fn args_of(cmd: &Command) -> Vec<String> {
 /// answers a question asked about `--tmpfs <mask root>`.
 fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
     args.windows(2).position(|w| w[0] == flag && w[1] == value)
+}
+
+/// Every mount this argument list places *at* `dst`, in order, as
+/// `(index, flag)`. Later mounts shadow earlier ones, so the last entry is
+/// what a sandboxed command actually sees there, which is the property the
+/// mask invariant is about.
+fn mounts_at(args: &[String], dst: &str) -> Vec<(usize, String)> {
+    let mut mounts = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arity = match args[i].as_str() {
+            "--tmpfs" | "--dev" | "--proc" | "--dir" => 2,
+            "--bind" | "--bind-try" | "--ro-bind" | "--ro-bind-try" | "--dev-bind" => 3,
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        if args.get(i + arity - 1).is_some_and(|arg| arg == dst) {
+            mounts.push((i, args[i].clone()));
+        }
+        i += arity;
+    }
+    mounts
+}
+
+fn last_mount_at(args: &[String], dst: &Path) -> (usize, String) {
+    mounts_at(args, &dst.to_string_lossy())
+        .pop()
+        .unwrap_or_else(|| panic!("expected something mounted at {}: {args:?}", dst.display()))
 }
 
 #[test]
@@ -75,7 +117,7 @@ fn test_nonexistent_mask_root_emits_no_tmpfs() {
         "the `/tmp` tmpfs should still be there, or the assertion above is vacuous: {args:?}"
     );
     assert!(
-        sandbox.masked_paths().is_empty(),
+        sandbox.masked_roots().is_empty(),
         "a mask root missing on the host is not a masked path"
     );
 
@@ -144,6 +186,414 @@ fn test_sibling_of_a_mask_root_is_not_shadowed() {
 }
 
 #[test]
+fn test_cwd_reached_through_a_symlinked_home_is_shadowed() {
+    // Same mismatch on the warning side: the working directory arrives from
+    // `getcwd(3)` fully resolved while the mask root is spelled through the
+    // `/home -> /data/home` symlink, so a lexical test reports no shadowing and
+    // the user is never told the project bind re-opens part of the mask.
+    let base = scratch_dir("symlinked-home-shadow");
+    let _ = std::fs::remove_dir_all(&base);
+    let real_home = base.join("data/home/tester");
+    let project = real_home.join(".gnupg/notes");
+    std::fs::create_dir_all(&project).unwrap();
+    let elsewhere = real_home.join("notes");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+    symlink(base.join("data/home"), base.join("home")).unwrap();
+    let root = base.join("home/tester/.gnupg");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.clone()]);
+
+    assert_eq!(
+        sandbox.shadowed_mask_root(&project.canonicalize().unwrap()),
+        Some(root.clone()),
+        "a project inside the mask root's target is shadowed by the project bind, however the root is spelled"
+    );
+    assert_eq!(
+        sandbox.shadowed_mask_root(&elsewhere.canonicalize().unwrap()),
+        None,
+        "resolving the paths must not turn the containment test into a blanket yes"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn test_mask_root_under_the_cwd_is_remasked_after_the_project_bind() {
+    // Running zerostack from `$HOME` puts every credential directory under the
+    // read-write project bind, which is emitted after the masks: without a
+    // second mask layer they come back, and writable at that.
+    let root = cwd_scratch_dir("under-cwd");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("under-cwd-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cwd = std::env::current_dir().unwrap();
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+    let (index, flag) = last_mount_at(&args, &root);
+
+    assert_eq!(
+        flag, "--tmpfs",
+        "the tmpfs must be the last mount at a mask root the project bind swallows, or the sandbox gets a writable credential directory: {args:?}"
+    );
+    assert!(
+        index > cwd_bind,
+        "the re-mask must come after the project bind to shadow it: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_mask_root_under_the_cache_bind_is_remasked() {
+    // Same shape via the other read-write bind: the cache directory is bound
+    // after the masks too.
+    let cache_dir = scratch_dir("cache-swallow");
+    let root = cache_dir.join(".aws");
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cache_bind = pair_at(&args, "--bind", &cache_dir.to_string_lossy())
+        .expect("the cache directory should be bound");
+    let (index, flag) = last_mount_at(&args, &root);
+
+    assert_eq!(
+        flag, "--tmpfs",
+        "the tmpfs must be the last mount at a mask root the cache bind swallows: {args:?}"
+    );
+    assert!(
+        index > cache_bind,
+        "the re-mask must come after the cache bind to shadow it: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_mask_root_symlinked_into_the_project_is_remasked() {
+    // `~/.ssh -> ~/dotfiles/ssh` with the project at `~/dotfiles`: the tmpfs
+    // lands on the resolved path, which is inside the read-write project bind,
+    // so the bind re-opens it writable. Spelled as written the mask root does
+    // not start with the project path at all, so only a symlink-resolved
+    // containment test sees the collision.
+    let real = cwd_scratch_dir("dotfiles");
+    std::fs::create_dir_all(real.join("ssh")).unwrap();
+    let home = scratch_dir("symlinked-ssh");
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    let root = home.join(".ssh");
+    symlink(real.join("ssh"), &root).unwrap();
+    let cache_dir = scratch_dir("symlinked-ssh-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cwd = std::env::current_dir().unwrap();
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+    let (index, flag) = last_mount_at(&args, &root);
+
+    assert_eq!(
+        flag, "--tmpfs",
+        "a mask root whose target the project bind swallows must end up masked: {args:?}"
+    );
+    assert!(
+        index > cwd_bind,
+        "the re-mask must come after the project bind, or the symlinked credential directory is writable inside the sandbox: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&real);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_mask_root_under_a_symlinked_home_is_remasked() {
+    // The other shape: `$HOME` itself traverses a symlink (`/home ->
+    // /data/home`, routine on NFS and LVM layouts), so every mask root is
+    // spelled through it while the bind, coming from `getcwd(3)`, is already
+    // resolved. Modelled on the cache bind, which the seams let a test place
+    // anywhere.
+    let base = scratch_dir("symlinked-home");
+    let _ = std::fs::remove_dir_all(&base);
+    let real_home = base.join("data/home/tester");
+    std::fs::create_dir_all(real_home.join(".aws")).unwrap();
+    symlink(base.join("data/home"), base.join("home")).unwrap();
+    let root = base.join("home/tester/.aws");
+    let sandbox = bwrap_sandbox(vec![root.clone()], real_home.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cache_bind = pair_at(&args, "--bind", &real_home.to_string_lossy())
+        .expect("the cache directory should be bound");
+    let (index, flag) = last_mount_at(&args, &root);
+
+    assert_eq!(
+        flag, "--tmpfs",
+        "a mask root reached through a symlinked home must end up masked: {args:?}"
+    );
+    assert!(
+        index > cache_bind,
+        "the re-mask must come after the read-write bind that contains the resolved root: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn test_expose_under_a_remasked_root_stays_visible_read_only() {
+    let root = cwd_scratch_dir("under-cwd-expose");
+    std::fs::create_dir_all(&root).unwrap();
+    let exposed = root.join("known_hosts");
+    std::fs::write(&exposed, b"").unwrap();
+    let cache_dir = scratch_dir("under-cwd-expose-cache");
+    let sandbox =
+        bwrap_sandbox(vec![root.clone()], cache_dir.clone()).with_expose(vec![exposed.clone()]);
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cwd = std::env::current_dir().unwrap();
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+    let (mask, mask_flag) = last_mount_at(&args, &root);
+    let (expose, expose_flag) = last_mount_at(&args, &exposed);
+
+    assert_eq!(mask_flag, "--tmpfs");
+    assert_eq!(
+        expose_flag, "--ro-bind-try",
+        "an exposed subpath must stay restored, and read-only: {args:?}"
+    );
+    assert!(
+        cwd_bind < mask && mask < expose,
+        "the re-mask lands after the project bind, so the exposed subpath has to be restored after it in turn: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_mask_root_containing_the_cwd_keeps_the_project_bind_as_the_last_word() {
+    // The other side of the same rule: a project living inside a masked
+    // directory stays usable, so a mask root that *contains* the working
+    // directory is masked once and left shadowed there.
+    let cwd = std::env::current_dir().unwrap();
+    let root = cwd
+        .parent()
+        .expect("cwd should have a parent")
+        .to_path_buf();
+    let cache_dir = scratch_dir("contains-cwd-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let mounts = mounts_at(&args, &root.to_string_lossy());
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+
+    assert_eq!(
+        mounts.len(),
+        1,
+        "a mask root containing the working directory must be masked exactly once: {args:?}"
+    );
+    assert!(
+        mounts[0].0 < cwd_bind,
+        "the mask comes first so the project bind can shadow it: {args:?}"
+    );
+    assert_eq!(
+        last_mount_at(&args, &cwd).1,
+        "--bind",
+        "the project bind must stay the last word on its own subtree: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_mask_root_outside_every_read_write_bind_is_masked_once() {
+    let root = scratch_dir("outside-binds");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("outside-binds-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    assert_eq!(
+        mounts_at(&args, &root.to_string_lossy()).len(),
+        1,
+        "nothing re-opens this root, so a second mask layer would be dead weight: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_optional_sandbox_falling_back_to_bare_masks_nothing() {
+    // An optional sandbox runs bare when the cached probe finds no backend,
+    // even if a fresh probe would find one. A masked-path claim there would
+    // tell the model a file was hidden while the command ran bare and read it
+    // fine.
+    let root = scratch_dir("probe");
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(false)
+        .with_backend_installed_now(true)
+        .with_mask_roots(vec![root.clone()]);
+
+    let cmd = sandbox.wrap_command("echo hello").unwrap();
+    assert_eq!(
+        cmd.as_std().get_program(),
+        "bash",
+        "sanity: the cached probe says the backend is missing, so the command runs unsandboxed"
+    );
+    assert!(
+        sandbox.masked_roots().is_empty(),
+        "an unsandboxed command masks nothing"
+    );
+
+    let sandboxed = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.clone()]);
+    assert_eq!(
+        sandboxed.masked_roots(),
+        vec![root.clone()],
+        "sanity: the same root is masked once the backend actually runs"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_required_sandbox_masks_on_the_fresh_probe_that_launches_it() {
+    // A required sandbox launches bwrap on the fresh probe when the cached one
+    // is stale (the backend was installed after the process-wide probe ran).
+    // Masking has to follow it there: gating on the cached probe alone would
+    // run bwrap with an empty mask list, leaving every credential directory
+    // readable inside the sandbox of the user who set `sandbox-required`.
+    let root = scratch_dir("required-probe");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("required-probe-cache");
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_required(true)
+        .with_backend_available(false)
+        .with_backend_installed_now(true)
+        .with_cache_dir(cache_dir.clone())
+        .with_mask_roots(vec![root.clone()]);
+
+    let cmd = sandbox.wrap_command("echo hello").unwrap();
+    assert_eq!(
+        cmd.as_std().get_program(),
+        "bwrap",
+        "sanity: a required sandbox launches on the fresh probe, so this command is sandboxed"
+    );
+    assert_eq!(
+        sandbox.masked_roots(),
+        vec![root.clone()],
+        "a sandboxed command must mask, whichever probe let it launch"
+    );
+    assert!(
+        pair_at(&args_of(&cmd), "--tmpfs", &root.to_string_lossy()).is_some(),
+        "the mask has to reach the bwrap invocation, not just masked_roots()"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_shadowed_mask_warning_is_computed_against_the_bound_working_directory() {
+    // The sandbox binds this process's working directory, never a directory
+    // handed in by a caller (an ACP client's session cwd, say), so the warning
+    // has to be about that one.
+    let cwd = std::env::current_dir().unwrap();
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![cwd.clone()]);
+    let warning = sandbox
+        .shadowed_mask_warning()
+        .expect("a mask root containing the bound working directory must warn");
+    assert!(
+        warning.contains(&cwd.display().to_string()),
+        "the warning should name the shadowed root: {warning}"
+    );
+
+    let elsewhere = scratch_dir("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+    let other = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![elsewhere.clone()]);
+    assert_eq!(
+        other.shadowed_mask_warning(),
+        None,
+        "a mask root the bound working directory is not inside must stay quiet"
+    );
+    assert_eq!(
+        other.shadowed_mask_root(&elsewhere.join("project")),
+        Some(elsewhere.clone()),
+        "sanity: that root would warn if some other directory decided the answer"
+    );
+
+    let _ = std::fs::remove_dir_all(&elsewhere);
+}
+
+// --- The built-in mask list ---
+
+#[test]
+fn test_mask_roots_follow_xdg_config_home_when_set() {
+    // XDG_CONFIG_HOME is forwarded into the sandbox, so masking `~/.config/gh`
+    // on a host that relocated its config base hides nothing the tools read.
+    let home = PathBuf::from("/home/tester");
+    let xdg = PathBuf::from("/home/tester/cfg");
+
+    assert_eq!(
+        mask_roots_for(&home, Some(&xdg)),
+        vec![
+            home.join(".ssh"),
+            home.join(".aws"),
+            home.join(".gnupg"),
+            home.join(".kube"),
+            home.join(".docker"),
+            xdg.join("gh"),
+            xdg.join("gcloud"),
+            xdg.join("op"),
+            xdg.join("sops/age"),
+        ]
+    );
+}
+
+#[test]
+fn test_mask_roots_default_to_dot_config() {
+    let home = PathBuf::from("/home/tester");
+
+    assert_eq!(
+        mask_roots_for(&home, None),
+        vec![
+            home.join(".ssh"),
+            home.join(".aws"),
+            home.join(".gnupg"),
+            home.join(".kube"),
+            home.join(".docker"),
+            home.join(".config/gh"),
+            home.join(".config/gcloud"),
+            home.join(".config/op"),
+            home.join(".config/sops/age"),
+        ]
+    );
+}
+
+#[test]
+fn test_relative_xdg_config_home_is_ignored() {
+    // A relative XDG_CONFIG_HOME is invalid per the spec; falling back beats
+    // masking a path relative to whatever the working directory happens to be.
+    let home = PathBuf::from("/home/tester");
+
+    assert_eq!(
+        mask_roots_for(&home, Some(Path::new("cfg"))),
+        mask_roots_for(&home, None)
+    );
+}
+
+#[test]
 fn test_disabled_sandbox_masks_nothing() {
     let root = scratch_dir("disabled");
     std::fs::create_dir_all(&root).unwrap();
@@ -151,7 +601,7 @@ fn test_disabled_sandbox_masks_nothing() {
         .with_backend_available(true)
         .with_mask_roots(vec![root.clone()]);
 
-    assert!(sandbox.masked_paths().is_empty());
+    assert!(sandbox.masked_roots().is_empty());
     assert_eq!(sandbox.shadowed_mask_root(&root), None);
 
     let _ = std::fs::remove_dir_all(&root);

--- a/src/tests/sandbox_mask_tests.rs
+++ b/src/tests/sandbox_mask_tests.rs
@@ -1,0 +1,158 @@
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use crate::sandbox::Sandbox;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("zerostack-mask-{}-{}", name, std::process::id()))
+}
+
+fn bwrap_sandbox(masks: Vec<PathBuf>, cache_dir: PathBuf) -> Sandbox {
+    Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir)
+        .with_mask_roots(masks)
+}
+
+fn args_of(cmd: &Command) -> Vec<String> {
+    cmd.as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
+/// answers a question asked about `--tmpfs <mask root>`.
+fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
+    args.windows(2).position(|w| w[0] == flag && w[1] == value)
+}
+
+#[test]
+fn test_existing_mask_root_is_masked_between_root_bind_and_cwd_bind() {
+    let root = scratch_dir("existing");
+    std::fs::create_dir_all(&root).unwrap();
+    let cache_dir = scratch_dir("existing-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let cwd = std::env::current_dir().unwrap();
+    let root_bind = pair_at(&args, "--ro-bind", "/").expect("`/` should be ro-bound");
+    let mask = pair_at(&args, "--tmpfs", &root.to_string_lossy())
+        .unwrap_or_else(|| panic!("existing mask root should be tmpfs-masked: {args:?}"));
+    let cwd_bind = pair_at(&args, "--bind", &cwd.to_string_lossy())
+        .expect("the working directory should be bound");
+
+    assert!(
+        root_bind < mask,
+        "the mask must shadow the `/` ro-bind, so it comes after it: {args:?}"
+    );
+    assert!(
+        mask < cwd_bind,
+        "the cwd bind must shadow the mask, so it comes after it: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_nonexistent_mask_root_emits_no_tmpfs() {
+    // bwrap creates `--tmpfs` mountpoints, which a read-only `/` forbids: a
+    // missing entry would abort every sandboxed command on that host.
+    let root = scratch_dir("missing");
+    let _ = std::fs::remove_dir_all(&root);
+    let cache_dir = scratch_dir("missing-cache");
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
+
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    assert!(
+        pair_at(&args, "--tmpfs", &root.to_string_lossy()).is_none(),
+        "a mask root missing on the host must not be mounted: {args:?}"
+    );
+    assert!(
+        pair_at(&args, "--tmpfs", "/tmp").is_some(),
+        "the `/tmp` tmpfs should still be there, or the assertion above is vacuous: {args:?}"
+    );
+    assert!(
+        sandbox.masked_paths().is_empty(),
+        "a mask root missing on the host is not a masked path"
+    );
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[test]
+fn test_zerobox_invocation_is_unchanged_by_masks() {
+    let root = scratch_dir("zerobox");
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = Sandbox::new(true, "zerobox")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.clone()]);
+
+    let cmd = sandbox.wrap_command("echo hello").unwrap();
+    assert_eq!(cmd.as_std().get_program(), "zerobox");
+    let cwd = std::env::current_dir()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(
+        args_of(&cmd),
+        vec!["--allow-write", &cwd, "--", "bash", "-c", "echo hello"],
+        "zerobox exposes no mount policy, so masking must not touch its invocation"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_cwd_under_a_mask_root_reports_that_root() {
+    let root = scratch_dir("shadowed");
+    let cwd = root.join("nvim/lua");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.clone()]);
+
+    assert_eq!(sandbox.shadowed_mask_root(&cwd), Some(root.clone()));
+    assert_eq!(
+        sandbox.shadowed_mask_root(&root),
+        Some(root.clone()),
+        "a cwd that is the mask root itself is shadowed too"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_sibling_of_a_mask_root_is_not_shadowed() {
+    // Component-wise containment, not string prefixes: `~/.ssh2` is not under
+    // `~/.ssh`.
+    let base = scratch_dir("sibling");
+    let root = base.join(".ssh");
+    let sibling = base.join(".ssh2");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root]);
+
+    assert_eq!(sandbox.shadowed_mask_root(&sibling), None);
+    assert_eq!(sandbox.shadowed_mask_root(&base), None);
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn test_disabled_sandbox_masks_nothing() {
+    let root = scratch_dir("disabled");
+    std::fs::create_dir_all(&root).unwrap();
+    let sandbox = Sandbox::new(false, "bwrap")
+        .with_backend_available(true)
+        .with_mask_roots(vec![root.clone()]);
+
+    assert!(sandbox.masked_paths().is_empty());
+    assert_eq!(sandbox.shadowed_mask_root(&root), None);
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary

With the `bwrap` backend, `/` is mounted read only but nothing is hidden, so every credential store under `$HOME` is readable inside the sandbox, and the environment allowlist keeps a running ssh-agent reachable, so a sandboxed command can sign with your keys without reading a key file. SECURITY.md lists both as known gaps. This closes them: a built-in list of credential directories is covered with a tmpfs by default, the advertised agent socket is masked and its environment variables are dropped, and a new `sandbox-expose` key restores read-only access to a specific entry when a command legitimately needs it.

This is the second of the sandbox series that started with #244 (`sandbox-required`), and it follows that PR's conventions: flat kebab config keys, pure `resolve_*` functions, warnings emitted once at startup, a `--print-config` row for the new key, and argument-assembly tests through the existing `#[cfg(test)]` seams.

## Motivation

Today, one careless command inside the sandbox can read `~/.ssh`, `~/.aws`, `~/.config/gh` and friends, or use the forwarded `SSH_AUTH_SOCK` to sign and push. The sandbox is documented as a seatbelt against accidents rather than a boundary against hostile code, but a seatbelt that leaves every credential in the room is doing less than users assume it is. Masking the well-known stores by default moves the common accident (an agent reading or exfiltrating a key while doing something unrelated) out of reach, and does it through the mount policy rather than through prose, so the property holds without anyone remembering a rule.

## Design decisions

**Why is the mask list subtract-only?** `sandbox-expose` removes entries, and nothing adds them. That is deliberate for a first cut: the built-in list is the part that has to be defensible in review, and an additive key invites the list to become a per-user configuration surface before we know what people actually need. The symmetric `sandbox-mask` key (append to the built-ins, for `~/.azure`, `~/.terraform.d`, `~/.config/containers`, a company credential directory) is the obvious follow-up and I am happy to send it as a separate PR; I would rather agree on the default list here than ship both directions at once.

**Why validate `sandbox-expose` against the mask list instead of accepting any path?** Because that is what makes "only shrink, never widen" a mechanism instead of a promise. Every masked path already sits under the read-only `/` bind, so restoring one with `--ro-bind-try` can only ever hand back read access that the sandbox already grants elsewhere. A free-form expose key would be a general mount-policy escape hatch, which is a much larger thing to review. Values outside the list are warned about once, quoted verbatim, and ignored.

**Why no way to re-enable the ssh-agent?** The combination this change exists to prevent is precisely "passphrase-protected key, automated push from inside the sandbox". Removing `SSH_AUTH_SOCK` and `SSH_AGENT_PID` alone is a speed bump, since the socket stays visible through the `/` bind and any command can set the variable itself, so the socket path is covered with `/dev/null` as well. The recovery paths are `sandbox-expose ~/.ssh` for direct key-file authentication, or the `!` prefix, which runs outside the sandbox with the agent intact. If upstream wants a `sandbox-ssh-agent` switch, that is a small follow-up, but I did not want to ship the hole and the door in the same PR.

**Why is masking bwrap only?** `zerobox` exposes no mount-policy surface beyond `--allow-write`, so there is no mechanism to inject masks there. The per-backend table in SECURITY.md says so plainly and does not claim `zerobox` is unaffected by the home-readable gap, because its documented behavior covers writes, network and environment, not reads.

## Testing

- `cargo test --all-features`: 1035 pass, 0 fail. The change adds 30 tests: mask emission and ordering, the re-mask that survives read-write binds (including symlinked `~/.ssh` and symlinked `$HOME`), expose validation including the `~/.ssh2` sibling trap and `..` traversal, the agent cutoff, the hint function, and the resolver.
- Ordering is asserted at the argument-assembly level through the existing test seams, plus two new ones (`with_mask_roots`, `with_ssh_auth_sock`), so nothing shells out to a real `bwrap` in the suite.
- Runtime verification: the built binary was driven headless against a mock provider with a stub `bwrap` that records the assembled argv and then execs the wrapped command. Confirmed: the argument order, the re-mask after the working-directory and cache binds when a mask root sits under them, the `/dev/null` socket cover landing after the expose mounts, no socket bind for a stale `SSH_AUTH_SOCK`, the warning for an out-of-list value, the hint text on a failed masked-path read, and the `--print-config` row.
- **Not verified against a real `bwrap`.** The development host is macOS and no Linux host was available in this session, so the specific bwrap behaviors this design assumes are inferred from its documented semantics rather than observed: that `--tmpfs` succeeds on a mountpoint whose parent is on a read-only bind, that `--ro-bind-try /dev/null <unix socket>` is accepted, that `--ro-bind-try` can restore a path inside a tmpfs mounted moments earlier, and that a later mount shadows an earlier one at the same path. If you want a Linux integration test gated behind a `bwrap`-present check before this merges, say so and I will add one.
- Independent two-axis review (repo standards, and fidelity to what was specified): 11 findings, 9 actioned, 2 recorded as accepted trade-offs.
- Adversarial maintainer-persona review of the finished diff: 20 findings, 14 fixed in the last commit, 6 answered above or in the notes below.
- Visual diff sign-off page: not produced for this branch.

## Reviewing

Read `src/sandbox.rs` first, and inside it read `wrap_command` before anything else: the entire security property is the order of the emitted bwrap arguments, and everything else in the file exists to feed it. The order is the read-only `/` bind, the mask layer, the expose mounts, the working-directory and cache binds, then a second mask layer for any root those read-write binds would otherwise re-open, then the agent socket cover last so nothing can restore it. `partition_expose` and the `contained_in` / `same_dir` helpers are the two places where a mistake turns into a silently permissive sandbox, so they are worth more attention than their size suggests.

`src/cli.rs`, `src/config/mod.rs` and `src/print.rs` are mechanical and follow #244's shape. `src/startup.rs` and `src/extras/acp/mod.rs` are wiring: both construction points go through one `build_sandbox` that returns its warnings rather than logging them, so the "warn once per session, never from inside a resolver" rule holds in both. The documentation commit is the honest inventory of what this does and does not do, and is probably the fastest way to judge whether the scope is right.

On size: 2010 insertions sounds like a lot for this feature. 1355 of them are tests and 114 are documentation, leaving roughly 540 lines of logic, a large share of which is comments explaining why mount order matters at each step.

## Notes

- The masks are writable tmpfs, not read-only views, so a command that writes into a masked directory succeeds and then loses the write when the sandbox exits, and because it exits zero the hint never fires for that shape. bwrap has `--remount-ro`, but a read-only mask would make tools that write into their own credential directory fail hard instead. Both behaviors are defensible; the current one is documented rather than chosen silently, and I will switch it if you prefer the harder failure.
- The agent socket cover uses `--ro-bind-try`, which fails open, while the masks use `--tmpfs`, which fails closed. The `-try` tolerates the socket disappearing between the existence check and the launch. If you would rather the cutoff fail closed, this is a one-word change.
- Directory masking does not touch live IPC credential endpoints. The environment allowlist still forwards `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` and `/run` stays readable, so the freedesktop secret service and everything built on it (`secret-tool`, `git-credential-libsecret`, `docker-credential-secretservice`) can still read stored tokens. This is now listed as a remaining gap in SECURITY.md rather than quietly left out.
- The hint matching is substring containment of either spelling of a masked root, not path parsing, so it can fire on `~/.ssh2` or miss a script that reads a masked path without naming it. It is advisory guidance rather than an oracle, and it no longer names the config key that would unmask the path, since it lands in a tool result the model reads and the model can write the project-local config that sets that key.
- `sandbox-expose` is settable from a project-local `.zerostack/config.toml`, exactly like every other key, so a cloned repository can unmask a directory. That is the existing trust model rather than something new here, and `docs/CONFIG.md` now says so where the key is documented.
- The CLI flag replaces the config list wholesale, following the existing `resolve_*` convention, which means there is no spelling for "ignore my config list and expose nothing". A `--no-sandbox-expose` would close that; say the word and I will add it.
- Existing sandbox users will see `git push` over SSH, `kubectl`, `docker push` and gpg signing stop working inside sandboxed commands. Recovery is one config line for the read-path tools, and the `!` prefix for human-driven operations. I did not mark this breaking because the sandbox is opt-in, but it is a real default change and the release notes should say so.
- `is_effectively_sandboxed`, which feeds the UI, still consults only the cached backend probe, so with `sandbox-required` and a backend installed mid-session it reports unsandboxed while bwrap actually runs. It errs toward warning rather than toward a false safety claim, and I left it alone rather than widen this PR into UI code.
