### PR TITLE
feat(sandbox): add sandbox-network to run bwrap commands offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ repeatable `--sandbox-expose <path>` flag) restores read-only access to one
 entry or a subpath of one. See [docs/CONFIG.md](docs/CONFIG.md) for the key
 and [SECURITY.md](SECURITY.md) for the full threat model.
 
+Sandboxed commands keep the host network by default. `sandbox-network = false`
+(or `--sandbox-network=false`) takes it away, which is what stops a command
+that read something sensitive from sending it anywhere. Each bash call then
+gets a fresh network namespace with only its own private loopback: a server the
+command starts and uses within that same command still works, but the internet,
+the LAN, and anything already listening on your machine (a dev server, a local
+registry) are unreachable, and the namespace itself is gone by the next bash
+call, taking anything bound to it (like a backgrounded server) with it; the
+working directory, by contrast, is shared with the host and persists across
+calls. That tradeoff is why the network stays open unless you ask.
+
 ## Quick start
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,8 @@ With the default `bwrap` backend, a sandboxed command sees:
   working in stays editable
 - a fresh `/tmp` (tmpfs), a private `/proc`, and a minimal `/dev`
 - separate IPC, PID, UTS, and cgroup namespaces, so the command cannot see or
-  signal processes outside the sandbox
+  signal processes outside the sandbox, plus a separate network namespace when
+  `sandbox-network = false` (see below; the default keeps the host network)
 - a cleared environment, repopulated with an allowlist of common variables
   (`PATH`, `HOME`, toolchain and locale variables, and so on)
 - `--die-with-parent`, so the sandboxed process tree does not outlive zerostack
@@ -60,11 +61,62 @@ your situation. Most of them come from how zerostack configures the default
 
 With the `bwrap` backend:
 
-- **Network access is fully open.** zerostack does not unshare the network
-  namespace, so a sandboxed command can reach the internet and your local
-  network, which means it can exfiltrate anything it can read. The `zerobox`
-  backend behaves differently here: it denies network access by default under
-  its own policy.
+- **Network access is open by default.** Out of the box zerostack does not
+  unshare the network namespace, so a sandboxed command can reach the internet
+  and your local network, which means it can exfiltrate anything it can read.
+  Set `sandbox-network = false` (or pass `--sandbox-network=false`) to unshare
+  it. Each bash call then runs in a fresh network namespace holding nothing but
+  its own private loopback device, which bubblewrap brings up for it: a server
+  the command starts and then talks to on `127.0.0.1` still works, because both
+  ends are inside that namespace, while the internet, the LAN, and anything
+  listening on the *host's* loopback (a dev server on `localhost:3000`, a
+  database, a local registry) are all unreachable. This is about routing only:
+  `/sys` is a host bind, so interface names and MAC addresses remain readable
+  from inside the offline namespace (`/proc` is remounted fresh and reflects
+  the new namespace, not the host's). The namespace lasts as long
+  as the command, so a server backgrounded by one bash call is gone for the
+  next one. Unsharing the network also replaces the abstract Unix socket
+  namespace, so abstract-address sockets on the host, which some D-Bus and X11
+  setups use, are cut off with it. Unix sockets that live at a filesystem path
+  are not cut off; see the next gap. Turning this on is what makes credential
+  masking worth more than it is alone: masking limits what a sandboxed command
+  can read but leaves it a way out, and an offline namespace removes the way
+  out but leaves everything outside the masked directories readable. Together
+  they narrow the path from "reads your secrets" to "sends them somewhere"
+  **for the `bash` tool only**, which is the scope of every claim in this
+  section: see "Only the `bash` tool is sandboxed" below for the file reads,
+  MCP servers, hooks, and `!` commands that never enter the sandbox at all.
+  Two things bound that narrowing, and neither is a detail. On a machine
+  running Docker, a session bus, or any other daemon that listens on a socket
+  file, the next gap applies and the way out is still open, so the narrowing
+  is not claimed there at all. And the tool result is itself a way out: a
+  sandboxed command's stdout and stderr are what the `bash` tool returns, and
+  that text is sent to whichever model provider the session is configured
+  with, so anything a command prints has left your machine no matter what the
+  network setting says. Turning the network off removes the command's own
+  network access; it cannot close the channel the agent itself runs on.
+  And without `sandbox-required`, a missing backend still falls back to
+  running commands bare, with the network intact and nothing masked. The
+  `zerobox` backend is unaffected by this key and denies network access by
+  default under its own policy.
+- **Unix sockets on disk stay connectable, even with the network unshared.**
+  A read-only bind mount stops writes to a socket *file*, but it does not stop
+  a `connect(2)` to it: the kernel's read-only protection covers regular
+  files, directories, and symlinks, not connecting to a socket inode. Socket
+  paths under `/run`, `/var/run`, and `/run/user/$UID` are therefore visible
+  and usable from inside the sandbox whatever `sandbox-network` is set to,
+  because they are filesystem objects rather than network ones and live
+  outside the network namespace entirely. The sharpest case is
+  `/run/docker.sock` on a host running Docker: a sandboxed command that can
+  talk to the Docker daemon can ask it to start a container with the host
+  filesystem mounted and the host network attached, which is a full escape
+  from both the mounts and the network namespace, credential masks included.
+  A session bus at `/run/user/$UID/bus` is the same shape at a smaller scale,
+  and so is any other daemon socket your distribution leaves there. zerostack
+  does not mask host socket paths today. Doing so is plausible future
+  hardening, not current behavior, so treat "the sandbox is offline" as a
+  statement about the network stack and not about every way out of the
+  machine.
 - **Most of your home directory is still readable.** `/` is mounted read only,
   not hidden, so everything under `$HOME` is visible inside the sandbox except
   the nine credential directories masked by default: `~/.ssh`, `~/.aws`,
@@ -149,8 +201,8 @@ a container with the network and credentials you are willing to expose.
 
 | Backend | Isolation |
 | --- | --- |
-| `bwrap` (default) | Linux only. The bubblewrap mounts and namespaces described above, with the network left open. The nine built-in credential directories are masked by default and the advertised ssh-agent socket is cut off; see above. |
-| `zerobox` | macOS and Linux. Denies writes, network access, and environment variables by default, with per-domain network allowances. zerostack invokes `zerobox --allow-write <cwd> -- <shell> -c <command>`, so the working directory is writable and the rest of the policy is whatever zerobox enforces. Credential masking does not apply here: zerobox exposes no mount-policy surface to inject it, and whether its own defaults limit reads under `$HOME` has not been verified. |
+| `bwrap` (default) | Linux only. The bubblewrap mounts and namespaces described above, with the host network left open unless `sandbox-network = false` unshares it, in which case each command gets a fresh namespace with only its own private loopback. The nine built-in credential directories are masked by default and the advertised ssh-agent socket is cut off; see above. |
+| `zerobox` | macOS and Linux. Denies writes, network access, and environment variables by default, with per-domain network allowances. `sandbox-network` is a bwrap-only key and does not apply here: zerobox denies network access under its own policy regardless of it. zerostack invokes `zerobox --allow-write <cwd> -- <shell> -c <command>`, so the working directory is writable and the rest of the policy is whatever zerobox enforces. Credential masking does not apply here: zerobox exposes no mount-policy surface to inject it, and whether its own defaults limit reads under `$HOME` has not been verified. |
 | none | With the sandbox off (the default), bash commands run directly as your user with no isolation at all. The permission system is the only gate. |
 
 ## Best effort versus guarantee
@@ -169,6 +221,16 @@ Two different contracts:
 (reading files, editing, planning) keeps working, only bash execution is
 refused. This is the setting to use for unattended or automated runs, where
 nobody is watching the log for the "running unsandboxed" warning.
+
+`sandbox-expose` and `sandbox-network` are neither contract: they are
+modifiers that change what the sandbox does when it runs, and neither of them
+switches the sandbox on. `sandbox-network = false` with `sandbox = false` is a
+no-op, warned about once at startup; `sandbox-network = false` with
+`sandbox = true` alone is best effort in the same way as everything else, since
+a missing backend still runs the command bare and online. Pairing it with
+`sandbox-required` is what makes "the bash tool cannot reach the host network"
+a guarantee, and that sentence is deliberately about the bash tool rather than
+about the session.
 
 Neither setting changes the gaps listed above. `sandbox-required` guarantees
 that the isolation is present, not that the isolation is complete.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -199,6 +199,7 @@ Accepted top-level keys:
 | `sandbox-backend`         | string  | Sandbox backend: `bwrap` (default, Linux only) or `zerobox` (macOS and Linux).                                                                                              |
 | `sandbox-required`        | boolean | Refuse to run bash commands when the sandbox backend is unavailable, instead of falling back to running them unsandboxed. Implies `sandbox`. Default: `false`.               |
 | `sandbox-expose`          | array   | Bwrap backend only. Restores read-only access to a masked credential directory or a subpath of one. `~` and `$HOME` expansion supported. Repeatable CLI flag `--sandbox-expose <path>`; when passed, it replaces this list wholesale. Values that are not a masked entry or a subpath of one, and values containing `..`, are warned about once at startup and ignored. Default: `[]` (nothing exposed). See Sandbox credential masking below. |
+| `sandbox-network`         | boolean | Bwrap backend only. When `false`, each sandboxed bash command runs in a fresh network namespace with only its own private loopback: a server it starts and uses within that one command still works on `127.0.0.1`, while the internet, the LAN, and anything listening on the *host's* loopback are unreachable. CLI flag `--sandbox-network[=true\|false]`, which wins over this key in both directions. Does not imply `sandbox`: with the sandbox off, the setting has no effect and a warning is logged once at startup. Default: `true` (network open). See Sandbox network isolation below. |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Accepts: `standard` (default), `restrictive`, `readonly`, `guarded`, `yolo`.                                          |
 | `show_tool_details`       | boolean or integer | Show tool-result previews in the TUI. `false` hides output, `true` shows all lines, an integer limits to that many lines (e.g. `3`). Default: `3`. |
 | `show_reasoning`          | boolean | Show streamed reasoning text in the TUI. Can still be toggled at runtime with `Ctrl+R` or `/reasoning`. Default: `false`. |
@@ -268,6 +269,76 @@ as noted above (see Project-local override). Masking, the ssh-agent cutoff,
 and `sandbox-expose` all apply to the `bwrap` backend only; see `SECURITY.md`
 for the full gap list, including what remains readable and the ssh-agent
 recovery paths.
+
+## Sandbox network isolation
+
+On the `bwrap` backend, sandboxed bash commands share the host network by
+default, which is the historical behavior. Set `sandbox-network = false` (or
+pass `--sandbox-network=false`) to run them in their own network namespace
+instead:
+
+```toml
+sandbox = true
+sandbox-network = false
+```
+
+### What "no network" means here
+
+Each bash call gets a fresh network namespace containing nothing but its own
+private loopback device, which bubblewrap brings up for it. Two consequences,
+and they pull in opposite directions:
+
+- **Loopback inside one command still works.** A command that starts a server
+  and then talks to it on `127.0.0.1` is fine, because both ends live in the
+  same namespace. `cargo test`, `pytest`, and anything else that binds a local
+  port inside a single command keep working.
+- **The host is gone, including the host's loopback.** No internet, no LAN,
+  and no reaching a service that is already listening on your machine: a dev
+  server on `localhost:3000`, a database on `localhost:5432`, or a local
+  package registry are all invisible from inside the sandbox, because they
+  live on the host's loopback and the sandbox has its own.
+
+The namespace lasts exactly as long as the command. A server backgrounded by
+one bash call is unreachable from the next one, which also takes away the
+"start it in one step, curl it in the next" pattern.
+
+Those last two points are why the default is `true`: turning the network off
+breaks host dev servers, private registries, and any workflow split across
+several bash calls, and that is too much to change under people silently.
+
+The CLI flag takes an optional value (bare `--sandbox-network` for `true`, or
+`--sandbox-network=false`) rather than being a plain on/off switch, because the
+key defaults to `true` and a plain switch could not express turning the
+network back on for a single run over a config that turns it off.
+
+`sandbox-network` is a modifier, not an enforcer. Unlike `sandbox-required`, it
+never switches the sandbox on: with `sandbox = false` there is nothing to cut
+the network from, so the setting has no effect and a warning is logged once at
+startup. Pairing it with `sandbox-required` is what turns the no-network
+promise into a guarantee, since a missing backend otherwise falls back to
+running commands bare, with the network intact.
+
+Like `sandbox-expose`, this key can be set from a project-local
+`.zerostack/config.toml`, which is trusted exactly like the global config. A
+checkout can therefore set `sandbox-network = true` and undo a global
+`false`, so review that file in untrusted checkouts (see Project-local
+override). Passing `--sandbox-network=false` on the command line settles the
+question for that run, since the CLI wins over both config files.
+
+When the network is off and a command fails with a resolver or unreachable
+network error, the tool result gets one extra line telling the model the
+sandbox cut the network and to ask you whether it should be enabled, so it
+stops retrying the command instead. The hint reads stderr, so a command that
+folds stderr into stdout with `2>&1` simply does not get one. On
+systemd-resolved hosts, `/etc/resolv.conf` points at `127.0.0.53`, which
+inside the fresh namespace is the sandbox's own loopback with nothing
+listening, so DNS failures there surface as connection refused rather than
+network unreachable, which is one reason "connection refused" is in the hint
+pattern list.
+
+Like masking and `sandbox-expose`, this applies to the `bwrap` backend only.
+The `zerobox` backend denies network access under its own policy regardless of
+this key; see `SECURITY.md`.
 
 ## System Prompt Suffix (`SUFFIX.md`)
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -165,6 +165,7 @@ If you want to use zerostack from scripts, from other programs, or if you just w
 | `--sandbox` | Run the agent inside a sandbox (Experimental) |
 | `--sandbox-required` | Refuse bash commands when the sandbox backend is unavailable (implies `--sandbox`) |
 | `--sandbox-expose <path>` | Restore read-only access to a masked credential path or subpath (repeatable) |
+| `--sandbox-network[=true\|false]` | Whether sandboxed bash commands can reach the host network (default: `true`; bare flag or `=true` enables it, `=false` leaves each command only its own private loopback) |
 | `--worktree` | Run the agent inside a git worktree (Experimental) |
 | `--parallel` | Run the agent inside a self-managed git worktree (Experimental) |
 | `--load-prompt <prompt>` | Use a specific prompt |

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -5,7 +5,7 @@ use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm}
 #[cfg(feature = "rtk")]
 use crate::extras::rtk::Rtk;
 use crate::extras::truncate::head_lines;
-use crate::sandbox::{Sandbox, mask_hint};
+use crate::sandbox::{Sandbox, mask_hint, network_hint};
 
 pub(crate) fn split_bash_commands(input: &str) -> Vec<String> {
     let mut result = Vec::new();
@@ -101,6 +101,37 @@ pub(crate) fn mask_hint_for_exit(
     mask_hint(command, stderr, &sandbox.masked_roots(), &home)
 }
 
+/// The no-network hint for a finished command, or `None`. Same shape as
+/// `mask_hint_for_exit`: the caller invokes it unconditionally and every gate
+/// lives here, so the branch under test is the branch production takes. The
+/// sandbox check comes before the string matching because it is the cheap one
+/// and because it is the one that keeps the hint honest: a session that runs
+/// with the network on, or unsandboxed, must never be told the sandbox cut it.
+pub(crate) fn network_hint_for_exit(
+    exit_code: i32,
+    stderr: &str,
+    sandbox: &Sandbox,
+) -> Option<String> {
+    if exit_code == 0 || !sandbox.network_unshared() {
+        return None;
+    }
+    network_hint(stderr)
+}
+
+/// The description every bash tool carries, whatever the session's sandbox
+/// settings are.
+const BASH_DESCRIPTION: &str =
+    "Execute a bash command in the current working directory. Returns stdout and stderr.";
+
+/// Appended to the description when this session's sandbox really will unshare
+/// the network, so the model reads it in the tool definition instead of
+/// discovering it by burning a turn on a command that cannot succeed and then
+/// guessing at the cause. Fixed text and one sentence: a tool description is
+/// prompt-cached context, not a place to render session state. The gate is
+/// `network_unshared`, the same one the failure hint uses, so the two can
+/// never tell the model different stories about the same session.
+const NO_NETWORK_NOTICE: &str = " This session's sandbox runs commands without network access, so the internet, the local network, and services listening on the host are unreachable; a server started and used within a single command still works on 127.0.0.1.";
+
 pub struct BashTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
@@ -141,8 +172,11 @@ impl Tool for BashTool {
     type Output = String;
 
     fn description(&self) -> String {
-        "Execute a bash command in the current working directory. Returns stdout and stderr."
-            .to_string()
+        let mut description = BASH_DESCRIPTION.to_string();
+        if self.sandbox.network_unshared() {
+            description.push_str(NO_NETWORK_NOTICE);
+        }
+        description
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -252,18 +286,26 @@ impl Tool for BashTool {
             result
         };
 
-        let result = match coaching {
+        let mut result = match coaching {
             Some(msg) => format!("{}\n\n{}", msg, result),
             None => result,
         };
-        // Append last, after truncation and coaching, so a masked-path hint
-        // always survives at the end of the tool result the model sees. The
-        // exit-code gate lives inside `mask_hint_for_exit`, which is also what
-        // keeps a successful command from paying for the mask list.
-        let result = match mask_hint_for_exit(exit_code, &command, &stderr, &self.sandbox) {
-            Some(hint) => format!("{result}\n{hint}"),
-            None => result,
-        };
+        // Sandbox hints are appended last, after truncation and coaching, so
+        // they always survive at the end of the tool result the model sees, and
+        // in one pass so the result is not copied once per hint. The exit-code
+        // gates live inside the two `*_for_exit` functions, which is also what
+        // keeps a successful command from paying for the mask list or the
+        // stderr scan.
+        for hint in [
+            mask_hint_for_exit(exit_code, &command, &stderr, &self.sandbox),
+            network_hint_for_exit(exit_code, &stderr, &self.sandbox),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            result.push('\n');
+            result.push_str(&hint);
+        }
         tracing::debug!(
             "tool bash done: exit_code={}, output_len={}",
             exit_code,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,15 @@ pub struct Cli {
     pub sandbox_expose: Vec<String>,
 
     #[arg(
+        long = "sandbox-network",
+        help = "Allow sandboxed bash commands to use the network. Bare flag or `=true` enables it (the default); use --sandbox-network=false to disable",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true
+    )]
+    pub sandbox_network: Option<bool>,
+
+    #[arg(
         long = "shell",
         help = "Shell binary to use for bash tool (default: bash)"
     )]
@@ -407,6 +416,15 @@ impl Cli {
         } else {
             cfg.sandbox_expose.clone().unwrap_or_default()
         }
+    }
+
+    /// Whether sandboxed bash commands keep the host network. Unlike the other
+    /// sandbox flags this one takes a value: it defaults to true, so a bare
+    /// switch could only ever say "true" again and never turn the network off
+    /// from the command line. `Option<bool>` lets the CLI win in both
+    /// directions over the config key.
+    pub fn resolve_sandbox_network(&self, cfg: &config::Config) -> bool {
+        self.sandbox_network.or(cfg.sandbox_network).unwrap_or(true)
     }
 
     pub fn resolve_shell(&self, cfg: &config::Config) -> String {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -119,6 +119,8 @@ pub struct Config {
     pub sandbox_required: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "sandbox-expose")]
     pub sandbox_expose: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "sandbox-network")]
+    pub sandbox_network: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_all_mcp_calls: Option<bool>,
     #[cfg(feature = "mcp")]

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -43,6 +43,7 @@ fn sandbox_setup(state: &AcpState) -> SandboxSetup {
         backend: &state.cli.resolve_sandbox_backend(&state.cfg),
         shell: &state.cli.resolve_shell(&state.cfg),
         expose: &state.cli.resolve_sandbox_expose(&state.cfg),
+        network: state.cli.resolve_sandbox_network(&state.cfg),
     })
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,5 +1,6 @@
 use crate::cli;
 use crate::config;
+use crate::sandbox::NetworkEffect;
 use crate::session;
 
 /// Renders the resolved `sandbox-expose` values for the `--print-config`
@@ -10,6 +11,27 @@ pub(crate) fn format_sandbox_expose_display(sandbox_expose: &[String]) -> String
     } else {
         sandbox_expose.join(", ")
     }
+}
+
+/// Renders the resolved `sandbox-network` value for the `--print-config`
+/// table. Like the `sandbox-expose` row, this reports what is actually in
+/// effect rather than the raw resolved value: turning the network off only
+/// does something when the sandbox is on, the backend is bwrap, and bwrap is
+/// installed, and a bare `false` in a table the user is reading to check
+/// their configuration would otherwise look like a promise the session is not
+/// keeping. The decision is not made here: the caller hands over a
+/// `NetworkEffect` computed by the sandbox itself, so this function has no
+/// copy of the conditions to drift from, and no pair of same-typed arguments
+/// a call site could silently transpose.
+pub(crate) fn format_sandbox_network_display(effect: NetworkEffect) -> String {
+    match effect {
+        NetworkEffect::Open => "true",
+        NetworkEffect::Unshared => "false",
+        NetworkEffect::SandboxOff => "false (no effect: sandbox is off)",
+        NetworkEffect::OtherBackend => "false (no effect: bwrap backend only)",
+        NetworkEffect::BackendMissing => "false (no effect: bwrap is not installed)",
+    }
+    .to_string()
 }
 
 pub(crate) fn print_section(title: &str, entries: &[(&str, String)]) {
@@ -87,6 +109,18 @@ pub(crate) fn print_config(cli: &cli::Cli, cfg: &config::Config) {
     let sandbox_required = cli.resolve_sandbox_required(cfg);
     let sandbox_backend = cli.resolve_sandbox_backend(cfg);
     let sandbox_expose_raw = cli.resolve_sandbox_expose(cfg);
+    // The network row has to answer "is the backend actually there", which is
+    // a probe rather than a resolved setting, so the row is rendered from a
+    // sandbox instead of from booleans. Only the fields the network question
+    // reads are set: this is a throwaway used for the readout, never the
+    // session sandbox, which both entry points still build via
+    // `build_sandbox`.
+    let sandbox_network_display = format_sandbox_network_display(
+        crate::sandbox::Sandbox::new(sandbox, &sandbox_backend)
+            .with_required(sandbox_required)
+            .with_network(cli.resolve_sandbox_network(cfg))
+            .network_effect(),
+    );
     let home = dirs::home_dir().unwrap_or_default();
     let (sandbox_expose, _rejected) = crate::sandbox::partition_expose(
         &sandbox_expose_raw,
@@ -203,6 +237,7 @@ pub(crate) fn print_config(cli: &cli::Cli, cfg: &config::Config) {
             ("sandbox-backend", sandbox_backend),
             ("sandbox-required", sandbox_required.to_string()),
             ("sandbox-expose", sandbox_expose_display),
+            ("sandbox-network", sandbox_network_display),
             ("no-tools", no_tools.to_string()),
             ("tools", tools_allowlist),
             ("no-context-files", no_context_files.to_string()),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -11,16 +11,22 @@ pub struct Sandbox {
     required: bool,
     backend: String,
     shell: String,
+    /// `sandbox-network`: when false, the bwrap branch unshares the network
+    /// namespace. Defaults to true, which is the historical behavior.
+    network: bool,
     // Test seams: `backend_available` replaces the cached PATH probe for the
     // backend binary (and `backend_installed_now` the fresh one) so tests
     // behave the same on hosts with and without bwrap, `cache_dir` keeps the
-    // bwrap arg builder away from the real user cache, and `mask_roots`
+    // bwrap arg builder away from the real user cache, `mask_roots`
     // replaces the built-in credential list with temp dirs so mask assertions
-    // do not depend on the developer's home.
+    // do not depend on the developer's home, and `resolv_conf` moves the
+    // resolver file the sandbox binds off `/etc/resolv.conf`, which does not
+    // exist on every host and so cannot be asserted on directly.
     backend_available: Option<bool>,
     backend_installed_now: Option<bool>,
     cache_dir: Option<std::path::PathBuf>,
     mask_roots: Option<Vec<std::path::PathBuf>>,
+    resolv_conf: Option<std::path::PathBuf>,
     // Already-validated `sandbox-expose` paths (see `partition_expose`),
     // restored read-only on top of the masks.
     expose: Vec<std::path::PathBuf>,
@@ -29,6 +35,29 @@ pub struct Sandbox {
     // `Some(Some(path))` pins the socket path a test masks.
     ssh_auth_sock: Option<Option<std::path::PathBuf>>,
     active_groups: Arc<Mutex<HashSet<u32>>>,
+}
+
+/// What `sandbox-network` does to the commands a session will actually run
+/// (see `Sandbox::network_effect`). A resolved `false` is a request, not an
+/// outcome: three things have to be true for it to reach a command, and
+/// anything that reports the setting to a user has to say which one is
+/// missing rather than printing the request back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkEffect {
+    /// `sandbox-network = true`: commands keep the host network, which is the
+    /// default and the historical behavior.
+    Open,
+    /// Off and honored: every bash command runs in its own network
+    /// namespace.
+    Unshared,
+    /// Off, but the sandbox is disabled, so nothing wraps the command.
+    SandboxOff,
+    /// Off, but the selected backend is not bwrap, whose flag this is.
+    OtherBackend,
+    /// Off, the sandbox is on and the backend is bwrap, but the bwrap binary
+    /// is not installed: without `sandbox-required` the command falls back to
+    /// running bare, with the network intact.
+    BackendMissing,
 }
 
 /// Well-known credential stores that live directly under the home directory.
@@ -184,10 +213,12 @@ impl Sandbox {
             required: false,
             backend: backend.to_string(),
             shell: "bash".to_string(),
+            network: true,
             backend_available: None,
             backend_installed_now: None,
             cache_dir: None,
             mask_roots: None,
+            resolv_conf: None,
             expose: Vec::new(),
             ssh_auth_sock: None,
             active_groups: Arc::new(Mutex::new(HashSet::new())),
@@ -212,6 +243,20 @@ impl Sandbox {
     /// unsandboxed if the backend binary is missing.
     pub fn with_required(mut self, required: bool) -> Self {
         self.required = required;
+        self
+    }
+
+    /// When false, each sandboxed command runs in a fresh network namespace
+    /// with nothing in it but its own private loopback. A server the command
+    /// starts and then talks to on `127.0.0.1` still works; everything on the
+    /// host is gone, including services listening on the host's own loopback,
+    /// and the namespace dies with the command, so a server backgrounded by
+    /// one bash call is unreachable from the next. Bwrap backend only; zerobox
+    /// applies its own network policy. `pub(crate)` rather than `pub`:
+    /// construction is meant to go through `build_sandbox`, which pairs this
+    /// with the sandbox-off conflict warning.
+    pub(crate) fn with_network(mut self, network: bool) -> Self {
+        self.network = network;
         self
     }
 
@@ -253,6 +298,17 @@ impl Sandbox {
         self
     }
 
+    /// Overrides the host resolver file the sandbox binds, so the bind can be
+    /// asserted on from a host that has no `/etc/resolv.conf` (macOS in a
+    /// minimal environment, some containers). Only the source path moves; the
+    /// destination inside the sandbox stays `/etc/resolv.conf`, which is what
+    /// production emits.
+    #[cfg(test)]
+    pub fn with_resolv_conf(mut self, path: std::path::PathBuf) -> Self {
+        self.resolv_conf = Some(path);
+        self
+    }
+
     /// Overrides the host `SSH_AUTH_SOCK` read: `Some(path)` pins the socket
     /// path the agent-cutoff mask targets, `None` models a host with no
     /// ssh-agent running.
@@ -266,7 +322,7 @@ impl Sandbox {
     /// the host: bwrap creates every `--tmpfs` mountpoint, and creating one on
     /// the read-only `/` bind aborts the whole launch.
     pub(crate) fn masked_roots(&self) -> Vec<std::path::PathBuf> {
-        if !self.masking_active() {
+        if !self.bwrap_policy_active() {
             return Vec::new();
         }
         self.mask_roots
@@ -277,17 +333,51 @@ impl Sandbox {
             .collect()
     }
 
-    /// Masking is a bwrap mount policy, so it needs the sandbox enabled, the
-    /// bwrap backend, and a backend that will actually run. The availability
-    /// question is asked exactly the way `wrap_command` asks it, by sharing
-    /// `backend_will_run` with it. Both directions of a mismatch hurt: a
-    /// looser probe here would tell the model a path was masked while the
-    /// command ran bare and read it fine, and a stricter one would leave a
-    /// `sandbox-required` session running under bwrap with no masks emitted at
-    /// all, which is the mount policy silently switching itself off for the
-    /// user who asked for it hardest.
-    fn masking_active(&self) -> bool {
+    /// Whether the bwrap mount and namespace policy actually applies to a
+    /// command: it needs the sandbox enabled, the bwrap backend, and a backend
+    /// that will actually run. Credential masking and `sandbox-network` both
+    /// hang off this, and the availability question is asked exactly the way
+    /// `wrap_command` asks it, by sharing `backend_will_run` with it. Both
+    /// directions of a mismatch hurt: a looser probe here would tell the model
+    /// a path was masked (or the network cut) while the command ran bare and
+    /// reached both fine, and a stricter one would leave a `sandbox-required`
+    /// session running under bwrap with no masks emitted at all, which is the
+    /// mount policy silently switching itself off for the user who asked for
+    /// it hardest.
+    fn bwrap_policy_active(&self) -> bool {
         self.backend_will_run() && self.backend_binary() == "bwrap"
+    }
+
+    /// Whether commands really do run without a network, which is the only
+    /// state in which the network hint (and the tool-description notice built
+    /// on the same question) is a true statement: `sandbox-network` is off
+    /// *and* the bwrap policy that implements it is the one running.
+    /// `pub(crate)` for the hint gate in `agent::tools::bash`.
+    pub(crate) fn network_unshared(&self) -> bool {
+        !self.network && self.bwrap_policy_active()
+    }
+
+    /// What `sandbox-network` actually does to this session's commands, and
+    /// when it does nothing, which of the three preconditions is missing.
+    /// `--print-config` renders this rather than the resolved boolean: the
+    /// only affirmative answer is `bwrap_policy_active` itself, so a row that
+    /// says the network is cut cannot disagree with the code that cuts it,
+    /// and the remaining variants exist purely to explain a `false` that the
+    /// session is not honoring.
+    pub(crate) fn network_effect(&self) -> NetworkEffect {
+        if self.network {
+            return NetworkEffect::Open;
+        }
+        if self.bwrap_policy_active() {
+            return NetworkEffect::Unshared;
+        }
+        if !self.enabled {
+            return NetworkEffect::SandboxOff;
+        }
+        if self.backend_binary() != "bwrap" {
+            return NetworkEffect::OtherBackend;
+        }
+        NetworkEffect::BackendMissing
     }
 
     /// The host's advertised ssh-agent socket, if any: the path
@@ -406,8 +496,8 @@ impl Sandbox {
 
         // Not refused and not launching means the sandbox is optional and its
         // backend is missing; `backend_will_run` is shared with
-        // `masking_active` so the two can never disagree about which probe
-        // decides that.
+        // `bwrap_policy_active` so the two can never disagree about which
+        // probe decides that.
         if !self.backend_will_run() {
             tracing::warn!(
                 "sandbox: {} not found, running unsandboxed",
@@ -435,7 +525,11 @@ impl Sandbox {
         for (k, v) in essential_env() {
             cmd.arg("--setenv").arg(k).arg(v);
         }
-        match std::fs::canonicalize("/etc/resolv.conf") {
+        let resolv_conf = self
+            .resolv_conf
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("/etc/resolv.conf"));
+        match std::fs::canonicalize(&resolv_conf) {
             Ok(target) => {
                 cmd.arg("--ro-bind-try");
                 cmd.arg(target);
@@ -443,7 +537,8 @@ impl Sandbox {
             }
             Err(e) => {
                 tracing::warn!(
-                    "sandbox: no resolver file could be mounted: could not resolve /etc/resolv.conf: {}",
+                    "sandbox: no resolver file could be mounted: could not resolve {}: {}",
+                    resolv_conf.display(),
                     e
                 );
             }
@@ -525,11 +620,23 @@ impl Sandbox {
             "--unshare-pid",
             "--unshare-uts",
             "--unshare-cgroup",
-            "--die-with-parent",
-            &self.shell,
-            "-c",
-            command,
         ]);
+        // `sandbox-network = false`. bwrap brings up a fresh loopback device
+        // inside the new namespace, so this is not "no sockets": a command
+        // that starts a server and then talks to it on 127.0.0.1 still works,
+        // because both ends live in the same namespace. What goes away is the
+        // host: the internet, the LAN, and anything already listening on the
+        // *host's* loopback, plus the abstract Unix socket namespace, which
+        // bwrap replaces along with the network one. The namespace lasts as
+        // long as the command, so a server one bash call leaves running in the
+        // background is unreachable from the next one. The /etc/resolv.conf
+        // bind above stays unconditional: it costs nothing here, and keeping
+        // it out of this branch is what keeps the rest of the argument
+        // assembly identical between the two settings.
+        if !self.network {
+            cmd.arg("--unshare-net");
+        }
+        cmd.args(["--die-with-parent", &self.shell, "-c", command]);
         configure_child_lifetime(&mut cmd);
         Ok(cmd)
     }
@@ -656,6 +763,8 @@ pub(crate) struct SandboxSettings<'a> {
     pub shell: &'a str,
     /// Raw `sandbox-expose` values, unexpanded and unvalidated.
     pub expose: &'a [String],
+    /// `sandbox-network`: false unshares the network namespace (bwrap only).
+    pub network: bool,
 }
 
 /// Single construction path for the session sandbox, shared by every entry
@@ -668,6 +777,7 @@ pub(crate) fn build_sandbox(settings: &SandboxSettings<'_>) -> SandboxSetup {
     let sandbox = Sandbox::new(settings.enabled, settings.backend)
         .with_required(settings.required)
         .with_shell(settings.shell)
+        .with_network(settings.network)
         .with_expose(expose);
     let mut warnings: Vec<String> = rejected
         .iter()
@@ -677,6 +787,17 @@ pub(crate) fn build_sandbox(settings: &SandboxSettings<'_>) -> SandboxSetup {
             )
         })
         .collect();
+    // `sandbox-network` is a modifier, not an enforcer: unlike
+    // `sandbox-required` it never switches the sandbox on, so with the sandbox
+    // off there is nothing to unshare and the setting silently does nothing.
+    // The warning lives here rather than at the two call sites so the wording
+    // exists once; both entry points already log everything in this list.
+    if !settings.network && !settings.enabled {
+        warnings.push(
+            "sandbox-network is set to false but the sandbox is disabled, so commands still have network access"
+                .to_string(),
+        );
+    }
     warnings.extend(sandbox.shadowed_mask_warning());
     SandboxSetup { sandbox, warnings }
 }
@@ -717,6 +838,63 @@ pub(crate) fn mask_hint(
     } else {
         Some(lines.join("\n"))
     }
+}
+
+/// The failure messages an unshared network produces, in the spellings the
+/// common tools use. The first three are the name-resolution and raw-address
+/// failures (curl and git print "Could not resolve host", Python and Go print
+/// a "name resolution" failure, `ENETUNREACH` surfaces as "Network is
+/// unreachable"); the last two are what reaching for a service on the *host's*
+/// loopback looks like from inside a namespace that has its own, which is the
+/// common case rather than an exotic one.
+///
+/// "could not resolve host" carries the "host" deliberately: bundlers say
+/// `Could not resolve "./missing"` about imports and npm says the same about
+/// dependency trees, and matching the shorter prefix would blame the sandbox
+/// for build errors that have nothing to do with it.
+const NETWORK_FAILURE_PATTERNS: [&str; 5] = [
+    "could not resolve host",
+    "name resolution",
+    "network is unreachable",
+    "connection refused",
+    "cannot assign requested address",
+];
+
+/// Case-insensitive substring search that allocates nothing. The patterns are
+/// pure ASCII, so a byte-window comparison answers the same question as
+/// lowercasing both sides would, without copying stderr, which can be the
+/// whole (untruncated) output of a failed build.
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    let (haystack, needle) = (haystack.as_bytes(), needle.as_bytes());
+    haystack.len() >= needle.len()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
+/// The guidance line for a command that failed the way an unshared network
+/// makes commands fail. Pure and deliberately narrow: the patterns are the
+/// price of not blaming `sandbox-network` for every failing command, and a
+/// hint that is missed costs nothing, while a hint that fires on an unrelated
+/// failure sends the model to the user with the wrong question. The caller,
+/// `bash::network_hint_for_exit`, holds the two state gates: the command
+/// failed, and the network really is unshared.
+///
+/// Only stderr is matched. The command string is not, because a command that
+/// merely mentions one of these phrases has not failed for that reason, and
+/// stdout is not, because the phrases are common enough in ordinary output to
+/// be a false-positive source. That makes the hint best-effort in both
+/// directions: a command that redirects with `2>&1`, or one whose tooling
+/// localizes its errors, produces nothing for the patterns to match and simply
+/// gets no hint.
+pub(crate) fn network_hint(stderr: &str) -> Option<String> {
+    let matched = NETWORK_FAILURE_PATTERNS
+        .iter()
+        .any(|pattern| contains_ignore_ascii_case(stderr, pattern));
+    matched.then(|| {
+        "note: network is disabled by the sandbox (sandbox-network = false); ask the user whether it should be enabled"
+            .to_string()
+    })
 }
 
 fn spawn_pipe_reader(

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -422,6 +422,7 @@ impl Startup {
             backend: &sandbox_backend,
             shell: &self.cli.resolve_shell(&self.cfg),
             expose: &sandbox_expose_raw,
+            network: self.cli.resolve_sandbox_network(&self.cfg),
         });
         self.sandbox = sandbox_setup.sandbox;
         for warning in &sandbox_setup.warnings {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -91,7 +91,11 @@ mod sandbox_hint_tests;
 #[cfg(test)]
 mod sandbox_mask_tests;
 #[cfg(test)]
+mod sandbox_network_tests;
+#[cfg(test)]
 mod sandbox_required_tests;
+#[cfg(test)]
+mod sandbox_support;
 #[cfg(all(test, feature = "export"))]
 mod session_export_tests;
 #[cfg(test)]

--- a/src/tests/print_config_tests.rs
+++ b/src/tests/print_config_tests.rs
@@ -1,5 +1,78 @@
-use crate::print::format_sandbox_expose_display;
-use crate::sandbox::partition_expose;
+use crate::print::{format_sandbox_expose_display, format_sandbox_network_display};
+use crate::sandbox::{Sandbox, partition_expose};
+
+/// The `sandbox-network` row as `--print-config` builds it: from a sandbox
+/// carrying the resolved settings, with the backend probe pinned so the
+/// answer does not change with whether the developer's host has bwrap.
+fn network_row(enabled: bool, backend: &str, network: bool, backend_available: bool) -> String {
+    format_sandbox_network_display(
+        Sandbox::new(enabled, backend)
+            .with_network(network)
+            .with_backend_available(backend_available)
+            .network_effect(),
+    )
+}
+
+/// The `sandbox-network` row reports what is in effect, the same way the
+/// `sandbox-expose` row does: `sandbox-network = false` is a bwrap policy, so
+/// with the sandbox off, another backend selected, or bwrap not installed it
+/// does nothing, and a bare `false` would read as a promise the session is
+/// not keeping.
+#[test]
+fn sandbox_network_display_open_network_is_plain_true() {
+    assert_eq!(network_row(true, "bwrap", true, true), "true");
+    assert_eq!(network_row(false, "bwrap", true, true), "true");
+    // An open network is open however the rest of the session is configured,
+    // so the row never annotates `true`.
+    assert_eq!(network_row(true, "bwrap", true, false), "true");
+    assert_eq!(network_row(true, "zerobox", true, true), "true");
+}
+
+#[test]
+fn sandbox_network_display_effective_when_sandboxed_under_bwrap() {
+    assert_eq!(network_row(true, "bwrap", false, true), "false");
+}
+
+#[test]
+fn sandbox_network_display_flags_a_disabled_sandbox() {
+    assert_eq!(
+        network_row(false, "bwrap", false, true),
+        "false (no effect: sandbox is off)"
+    );
+}
+
+#[test]
+fn sandbox_network_display_flags_the_zerobox_backend() {
+    assert_eq!(
+        network_row(true, "zerobox", false, true),
+        "false (no effect: bwrap backend only)"
+    );
+}
+
+/// The variant the row used to be missing, and the one that mattered most: on
+/// a host with no bwrap the sandbox falls back to running commands bare, with
+/// the network intact, and a row printing a plain `false` told the user their
+/// commands were offline while every one of them was online. The reason the
+/// row is rendered from a sandbox rather than from resolved booleans is that
+/// this question is a probe, not a setting.
+#[test]
+fn sandbox_network_display_flags_a_missing_backend() {
+    assert_eq!(
+        network_row(true, "bwrap", false, false),
+        "false (no effect: bwrap is not installed)"
+    );
+}
+
+/// The sandbox being off wins over the backend also being missing: with
+/// nothing wrapping the command, which binary is on `PATH` is not the thing
+/// the user needs to fix first.
+#[test]
+fn sandbox_network_display_prefers_the_disabled_sandbox_reason() {
+    assert_eq!(
+        network_row(false, "bwrap", false, false),
+        "false (no effect: sandbox is off)"
+    );
+}
 
 #[test]
 fn sandbox_expose_display_empty() {

--- a/src/tests/sandbox_agent_cutoff_tests.rs
+++ b/src/tests/sandbox_agent_cutoff_tests.rs
@@ -1,36 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use tokio::process::Command;
+use crate::sandbox::essential_env_from;
+use crate::tests::sandbox_support::{args_of, bwrap_sandbox, pair_at, scratch_dir, triple_at};
 
-use crate::sandbox::{Sandbox, essential_env_from};
-
-fn scratch_dir(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "zerostack-agent-cutoff-{}-{}",
-        name,
-        std::process::id()
-    ))
-}
-
-fn args_of(cmd: &Command) -> Vec<String> {
-    cmd.as_std()
-        .get_args()
-        .map(|a| a.to_string_lossy().into_owned())
-        .collect()
-}
-
-/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
-/// answers a question asked about `--tmpfs <mask root>`.
-fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
-    args.windows(2).position(|w| w[0] == flag && w[1] == value)
-}
-
-/// Index of `flag` in an adjacent `flag src dst` triple, matching the
-/// `--ro-bind-try <src> <dst>` shape the agent-socket mask emits.
-fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize> {
-    args.windows(3)
-        .position(|w| w[0] == flag && w[1] == src && w[2] == dst)
+fn dir(name: &str) -> PathBuf {
+    scratch_dir("agent-cutoff", name)
 }
 
 #[test]
@@ -72,14 +47,11 @@ fn touch_socket(dir: &std::path::Path, name: &str) -> PathBuf {
 
 #[test]
 fn test_ssh_auth_sock_seam_emits_dev_null_bind_after_root_bind() {
-    let sock_dir = scratch_dir("sock");
+    let sock_dir = dir("sock");
     let sock = touch_socket(&sock_dir, "agent.sock");
-    let cache_dir = scratch_dir("sock-cache");
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(Vec::new())
-        .with_ssh_auth_sock(Some(sock.clone()));
+    let cache_dir = dir("sock-cache");
+    let sandbox =
+        bwrap_sandbox(Vec::new(), cache_dir.clone()).with_ssh_auth_sock(Some(sock.clone()));
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     let sock_str = sock.to_string_lossy();
@@ -102,14 +74,11 @@ fn test_stale_ssh_auth_sock_emits_no_dev_null_bind() {
     // exists (routine in long-lived tmux sessions). Binding over it would make
     // bwrap create the destination on the read-only `/` bind, which fails with
     // EROFS and aborts every command in the session.
-    let sock = scratch_dir("stale").join("agent.sock");
-    let _ = std::fs::remove_dir_all(scratch_dir("stale"));
-    let cache_dir = scratch_dir("stale-cache");
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(Vec::new())
-        .with_ssh_auth_sock(Some(sock.clone()));
+    let sock = dir("stale").join("agent.sock");
+    let _ = std::fs::remove_dir_all(dir("stale"));
+    let cache_dir = dir("stale-cache");
+    let sandbox =
+        bwrap_sandbox(Vec::new(), cache_dir.clone()).with_ssh_auth_sock(Some(sock.clone()));
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     assert!(
@@ -124,12 +93,9 @@ fn test_stale_ssh_auth_sock_emits_no_dev_null_bind() {
 fn test_empty_ssh_auth_sock_emits_no_dev_null_bind() {
     // `SSH_AUTH_SOCK=` is a common way to disable forwarding; it names no path
     // at all, so there is nothing to mask.
-    let cache_dir = scratch_dir("empty-cache");
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(Vec::new())
-        .with_ssh_auth_sock(Some(PathBuf::new()));
+    let cache_dir = dir("empty-cache");
+    let sandbox =
+        bwrap_sandbox(Vec::new(), cache_dir.clone()).with_ssh_auth_sock(Some(PathBuf::new()));
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     assert!(
@@ -146,13 +112,10 @@ fn test_agent_socket_mask_survives_exposing_the_directory_holding_it() {
     // mask, which brings the gpg-agent SSH socket inside it back: the agent
     // cutoff has no re-enable switch, so the socket bind must come after every
     // expose bind that could re-open it.
-    let gnupg = scratch_dir("gnupg");
+    let gnupg = dir("gnupg");
     let sock = touch_socket(&gnupg, "S.gpg-agent.ssh");
-    let cache_dir = scratch_dir("gnupg-cache");
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(vec![gnupg.clone()])
+    let cache_dir = dir("gnupg-cache");
+    let sandbox = bwrap_sandbox(vec![gnupg.clone()], cache_dir.clone())
         .with_expose(vec![gnupg.clone()])
         .with_ssh_auth_sock(Some(sock.clone()));
 
@@ -174,12 +137,8 @@ fn test_agent_socket_mask_survives_exposing_the_directory_holding_it() {
 
 #[test]
 fn test_no_host_ssh_auth_sock_emits_no_dev_null_bind() {
-    let cache_dir = scratch_dir("none-cache");
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(Vec::new())
-        .with_ssh_auth_sock(None);
+    let cache_dir = dir("none-cache");
+    let sandbox = bwrap_sandbox(Vec::new(), cache_dir.clone()).with_ssh_auth_sock(None);
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     assert!(

--- a/src/tests/sandbox_expose_tests.rs
+++ b/src/tests/sandbox_expose_tests.rs
@@ -1,33 +1,12 @@
 use std::path::PathBuf;
 
-use tokio::process::Command;
-
 use crate::cli::Cli;
 use crate::config::Config;
-use crate::sandbox::{Sandbox, partition_expose};
+use crate::sandbox::partition_expose;
+use crate::tests::sandbox_support::{args_of, bwrap_sandbox, pair_at, scratch_dir, triple_at};
 
-fn scratch_dir(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("zerostack-expose-{}-{}", name, std::process::id()))
-}
-
-fn args_of(cmd: &Command) -> Vec<String> {
-    cmd.as_std()
-        .get_args()
-        .map(|a| a.to_string_lossy().into_owned())
-        .collect()
-}
-
-/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
-/// answers a question asked about `--tmpfs <mask root>`.
-fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
-    args.windows(2).position(|w| w[0] == flag && w[1] == value)
-}
-
-/// Index of `flag` in an adjacent `flag src dst` triple, matching the
-/// `--ro-bind-try <path> <path>` shape expose emits.
-fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize> {
-    args.windows(3)
-        .position(|w| w[0] == flag && w[1] == src && w[2] == dst)
+fn dir(name: &str) -> PathBuf {
+    scratch_dir("expose", name)
 }
 
 // --- Resolver: CLI replaces config wholesale ---
@@ -70,7 +49,7 @@ fn test_resolve_sandbox_expose_defaults_to_empty() {
 
 #[test]
 fn test_partition_accepts_exact_mask_root() {
-    let home = scratch_dir("home-exact");
+    let home = dir("home-exact");
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh".to_string()];
 
@@ -85,7 +64,7 @@ fn test_partition_accepts_exact_mask_root() {
 
 #[test]
 fn test_partition_accepts_subpath_of_mask_root() {
-    let home = scratch_dir("home-subpath");
+    let home = dir("home-subpath");
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh/known_hosts".to_string()];
 
@@ -100,7 +79,7 @@ fn test_partition_accepts_subpath_of_mask_root() {
 
 #[test]
 fn test_partition_rejects_path_outside_mask_list() {
-    let home = scratch_dir("home-outside");
+    let home = dir("home-outside");
     let ssh = home.join(".ssh");
     let raw = vec!["/etc".to_string()];
 
@@ -117,7 +96,7 @@ fn test_partition_rejects_path_outside_mask_list() {
 fn test_partition_rejects_sibling_component_trap() {
     // Component-wise containment, not string prefixes: `~/.ssh2` is not under
     // `~/.ssh`, even though the string "~/.ssh" is a text prefix of it.
-    let home = scratch_dir("home-sibling");
+    let home = dir("home-sibling");
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh2".to_string()];
 
@@ -134,7 +113,7 @@ fn test_partition_rejects_sibling_component_trap() {
 fn test_partition_accepts_dollar_home_spelling() {
     // Every other path-taking config key accepts `$HOME/...`; expose rejecting
     // it would be a trap with no reason behind it.
-    let home = scratch_dir("home-dollar");
+    let home = dir("home-dollar");
     let ssh = home.join(".ssh");
     let raw = vec!["$HOME/.ssh".to_string()];
 
@@ -151,7 +130,7 @@ fn test_partition_accepts_dollar_home_spelling() {
 fn test_partition_rejects_parent_dir_escape_to_home() {
     // `~/.ssh/..` passes a component-wise subpath test while naming the whole
     // home directory, which would re-bind everything the masks hide.
-    let home = scratch_dir("home-escape");
+    let home = dir("home-escape");
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh/..".to_string()];
 
@@ -166,7 +145,7 @@ fn test_partition_rejects_parent_dir_escape_to_home() {
 
 #[test]
 fn test_partition_rejects_parent_dir_escape_into_a_sibling_mask() {
-    let home = scratch_dir("home-escape-sibling");
+    let home = dir("home-escape-sibling");
     let ssh = home.join(".ssh");
     let aws = home.join(".aws");
     let raw = vec!["~/.ssh/../.aws".to_string()];
@@ -182,7 +161,7 @@ fn test_partition_rejects_parent_dir_escape_into_a_sibling_mask() {
 
 #[test]
 fn test_partition_rejects_parent_dir_escape_out_of_home() {
-    let home = scratch_dir("home-escape-out");
+    let home = dir("home-escape-out");
     let ssh = home.join(".ssh");
     let raw = vec!["~/.ssh/../../../etc".to_string()];
 
@@ -240,6 +219,7 @@ fn test_build_sandbox_returns_the_rejected_value_warning() {
         backend: "bwrap",
         shell: "bash",
         expose: &["/etc".to_string()],
+        network: true,
     });
 
     assert!(
@@ -260,6 +240,7 @@ fn test_build_sandbox_is_quiet_without_expose_values() {
         backend: "bwrap",
         shell: "bash",
         expose: &[],
+        network: true,
     });
 
     assert!(
@@ -276,15 +257,12 @@ fn test_build_sandbox_is_quiet_without_expose_values() {
 
 #[test]
 fn test_expose_emits_ro_bind_try_between_masks_and_cwd_bind() {
-    let root = scratch_dir("expose-arg-assembly");
+    let root = dir("expose-arg-assembly");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("expose-arg-assembly-cache");
+    let cache_dir = dir("expose-arg-assembly-cache");
 
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(vec![root.clone()])
-        .with_expose(vec![root.clone()]);
+    let sandbox =
+        bwrap_sandbox(vec![root.clone()], cache_dir.clone()).with_expose(vec![root.clone()]);
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     let root_str = root.to_string_lossy();
@@ -316,14 +294,11 @@ fn test_expose_emits_ro_bind_try_between_masks_and_cwd_bind() {
 
 #[test]
 fn test_no_expose_emits_no_ro_bind_try() {
-    let root = scratch_dir("no-expose");
+    let root = dir("no-expose");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("no-expose-cache");
+    let cache_dir = dir("no-expose-cache");
 
-    let sandbox = Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir.clone())
-        .with_mask_roots(vec![root.clone()]);
+    let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
     let root_str = root.to_string_lossy();

--- a/src/tests/sandbox_mask_tests.rs
+++ b/src/tests/sandbox_mask_tests.rs
@@ -1,12 +1,11 @@
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 
-use tokio::process::Command;
-
 use crate::sandbox::{Sandbox, mask_roots_for};
+use crate::tests::sandbox_support::{args_of, bwrap_sandbox, pair_at, scratch_dir};
 
-fn scratch_dir(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("zerostack-mask-{}-{}", name, std::process::id()))
+fn dir(name: &str) -> PathBuf {
+    scratch_dir("mask", name)
 }
 
 /// A scratch directory *inside* the working directory, which is the directory
@@ -18,26 +17,6 @@ fn cwd_scratch_dir(name: &str) -> PathBuf {
         .unwrap()
         .join("target")
         .join(format!("zerostack-mask-{}-{}", name, std::process::id()))
-}
-
-fn bwrap_sandbox(masks: Vec<PathBuf>, cache_dir: PathBuf) -> Sandbox {
-    Sandbox::new(true, "bwrap")
-        .with_backend_available(true)
-        .with_cache_dir(cache_dir)
-        .with_mask_roots(masks)
-}
-
-fn args_of(cmd: &Command) -> Vec<String> {
-    cmd.as_std()
-        .get_args()
-        .map(|a| a.to_string_lossy().into_owned())
-        .collect()
-}
-
-/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
-/// answers a question asked about `--tmpfs <mask root>`.
-fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
-    args.windows(2).position(|w| w[0] == flag && w[1] == value)
 }
 
 /// Every mount this argument list places *at* `dst`, in order, as
@@ -72,9 +51,9 @@ fn last_mount_at(args: &[String], dst: &Path) -> (usize, String) {
 
 #[test]
 fn test_existing_mask_root_is_masked_between_root_bind_and_cwd_bind() {
-    let root = scratch_dir("existing");
+    let root = dir("existing");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("existing-cache");
+    let cache_dir = dir("existing-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -102,9 +81,9 @@ fn test_existing_mask_root_is_masked_between_root_bind_and_cwd_bind() {
 fn test_nonexistent_mask_root_emits_no_tmpfs() {
     // bwrap creates `--tmpfs` mountpoints, which a read-only `/` forbids: a
     // missing entry would abort every sandboxed command on that host.
-    let root = scratch_dir("missing");
+    let root = dir("missing");
     let _ = std::fs::remove_dir_all(&root);
-    let cache_dir = scratch_dir("missing-cache");
+    let cache_dir = dir("missing-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -126,7 +105,7 @@ fn test_nonexistent_mask_root_emits_no_tmpfs() {
 
 #[test]
 fn test_zerobox_invocation_is_unchanged_by_masks() {
-    let root = scratch_dir("zerobox");
+    let root = dir("zerobox");
     std::fs::create_dir_all(&root).unwrap();
     let sandbox = Sandbox::new(true, "zerobox")
         .with_backend_available(true)
@@ -149,7 +128,7 @@ fn test_zerobox_invocation_is_unchanged_by_masks() {
 
 #[test]
 fn test_cwd_under_a_mask_root_reports_that_root() {
-    let root = scratch_dir("shadowed");
+    let root = dir("shadowed");
     let cwd = root.join("nvim/lua");
     std::fs::create_dir_all(&cwd).unwrap();
     let sandbox = Sandbox::new(true, "bwrap")
@@ -170,7 +149,7 @@ fn test_cwd_under_a_mask_root_reports_that_root() {
 fn test_sibling_of_a_mask_root_is_not_shadowed() {
     // Component-wise containment, not string prefixes: `~/.ssh2` is not under
     // `~/.ssh`.
-    let base = scratch_dir("sibling");
+    let base = dir("sibling");
     let root = base.join(".ssh");
     let sibling = base.join(".ssh2");
     std::fs::create_dir_all(&root).unwrap();
@@ -191,7 +170,7 @@ fn test_cwd_reached_through_a_symlinked_home_is_shadowed() {
     // `getcwd(3)` fully resolved while the mask root is spelled through the
     // `/home -> /data/home` symlink, so a lexical test reports no shadowing and
     // the user is never told the project bind re-opens part of the mask.
-    let base = scratch_dir("symlinked-home-shadow");
+    let base = dir("symlinked-home-shadow");
     let _ = std::fs::remove_dir_all(&base);
     let real_home = base.join("data/home/tester");
     let project = real_home.join(".gnupg/notes");
@@ -225,7 +204,7 @@ fn test_mask_root_under_the_cwd_is_remasked_after_the_project_bind() {
     // second mask layer they come back, and writable at that.
     let root = cwd_scratch_dir("under-cwd");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("under-cwd-cache");
+    let cache_dir = dir("under-cwd-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -251,7 +230,7 @@ fn test_mask_root_under_the_cwd_is_remasked_after_the_project_bind() {
 fn test_mask_root_under_the_cache_bind_is_remasked() {
     // Same shape via the other read-write bind: the cache directory is bound
     // after the masks too.
-    let cache_dir = scratch_dir("cache-swallow");
+    let cache_dir = dir("cache-swallow");
     let root = cache_dir.join(".aws");
     std::fs::create_dir_all(&root).unwrap();
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
@@ -282,12 +261,12 @@ fn test_mask_root_symlinked_into_the_project_is_remasked() {
     // containment test sees the collision.
     let real = cwd_scratch_dir("dotfiles");
     std::fs::create_dir_all(real.join("ssh")).unwrap();
-    let home = scratch_dir("symlinked-ssh");
+    let home = dir("symlinked-ssh");
     let _ = std::fs::remove_dir_all(&home);
     std::fs::create_dir_all(&home).unwrap();
     let root = home.join(".ssh");
     symlink(real.join("ssh"), &root).unwrap();
-    let cache_dir = scratch_dir("symlinked-ssh-cache");
+    let cache_dir = dir("symlinked-ssh-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -317,7 +296,7 @@ fn test_mask_root_under_a_symlinked_home_is_remasked() {
     // spelled through it while the bind, coming from `getcwd(3)`, is already
     // resolved. Modelled on the cache bind, which the seams let a test place
     // anywhere.
-    let base = scratch_dir("symlinked-home");
+    let base = dir("symlinked-home");
     let _ = std::fs::remove_dir_all(&base);
     let real_home = base.join("data/home/tester");
     std::fs::create_dir_all(real_home.join(".aws")).unwrap();
@@ -348,7 +327,7 @@ fn test_expose_under_a_remasked_root_stays_visible_read_only() {
     std::fs::create_dir_all(&root).unwrap();
     let exposed = root.join("known_hosts");
     std::fs::write(&exposed, b"").unwrap();
-    let cache_dir = scratch_dir("under-cwd-expose-cache");
+    let cache_dir = dir("under-cwd-expose-cache");
     let sandbox =
         bwrap_sandbox(vec![root.clone()], cache_dir.clone()).with_expose(vec![exposed.clone()]);
 
@@ -383,7 +362,7 @@ fn test_mask_root_containing_the_cwd_keeps_the_project_bind_as_the_last_word() {
         .parent()
         .expect("cwd should have a parent")
         .to_path_buf();
-    let cache_dir = scratch_dir("contains-cwd-cache");
+    let cache_dir = dir("contains-cwd-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -411,9 +390,9 @@ fn test_mask_root_containing_the_cwd_keeps_the_project_bind_as_the_last_word() {
 
 #[test]
 fn test_mask_root_outside_every_read_write_bind_is_masked_once() {
-    let root = scratch_dir("outside-binds");
+    let root = dir("outside-binds");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("outside-binds-cache");
+    let cache_dir = dir("outside-binds-cache");
     let sandbox = bwrap_sandbox(vec![root.clone()], cache_dir.clone());
 
     let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
@@ -433,7 +412,7 @@ fn test_optional_sandbox_falling_back_to_bare_masks_nothing() {
     // even if a fresh probe would find one. A masked-path claim there would
     // tell the model a file was hidden while the command ran bare and read it
     // fine.
-    let root = scratch_dir("probe");
+    let root = dir("probe");
     std::fs::create_dir_all(&root).unwrap();
     let sandbox = Sandbox::new(true, "bwrap")
         .with_backend_available(false)
@@ -470,9 +449,9 @@ fn test_required_sandbox_masks_on_the_fresh_probe_that_launches_it() {
     // Masking has to follow it there: gating on the cached probe alone would
     // run bwrap with an empty mask list, leaving every credential directory
     // readable inside the sandbox of the user who set `sandbox-required`.
-    let root = scratch_dir("required-probe");
+    let root = dir("required-probe");
     std::fs::create_dir_all(&root).unwrap();
-    let cache_dir = scratch_dir("required-probe-cache");
+    let cache_dir = dir("required-probe-cache");
     let sandbox = Sandbox::new(true, "bwrap")
         .with_required(true)
         .with_backend_available(false)
@@ -517,7 +496,7 @@ fn test_shadowed_mask_warning_is_computed_against_the_bound_working_directory() 
         "the warning should name the shadowed root: {warning}"
     );
 
-    let elsewhere = scratch_dir("elsewhere");
+    let elsewhere = dir("elsewhere");
     std::fs::create_dir_all(&elsewhere).unwrap();
     let other = Sandbox::new(true, "bwrap")
         .with_backend_available(true)
@@ -595,7 +574,7 @@ fn test_relative_xdg_config_home_is_ignored() {
 
 #[test]
 fn test_disabled_sandbox_masks_nothing() {
-    let root = scratch_dir("disabled");
+    let root = dir("disabled");
     std::fs::create_dir_all(&root).unwrap();
     let sandbox = Sandbox::new(false, "bwrap")
         .with_backend_available(true)

--- a/src/tests/sandbox_network_tests.rs
+++ b/src/tests/sandbox_network_tests.rs
@@ -1,0 +1,440 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use rig::tool::Tool;
+
+use crate::agent::tools::bash::{BashTool, network_hint_for_exit};
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::sandbox::{Sandbox, network_hint};
+use crate::tests::sandbox_support::{args_of, backend_sandbox, scratch_dir, triple_at};
+
+const HINT: &str = "note: network is disabled by the sandbox (sandbox-network = false); ask the user whether it should be enabled";
+
+fn dir(name: &str) -> PathBuf {
+    scratch_dir("network", name)
+}
+
+/// A sandbox whose backend will run, so the bwrap policy (and with it the
+/// network setting) actually applies.
+fn running_sandbox(backend: &str, network: bool, name: &str) -> Sandbox {
+    backend_sandbox(backend, Vec::new(), dir(name)).with_network(network)
+}
+
+/// The argv of one sandboxed command, with the scratch cache directory that
+/// assembling it creates removed again.
+fn wrap_args(sandbox: Sandbox, name: &str) -> Vec<String> {
+    let args = args_of(&sandbox.wrap_command("echo hello").unwrap());
+    let _ = std::fs::remove_dir_all(dir(name));
+    args
+}
+
+fn index_of(args: &[String], flag: &str) -> Option<usize> {
+    args.iter().position(|a| a == flag)
+}
+
+/// The warnings `build_sandbox` produces for a set of resolved settings. This
+/// is the channel both entry points log once per session, so the conflict
+/// warning is asserted where it is actually produced.
+fn warnings_for(enabled: bool, network: bool) -> Vec<String> {
+    crate::sandbox::build_sandbox(&crate::sandbox::SandboxSettings {
+        enabled,
+        required: false,
+        backend: "bwrap",
+        shell: "bash",
+        expose: &[],
+        network,
+    })
+    .warnings
+}
+
+fn warns_about_network(enabled: bool, network: bool) -> bool {
+    warnings_for(enabled, network)
+        .iter()
+        .any(|w| w.contains("sandbox-network is set to false"))
+}
+
+// --- CLI parsing: bare flag means true ---
+
+#[test]
+fn test_bare_flag_parses_as_some_true() {
+    let cli = Cli::try_parse_from(["zerostack", "--sandbox-network"]).unwrap();
+    assert_eq!(cli.sandbox_network, Some(true));
+}
+
+// --- Resolver: CLI over config, default true ---
+
+#[test]
+fn test_resolve_sandbox_network_defaults_to_true() {
+    let cli = Cli::default();
+    let cfg = Config::default();
+    assert!(
+        cli.resolve_sandbox_network(&cfg),
+        "the network stays open unless it is turned off explicitly"
+    );
+}
+
+#[test]
+fn test_resolve_sandbox_network_from_config() {
+    let cli = Cli::default();
+    let cfg = Config {
+        sandbox: Some(true),
+        sandbox_network: Some(false),
+        ..Default::default()
+    };
+    assert!(!cli.resolve_sandbox_network(&cfg));
+}
+
+#[test]
+fn test_resolve_sandbox_network_cli_disables_over_config() {
+    let cli = Cli {
+        sandbox_network: Some(false),
+        ..Default::default()
+    };
+    let cfg = Config {
+        sandbox: Some(true),
+        sandbox_network: Some(true),
+        ..Default::default()
+    };
+    assert!(!cli.resolve_sandbox_network(&cfg));
+}
+
+#[test]
+fn test_resolve_sandbox_network_cli_enables_over_config() {
+    // The direction a bare boolean flag could not express: the config turns
+    // the network off and the command line wants it back for one run.
+    let cli = Cli {
+        sandbox_network: Some(true),
+        ..Default::default()
+    };
+    let cfg = Config {
+        sandbox: Some(true),
+        sandbox_network: Some(false),
+        ..Default::default()
+    };
+    assert!(cli.resolve_sandbox_network(&cfg));
+}
+
+#[test]
+fn test_sandbox_network_never_enables_the_sandbox() {
+    // `sandbox-network` is a modifier, not an enforcer: unlike
+    // `sandbox-required` it must not switch the sandbox on by itself.
+    let cli = Cli::default();
+    let cfg = Config {
+        sandbox_network: Some(false),
+        ..Default::default()
+    };
+    assert!(
+        !cli.resolve_sandbox(&cfg),
+        "turning the network off must not imply sandbox = true"
+    );
+}
+
+// --- The one-shot warning for a setting that cannot take effect ---
+
+#[test]
+fn test_network_off_with_the_sandbox_off_warns_once() {
+    let warnings = warnings_for(false, false);
+    let matched: Vec<&String> = warnings
+        .iter()
+        .filter(|w| w.contains("sandbox-network is set to false"))
+        .collect();
+    assert_eq!(
+        matched.len(),
+        1,
+        "exactly one warning, naming the key: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_no_warning_when_the_sandbox_is_on() {
+    assert!(!warns_about_network(true, false));
+}
+
+#[test]
+fn test_no_warning_when_the_network_stays_open() {
+    assert!(!warns_about_network(false, true));
+    assert!(!warns_about_network(true, true));
+}
+
+// --- Arg assembly: --unshare-net iff the network is resolved off ---
+
+#[test]
+fn test_default_emits_no_unshare_net() {
+    let args = wrap_args(running_sandbox("bwrap", true, "default"), "default");
+    assert!(
+        index_of(&args, "--unshare-net").is_none(),
+        "the default keeps the network, so the flag must be absent: {args:?}"
+    );
+}
+
+#[test]
+fn test_network_off_emits_unshare_net_in_the_unshare_block() {
+    let args = wrap_args(running_sandbox("bwrap", false, "off"), "off");
+
+    let cgroup = index_of(&args, "--unshare-cgroup")
+        .unwrap_or_else(|| panic!("the existing unshare block should still be there: {args:?}"));
+    let net = index_of(&args, "--unshare-net")
+        .unwrap_or_else(|| panic!("expected --unshare-net when the network is off: {args:?}"));
+    let die = index_of(&args, "--die-with-parent")
+        .unwrap_or_else(|| panic!("--die-with-parent should still be emitted: {args:?}"));
+
+    assert!(
+        cgroup < net && net < die,
+        "--unshare-net belongs in the unshare block, before --die-with-parent: {args:?}"
+    );
+}
+
+#[test]
+fn test_resolver_file_stays_bound_when_the_network_is_off() {
+    // The /etc/resolv.conf bind is deliberately unconditional: keeping it out
+    // of the branch is what keeps the rest of the assembly identical. The
+    // resolver path comes through the test seam rather than from the host, so
+    // this asserts on a real bind on every platform instead of skipping itself
+    // wherever `/etc/resolv.conf` happens not to exist.
+    let root = dir("resolv");
+    std::fs::create_dir_all(&root).unwrap();
+    let resolver = root.join("resolv.conf");
+    std::fs::write(&resolver, "nameserver 127.0.0.53\n").unwrap();
+    let expected = std::fs::canonicalize(&resolver).unwrap();
+
+    let sandbox = running_sandbox("bwrap", false, "resolv").with_resolv_conf(resolver);
+    let args = wrap_args(sandbox, "resolv");
+
+    assert!(
+        triple_at(
+            &args,
+            "--ro-bind-try",
+            &expected.to_string_lossy(),
+            "/etc/resolv.conf"
+        )
+        .is_some(),
+        "the resolver bind must still be emitted with the network off: {args:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_network_off_changes_nothing_else_in_the_argv() {
+    // The one-flag diff is the whole mechanism: the resolver bind, the masks,
+    // the read-write binds and their order are identical either way, so
+    // removing `--unshare-net` reproduces the default argv exactly.
+    let with_network = wrap_args(running_sandbox("bwrap", true, "diff"), "diff");
+    let without_network = wrap_args(running_sandbox("bwrap", false, "diff"), "diff");
+
+    let stripped: Vec<String> = without_network
+        .iter()
+        .filter(|a| *a != "--unshare-net")
+        .cloned()
+        .collect();
+    assert_eq!(
+        stripped, with_network,
+        "turning the network off must add exactly one flag and change nothing else"
+    );
+}
+
+#[test]
+fn test_zerobox_backend_ignores_the_network_setting() {
+    // zerobox applies its own network policy; zerostack hands it the same
+    // arguments either way.
+    let args = wrap_args(running_sandbox("zerobox", false, "zerobox"), "zerobox");
+    assert!(
+        index_of(&args, "--unshare-net").is_none(),
+        "--unshare-net is a bwrap flag and must never reach zerobox: {args:?}"
+    );
+}
+
+#[test]
+fn test_build_sandbox_wires_the_setting_through() {
+    // The shared construction path is what both entry points use, so the
+    // setting has to survive it and not just `Sandbox::with_network`.
+    let setup = crate::sandbox::build_sandbox(&crate::sandbox::SandboxSettings {
+        enabled: true,
+        required: false,
+        backend: "bwrap",
+        shell: "bash",
+        expose: &[],
+        network: false,
+    });
+    let sandbox = setup
+        .sandbox
+        .with_backend_available(true)
+        .with_cache_dir(dir("build"))
+        .with_mask_roots(Vec::new());
+
+    let args = wrap_args(sandbox, "build");
+    assert!(
+        index_of(&args, "--unshare-net").is_some(),
+        "build_sandbox must forward sandbox-network to the sandbox it returns: {args:?}"
+    );
+}
+
+// --- Hint: only when the network really is cut and the command failed ---
+
+const DNS_FAILURE: &str = "curl: (6) Could not resolve host: example.com";
+
+#[test]
+fn test_hint_matches_the_no_network_failure_spellings() {
+    for stderr in [
+        DNS_FAILURE,
+        "fatal: unable to access 'https://example.com/': Could not resolve host: example.com",
+        "socket.gaierror: [Errno -3] Temporary failure in name resolution",
+        "ping: connect: Network is unreachable",
+        // A service on the *host's* loopback, which the sandbox's own private
+        // loopback does not have: the common failure once the network is off.
+        "curl: (7) Failed to connect to 127.0.0.1 port 5432: Connection refused",
+        "bind: Cannot assign requested address",
+    ] {
+        assert_eq!(
+            network_hint(stderr).as_deref(),
+            Some(HINT),
+            "expected a hint for: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_hint_matching_is_case_insensitive() {
+    assert_eq!(
+        network_hint("COULD NOT RESOLVE HOST: EXAMPLE.COM").as_deref(),
+        Some(HINT)
+    );
+}
+
+#[test]
+fn test_module_resolution_failures_never_hint() {
+    // The reason the pattern carries "host": bundlers and package managers say
+    // "could not resolve" about imports and dependency trees, and blaming the
+    // sandbox for a build error would send the model to the user with a
+    // question about the wrong thing entirely.
+    for stderr in [
+        "X [ERROR] Could not resolve \"./missing-module\"",
+        "npm ERR! code ERESOLVE\nnpm ERR! Could not resolve dependency:",
+    ] {
+        assert_eq!(
+            network_hint(stderr),
+            None,
+            "a module resolution failure is not a network failure: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_unrelated_failure_never_hints() {
+    assert_eq!(
+        network_hint("cat: missing.txt: No such file or directory"),
+        None,
+        "the narrow pattern list is what keeps the sandbox from being blamed for every failure"
+    );
+}
+
+#[test]
+fn test_unlisted_wording_is_a_harmless_miss() {
+    // Localized or unusual resolver messages are out of reach of a substring
+    // list, as is a command that redirects stderr with `2>&1`; a missed hint
+    // costs nothing, a wrong one costs the user a question.
+    assert_eq!(network_hint("wget: unable to resolve host address"), None);
+}
+
+#[test]
+fn test_exit_zero_never_hints() {
+    // A command can print a resolver error inside a retry loop and still
+    // succeed; the gate lives in the function the tool calls unconditionally.
+    let sandbox = running_sandbox("bwrap", false, "exit-zero");
+    assert_eq!(network_hint_for_exit(0, DNS_FAILURE, &sandbox), None);
+    assert_eq!(
+        network_hint_for_exit(6, DNS_FAILURE, &sandbox).as_deref(),
+        Some(HINT)
+    );
+}
+
+#[test]
+fn test_open_network_never_hints() {
+    // The same failure with the network on is a real resolver problem on the
+    // host, and blaming the sandbox would send the model to the user with the
+    // wrong question.
+    let sandbox = running_sandbox("bwrap", true, "open");
+    assert_eq!(network_hint_for_exit(6, DNS_FAILURE, &sandbox), None);
+}
+
+#[test]
+fn test_unsandboxed_command_never_hints() {
+    // Nothing unshared the network namespace, because nothing sandboxed the
+    // command at all: the setting resolved to false, but no policy applied it.
+    let sandbox = Sandbox::new(true, "bwrap")
+        .with_backend_available(false)
+        .with_network(false);
+    assert_eq!(network_hint_for_exit(6, DNS_FAILURE, &sandbox), None);
+}
+
+#[test]
+fn test_zerobox_command_never_hints() {
+    // `--unshare-net` never reached zerobox, so whatever its own policy did is
+    // not something this hint can explain.
+    let sandbox = running_sandbox("zerobox", false, "zerobox-hint");
+    assert_eq!(network_hint_for_exit(6, DNS_FAILURE, &sandbox), None);
+}
+
+// --- Tool description: told upfront, not discovered by failing a command ---
+
+/// The base description, unchanged from before the key existed.
+const BASE_DESCRIPTION: &str =
+    "Execute a bash command in the current working directory. Returns stdout and stderr.";
+
+/// The one sentence appended when the network really is unshared. Spelled out
+/// here rather than imported so a silent reword of the tool definition, which
+/// is prompt context the model reads and the user never sees, has to be a
+/// deliberate edit in two places.
+const NOTICE: &str = " This session's sandbox runs commands without network access, so the internet, the local network, and services listening on the host are unreachable; a server started and used within a single command still works on 127.0.0.1.";
+
+fn bash_description(sandbox: Sandbox) -> String {
+    BashTool::new(
+        None,
+        None,
+        sandbox,
+        None,
+        #[cfg(feature = "rtk")]
+        None,
+    )
+    .description()
+}
+
+#[test]
+fn test_description_announces_an_unshared_network() {
+    // Without this the model finds out only by running something that cannot
+    // work, and its first guess at the cause is usually not the sandbox.
+    let described = bash_description(running_sandbox("bwrap", false, "describe-off"));
+    assert_eq!(
+        described,
+        format!("{BASE_DESCRIPTION}{NOTICE}"),
+        "the notice is appended to the description, not substituted for it"
+    );
+}
+
+#[test]
+fn test_description_is_unchanged_when_the_network_is_open() {
+    let described = bash_description(running_sandbox("bwrap", true, "describe-on"));
+    assert_eq!(described, BASE_DESCRIPTION);
+}
+
+#[test]
+fn test_description_stays_silent_when_nothing_unshares_the_network() {
+    // The same gate as the hint: a session whose backend is missing, or whose
+    // backend is zerobox, must not be told its commands are offline when they
+    // are not. Telling the model the network is gone when it is not costs a
+    // capability it actually has.
+    let no_backend = Sandbox::new(true, "bwrap")
+        .with_backend_available(false)
+        .with_network(false);
+    assert_eq!(bash_description(no_backend), BASE_DESCRIPTION);
+
+    let zerobox = running_sandbox("zerobox", false, "describe-zerobox");
+    assert_eq!(bash_description(zerobox), BASE_DESCRIPTION);
+
+    let sandbox_off = Sandbox::new(false, "bwrap")
+        .with_backend_available(true)
+        .with_network(false);
+    assert_eq!(bash_description(sandbox_off), BASE_DESCRIPTION);
+}

--- a/src/tests/sandbox_support.rs
+++ b/src/tests/sandbox_support.rs
@@ -1,0 +1,65 @@
+//! Scaffolding shared by the sandbox test files (masking, expose, agent
+//! cutoff, network). All of them ask the same question in the same way: build
+//! a sandbox whose backend is pinned to "available" so the bwrap branch runs
+//! on any host, then assert on the argument list it assembles. These are the
+//! pieces every one of them needs; anything used by a single file stays in
+//! that file.
+
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use crate::sandbox::Sandbox;
+
+/// A scratch path under the system temp directory, namespaced by test file
+/// (`group`) and by case (`name`) so tests running in parallel, in the same
+/// process, never collide on a directory.
+pub(super) fn scratch_dir(group: &str, name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "zerostack-{}-{}-{}",
+        group,
+        name,
+        std::process::id()
+    ))
+}
+
+/// The arguments a wrapped command would be launched with, as strings. Every
+/// sandbox assertion is a statement about this list.
+pub(super) fn args_of(cmd: &Command) -> Vec<String> {
+    cmd.as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Index of `flag` in an adjacent `flag value` pair, so `--tmpfs /tmp` never
+/// answers a question asked about `--tmpfs <mask root>`.
+pub(super) fn pair_at(args: &[String], flag: &str, value: &str) -> Option<usize> {
+    args.windows(2).position(|w| w[0] == flag && w[1] == value)
+}
+
+/// Index of `flag` in an adjacent `flag src dst` triple, matching the
+/// `--ro-bind-try <src> <dst>` shape the masks and expose emit.
+pub(super) fn triple_at(args: &[String], flag: &str, src: &str, dst: &str) -> Option<usize> {
+    args.windows(3)
+        .position(|w| w[0] == flag && w[1] == src && w[2] == dst)
+}
+
+/// A sandbox on `backend` whose backend probe is pinned to "available", so the
+/// argument assembly under test runs on hosts without bwrap installed. The
+/// cache bind is pointed at a scratch path because assembling the arguments
+/// creates that directory, which must never be the developer's real
+/// `~/.cache`, and the mask list is given explicitly so assertions do not
+/// depend on which credential directories the host happens to have.
+pub(super) fn backend_sandbox(backend: &str, masks: Vec<PathBuf>, cache_dir: PathBuf) -> Sandbox {
+    Sandbox::new(true, backend)
+        .with_backend_available(true)
+        .with_cache_dir(cache_dir)
+        .with_mask_roots(masks)
+}
+
+/// `backend_sandbox` on the default backend, which is what almost every
+/// sandbox test wants.
+pub(super) fn bwrap_sandbox(masks: Vec<PathBuf>, cache_dir: PathBuf) -> Sandbox {
+    backend_sandbox("bwrap", masks, cache_dir)
+}


### PR DESCRIPTION
## Summary

Adds `sandbox-network` (config key, default `true`) and `--sandbox-network[=true|false]` (CLI flag): when resolved `false`, the bwrap sandbox runs bash commands with `--unshare-net`, cutting the command's own network access. Ships with a network-failure hint appended to failed tool results, a proactive notice in the bash tool description, an effect-aware `--print-config` row, and a docs pass that states the real semantics, including the parts that stay open.

## Motivation

PR #245 masked credential directories, which is the "reads your secrets" half of the exfiltration story. This PR adds the other half for the bash tool: with `sandbox-network = false`, a sandboxed command cannot ship what it read over the network. SECURITY.md's bwrap gap list has carried "network access is fully open" since #244; this closes that row for users who opt in, while the default keeps today's behavior exactly.

## Design decisions

- **Default `true`.** `--unshare-net` gives each bash command a fresh network namespace with its own private loopback, so a server started and used within one command still works on 127.0.0.1. What breaks is reaching the host: package registries, already-running dev servers, and anything cross-command, since the namespace dies with the command. That is too disruptive to force on, so offline is opt-in and the docs say precisely what changes.
- **Modifier, not enforcer.** Like `sandbox-expose` and unlike `sandbox-required`, the key does not switch the sandbox on. Setting `false` while the sandbox is off produces a one-shot startup warning, and only pairing with `sandbox-required` turns the promise into a guarantee; `--print-config` annotates the row with `(no effect: ...)` whenever the sandbox is off, the backend is not bwrap, or bwrap is not installed, so the readout never claims an isolation that will not happen.
- **Hint matching is stderr-only and deliberately narrow.** Five patterns (`could not resolve host`, `name resolution`, `network is unreachable`, `connection refused`, `cannot assign requested address`), matched case-insensitively against stderr with no allocation, gated on the bwrap policy actually applying. The command string is not scanned: a command mentioning a phrase is not failing because of it. `connection refused` is included because host-localhost services are the most common casualty, and on systemd-resolved hosts DNS against the bound 127.0.0.53 resolver surfaces as exactly that. The hint text is fixed, so untrusted stderr can trigger the note but never inject content into it, and the user remains the gate for any change; this mirrors the merged mask-hint mechanism from #245.
- **Proactive disclosure.** When the session will unshare the network, the bash tool description says so upfront (one fixed sentence, same gate as the hint), so the model does not burn a turn discovering it by failure.
- **resolv.conf stays bound when offline.** Its contents are reachable through the `--ro-bind / /` root bind regardless, so skipping the bind hides nothing and would only fork the assembly order.

## Testing

- 1071 tests green with `--all-features` (the ACP entry point is feature-gated); `cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` both clean.
- New coverage: `src/tests/sandbox_network_tests.rs` (argv contains `--unshare-net` iff resolved false, whole-argv byte-identity otherwise, CLI/config precedence in both directions, resolver-bind invariant via an injected resolver path, conflict warning on the warnings channel, hint pattern positives and negatives including esbuild/npm ERESOLVE non-matches, bash description notice on and off) plus `--print-config` variants for all effect states in `src/tests/print_config_tests.rs`. Tests assert at the bwrap argument assembly layer through the existing injection seams and never touch host bwrap.
- Live verification on macOS (no bwrap): `--print-config` shows `false (no effect: bwrap is not installed)` / `(no effect: sandbox is off)` / `(no effect: bwrap backend only)` in the corresponding states, and clap rejects invalid flag values.
- vibe-diff: not run
- cross-check: not run
- verify: not run

## Reviewing

Start with `src/sandbox.rs`: the `--unshare-net` line in `wrap_command`'s unshare block, `NetworkEffect`, and the hint patterns are the behavior core. Then `src/agent/tools/bash.rs` for the single-pass hint append and the description notice, `src/cli.rs` and `src/print.rs` for the flag and the row, and SECURITY.md for the threat-model wording. The test diff is large but mostly mechanical: four sandbox test files now share one `sandbox_support.rs` scaffolding module instead of carrying private copies, which is where most of the deleted lines went. LoC split: logic +310/-33, tests +651/-156, docs +153/-8.

## Notes

- Behavioral evidence is at the argv layer, consistent with the earlier sandbox PRs: macOS cannot run bwrap, so the loopback and reachability semantics are asserted from bwrap's documented behavior rather than a live run. A Linux CI job exercising a real `--unshare-net` round trip (loopback up within one command, host localhost unreachable, internet unreachable) would harden this and the two earlier sandbox PRs alike; happy to add one in a follow-up if wanted.
- Filesystem Unix sockets remain connectable with the network unshared (a read-only bind blocks writes, not `connect(2)`), so `/run/docker.sock` on a Docker host is a full residual escape. SECURITY.md now states this plainly instead of implying the mounts cover it; masking host socket paths is named there as plausible future hardening, out of scope here.
- A sandboxed command that runs where `unshare(CLONE_NEWNET)` itself is denied (nested containers, restrictive seccomp) fails loudly with bwrap's own error rather than falling back to an online run; failing closed is the intended direction, and the error names bwrap so it is attributable.
- A project-local config override can re-enable the network for a checkout, as it can for every sandbox key; docs carry the same untrusted-checkout warning the `sandbox-expose` section already had. Whether security keys should be exempt from local override is a pre-existing question that deserves its own discussion rather than a rider here.
- `/sys` is a host bind, so interface names and MAC addresses remain readable inside the offline namespace; SECURITY.md scopes the "host is unreachable" claim to routing accordingly.
- The hint misses failures whose stderr was redirected (`2>&1`) and localized error text; both are documented as accepted best-effort limits, and a missed hint is harmless.
