### PR TITLE
chore: refresh model catalog from models.dev

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -314,8 +314,8 @@
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
       "context": 1050000,
-      "input_price": 1,
-      "output_price": 6
+      "input_price": 0.2,
+      "output_price": 1.2
     },
     {
       "id": "gpt-5.6-sol",
@@ -328,8 +328,8 @@
       "id": "gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
       "context": 1050000,
-      "input_price": 2.5,
-      "output_price": 15
+      "input_price": 2,
+      "output_price": 12
     },
     {
       "id": "o1",
@@ -737,6 +737,11 @@
       "context": 1048576
     },
     {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek V4 Flash 0731",
+      "context": 1048576
+    },
+    {
       "id": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
       "context": 1048576
@@ -794,7 +799,7 @@
     {
       "id": "google/gemini-3.1-flash-image-preview",
       "name": "Nano Banana 2",
-      "context": 131072
+      "context": 65536
     },
     {
       "id": "google/gemini-3.1-flash-lite",
@@ -935,11 +940,6 @@
       "id": "mistralai/codestral-2508",
       "name": "Codestral 2508",
       "context": 256000
-    },
-    {
-      "id": "mistralai/devstral-2512",
-      "name": "Devstral 2",
-      "context": 262144
     },
     {
       "id": "mistralai/ministral-14b-2512",
@@ -1142,23 +1142,8 @@
       "context": 128000
     },
     {
-      "id": "openai/gpt-4o-search-preview",
-      "name": "GPT-4o Search Preview",
-      "context": 128000
-    },
-    {
       "id": "openai/gpt-5",
       "name": "GPT-5",
-      "context": 400000
-    },
-    {
-      "id": "openai/gpt-5-chat",
-      "name": "GPT-5 Chat",
-      "context": 128000
-    },
-    {
-      "id": "openai/gpt-5-codex",
-      "name": "GPT-5-Codex",
       "context": 400000
     },
     {
@@ -1190,11 +1175,6 @@
       "id": "openai/gpt-5.1",
       "name": "GPT-5.1",
       "context": 400000
-    },
-    {
-      "id": "openai/gpt-5.1-chat",
-      "name": "GPT-5.1 Chat",
-      "context": 128000
     },
     {
       "id": "openai/gpt-5.1-codex",
@@ -1347,11 +1327,6 @@
       "context": 200000
     },
     {
-      "id": "openai/o3-deep-research",
-      "name": "o3-deep-research",
-      "context": 200000
-    },
-    {
       "id": "openai/o3-mini",
       "name": "o3-mini",
       "context": 200000
@@ -1369,11 +1344,6 @@
     {
       "id": "openai/o4-mini",
       "name": "o4-mini",
-      "context": 200000
-    },
-    {
-      "id": "openai/o4-mini-deep-research",
-      "name": "o4-mini-deep-research",
       "context": 200000
     },
     {
@@ -1607,6 +1577,11 @@
       "context": 1000000
     },
     {
+      "id": "qwen/qwen3.7-flash",
+      "name": "Qwen3.7 Flash",
+      "context": 1000000
+    },
+    {
       "id": "qwen/qwen3.7-max",
       "name": "Qwen3.7 Max",
       "context": 1000000
@@ -1614,6 +1589,11 @@
     {
       "id": "qwen/qwen3.7-plus",
       "name": "Qwen3.7 Plus",
+      "context": 1000000
+    },
+    {
+      "id": "qwen/qwen3.8-max",
+      "name": "Qwen3.8 Max",
       "context": 1000000
     },
     {


### PR DESCRIPTION
Automated refresh of `data/models.json` from https://models.dev/api.json via `scripts/gen-models-catalog.sh`.

## Summary

| Provider | Models | Added | Removed | Changed |
|---|---|---|---|---|
| anthropic | 15 → 15 | 0 | 0 | 0 |
| gemini | 32 → 32 | 0 | 0 | 0 |
| openai | 38 → 38 | 0 | 0 | 2 |
| openrouter | 220 → 216 | 3 | 7 | 1 |

### openai

**Changed**
- `gpt-5.6-luna`: input_price 1 → 0.2, output_price 6 → 1.2
- `gpt-5.6-terra`: input_price 2.5 → 2, output_price 15 → 12

### openrouter

**Added**
- `deepseek/deepseek-v4-flash-0731` (DeepSeek V4 Flash 0731, context 1048576)
- `qwen/qwen3.7-flash` (Qwen3.7 Flash, context 1000000)
- `qwen/qwen3.8-max` (Qwen3.8 Max, context 1000000)

**Removed**
- `mistralai/devstral-2512` (Devstral 2, context 262144)
- `openai/gpt-4o-search-preview` (GPT-4o Search Preview, context 128000)
- `openai/gpt-5-chat` (GPT-5 Chat, context 128000)
- `openai/gpt-5-codex` (GPT-5-Codex, context 400000)
- `openai/gpt-5.1-chat` (GPT-5.1 Chat, context 128000)
- `openai/o3-deep-research` (o3-deep-research, context 200000)
- `openai/o4-mini-deep-research` (o4-mini-deep-research, context 200000)

**Changed**
- `google/gemini-3.1-flash-image-preview`: context 131072 → 65536

Review the diff for unexpected additions or removals before merging.
