### PR TITLE
docs: fix MiniMax full-context pricing

### DIFF
--- a/docs/providers/Minimax.md
+++ b/docs/providers/Minimax.md
@@ -65,7 +65,7 @@ zerostack --provider minimax-cn-anthropic --model MiniMax-M2.7
 
 | Model | Context window | Input modes | Thinking | Input | Output | Cache read | Cache write |
 | ----- | -------------: | ----------- | -------- | ----: | -----: | ---------: | ----------: |
-| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive or disabled | $0.30 | $1.20 | $0.06 | not listed |
+| `MiniMax-M3` | 1,000,000 | text, image, video | adaptive or disabled | $0.60 | $2.40 | $0.12 | not listed |
 | `MiniMax-M2.7` | 204,800 | text | always on | $0.30 | $1.20 | $0.06 | $0.375 |
 
 Prices are in USD per million tokens. MiniMax-M3 also has the following
@@ -78,16 +78,16 @@ service-tier pricing:
 | priority | up to 512,000 tokens | $0.45 | $1.80 | $0.09 |
 | priority | over 512,000 tokens | $0.90 | $3.60 | $0.18 |
 
-The optional quick-model entries below use the standard tier at up to 512,000
-tokens for zerostack's local cost estimate:
+The optional quick-model entries below use the standard tier for their full
+configured context windows in zerostack's local cost estimate:
 
 ```toml
 [quick_models.minimax-m3]
 provider = "minimax-global-openai"
 model = "MiniMax-M3"
 context_window = 1000000
-input_token_cost = 0.3
-output_token_cost = 1.2
+input_token_cost = 0.6
+output_token_cost = 2.4
 
 [quick_models.minimax-m2-7]
 provider = "minimax-global-openai"


### PR DESCRIPTION
Reason: Correct MiniMax-M3 pricing estimates for its full 1M-token context window.

- Update the MiniMax-M3 pricing row to the standard over-512K rates.
- Align the MiniMax-M3 quick-model cost estimate with its configured 1M context window.

Checks:
- `cargo fmt --check`
- `cargo test --locked`
