### PR TITLE
chore: refresh model catalog from models.dev

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -22,20 +22,6 @@
       "output_price": 5
     },
     {
-      "id": "claude-opus-4-1",
-      "name": "Claude Opus 4.1 (latest)",
-      "context": 200000,
-      "input_price": 15,
-      "output_price": 75
-    },
-    {
-      "id": "claude-opus-4-1-20250805",
-      "name": "Claude Opus 4.1",
-      "context": 200000,
-      "input_price": 15,
-      "output_price": 75
-    },
-    {
       "id": "claude-opus-4-5",
       "name": "Claude Opus 4.5 (latest)",
       "context": 200000,


### PR DESCRIPTION
Automated refresh of `data/models.json` from https://models.dev/api.json via `scripts/gen-models-catalog.sh`.

## Summary

| Provider | Models | Added | Removed | Changed |
|---|---|---|---|---|
| anthropic | 15 → 13 | 0 | 2 | 0 |
| gemini | 32 → 32 | 0 | 0 | 0 |
| openai | 38 → 38 | 0 | 0 | 0 |
| openrouter | 216 → 216 | 0 | 0 | 0 |

### anthropic

**Removed**
- `claude-opus-4-1` (Claude Opus 4.1 (latest), context 200000, in $15/M, out $75/M)
- `claude-opus-4-1-20250805` (Claude Opus 4.1, context 200000, in $15/M, out $75/M)

Review the diff for unexpected additions or removals before merging.
