### PR TITLE
Redraw prompt input char when run finished

### DIFF
--- a/src/tests/tui_loop_tests.rs
+++ b/src/tests/tui_loop_tests.rs
@@ -174,6 +174,43 @@ async fn submit_prompt_streams_response_and_updates_session() {
 }
 
 #[tokio::test]
+async fn spinner_cleared_when_run_finishes() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["done"]]).await;
+
+    type_and_submit(&app, "hi").await;
+    step_until(&mut app, |a| a.is_running()).await;
+
+    // Positive control: confirm a spinner was actually painted mid-run, so the
+    // idle check below is a real "spinner then cleared" regression rather than
+    // a test that never saw a spinner at all.
+    let mid = app.backend_output();
+    assert!(
+        mid.chars()
+            .any(|c| ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'].contains(&c)),
+        "a spinner frame should be painted while running"
+    );
+
+    // Regression: Done/Error set is_running false without repainting the bottom
+    // row, and the 100ms refresh is gated on is_running, so the spinner froze on
+    // screen until the next keypress. The last bottom draw must now be idle.
+    step_until(&mut app, |a| !a.is_running()).await;
+    let snap = app
+        .last_bottom_snapshot()
+        .expect("bottom should have been drawn at least once");
+    assert!(
+        !snap.is_running,
+        "last bottom draw should be idle after the run finishes"
+    );
+    assert!(
+        snap.prompt == crate::ui::renderer::PromptSnapshot::Input,
+        "last bottom draw should show the input prompt after the run finishes"
+    );
+
+    app.teardown().await;
+}
+
+#[tokio::test]
 async fn queued_input_replays_after_current_run() {
     let _guard = acquire();
     let (mut app, model) = headless_app(vec![vec!["answer one"], vec!["answer two"]]).await;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -537,6 +537,11 @@ impl<'a> App<'a> {
         self.renderer.is_scrolling()
     }
 
+    #[cfg(test)]
+    pub(crate) fn last_bottom_snapshot(&self) -> Option<&crate::ui::renderer::BottomSnapshot> {
+        self.renderer.last_bottom_snapshot()
+    }
+
     /// All feed lines (wrapped to 80 cols) joined with newlines.
     #[cfg(test)]
     pub(crate) fn feed_text(&self) -> String {
@@ -1030,6 +1035,9 @@ impl<'a> App<'a> {
         .await?;
 
         self.finalize_turn(turn_errored).await?;
+        if !self.run.is_running {
+            self.refresh()?;
+        }
         Ok(())
     }
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -426,6 +426,21 @@ impl Renderer {
         self.backend.captured().unwrap_or_default()
     }
 
+    /// Test helper: snapshot of everything the last successful `draw_bottom`
+    /// painted (input area + statusline), or `None` before the first draw.
+    ///
+    /// This is the renderer's recorded *draw intent*, not the raw byte log, so
+    /// it reflects the bottom row regardless of later chat writes that bury the
+    /// bottom's bytes under newer ones in the append-only `FakeBackend`. That
+    /// makes it the right thing to assert against when checking whether the
+    /// bottom is left idle (or a spinner frozen) after a run ends: a byte-scan
+    /// helper cannot observe a frozen spinner the chat later overwrote in the
+    /// tail, but `last_bottom_snapshot().is_running` records the truth.
+    #[cfg(test)]
+    pub(crate) fn last_bottom_snapshot(&self) -> Option<&BottomSnapshot> {
+        self.last_bottom_snapshot.as_ref()
+    }
+
     /// Whether the renderer drives a headless test backend instead of a real
     /// terminal. Used to skip code paths that bypass the backend abstraction
     /// and write straight to stdout (e.g. the pickers), which break on CI


### PR DESCRIPTION
I noticed that sometimes after a prompt, the prompt "> " was not redrawn and instead a stale spinner was still shown. This commit fixes the issue and adds tests for it.
