### PR TITLE
fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ _zerostack_ is one of the smallest and most performant coding agents on the mark
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=gi-dellav%2Fzerostack&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#gi-dellav/zerostack&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=gi-dellav/zerostack&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=gi-dellav/zerostack&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=gi-dellav/zerostack&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gi-dellav/zerostack&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gi-dellav/zerostack&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gi-dellav/zerostack&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render reliably. Update its links so the chart works again.