### PR TITLE
fix(clippy): allow await_holding_lock in the TUI loop tests

### DIFF
--- a/src/tests/tui_loop_tests.rs
+++ b/src/tests/tui_loop_tests.rs
@@ -14,6 +14,13 @@
 //! runtime used by `#[tokio::test]`, injected user events are always drained
 //! before the freshly spawned agent task is first polled.
 
+// Every test holds `acquire()`'s guard across its awaits on purpose: the lock
+// serializes tests that mutate process-global state, so it has to cover the
+// whole test body. The lint guards against deadlock from contending tasks,
+// which cannot happen here (single-threaded `#[tokio::test]`, and the guard is
+// the only thing keeping these tests from racing each other).
+#![allow(clippy::await_holding_lock)]
+
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 


### PR DESCRIPTION
`cargo clippy --all-targets --all-features -- -D warnings` currently fails on `main` with 11 `clippy::await_holding_lock` errors, all in `src/tests/tui_loop_tests.rs`.

The lint is right about the mechanism and wrong about the risk here. Every test in that file opens with `let _guard = acquire();`, a process-wide serialization lock that exists precisely to stop these tests from racing: they mutate global state (`ZS_DATA_DIR`/`ZS_CONFIG_DIR`, the event-sender singleton, the model cache). The guard therefore has to cover the whole test body, awaits included. The deadlock the lint protects against needs a task contending for the same lock, and there is none: `#[tokio::test]` runs on the current-thread runtime, and the guard is itself what keeps these tests serialized.

So this adds a file-level `#![allow(clippy::await_holding_lock)]` with that reasoning recorded next to it, rather than restructuring the tests to satisfy the lint.

The CI clippy job does not pass `--all-targets`, so test code is not linted there and these never surfaced in CI. The effect is limited to the stricter local gate (`just check`).

Verification: `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo test tui_loop` passes 11/11.