### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 
 ## Features
 
-- **Multi-provider**: OpenRouter, OpenAI, Anthropic, Gemini, Ollama, plus custom providers
+- **Multi-provider**: OpenRouter, OrcaRouter, OpenAI, Anthropic, Gemini, Ollama, plus custom providers
 - **Standard tools**: all of the standard tools exposed to coding agents, as described by the opencode documentation.
 - **Permission system**: five configurable modes with per-tool patterns, session allowlists, and configurable mode-to-rule application policies
 - **Session management**: save/load/resume sessions, auto-compaction to stay within context windows
@@ -519,6 +519,7 @@ and API key env vars apply). Without it, zerostack cannot process prompts.
 ## Supported providers
 
 - OpenRouter (default)
+- OrcaRouter
 - OpenAI-compatible (vLLM, LiteLLM, etc.)
 - Anthropic
 - Gemini

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -165,7 +165,7 @@ Accepted top-level keys:
 
 | Key                       | Type    | Description                                                                                                                                                                 |
 | ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider`                | string  | Provider name. Built-ins are `openrouter`, `openai`, `anthropic`, `gemini`/`google`, and `ollama`; custom provider aliases are also accepted. Default: `openrouter`.        |
+| `provider`                | string  | Provider name. Built-ins are `openrouter`, `orcarouter`, `openai`, `anthropic`, `gemini`/`google`, and `ollama`; custom provider aliases are also accepted. Default: `openrouter`.        |
 | `model`                   | string  | Model name. Default: `deepseek/deepseek-v4-flash`.                                                                                                                          |
 | `max_tokens`              | integer | Maximum response tokens. Default: `16384`.                                                                                                                                  |
 | `max_agent_turns`         | integer | Maximum agent turns per response. Default: `200`.                                                                                                                           |
@@ -579,9 +579,9 @@ a routing strategy:
 
 `extra_body` injects arbitrary JSON into the completion request body. It is
 shallow-merged (top-level keys win on collision) and works for **every**
-provider — OpenAI, Anthropic, Gemini, Ollama, OpenRouter, and any custom
-provider — not just OpenRouter. The same value is applied to the main agent and
-the isolated `/btw` agent so they behave identically.
+provider — OpenAI, Anthropic, Gemini, Ollama, OpenRouter, OrcaRouter, and any
+custom provider — not just OpenRouter. The same value is applied to the main
+agent and the isolated `/btw` agent so they behave identically.
 
 It can be set at two levels, resolved most-specific first:
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -12,6 +12,7 @@ definitions for OpenAI-compatible endpoints.
 | Provider   | Config name         | Default env var for API key |
 | ---------- | ------------------- | --------------------------- |
 | OpenRouter | `openrouter`        | `OPENROUTER_API_KEY`        |
+| OrcaRouter | `orcarouter`        | `ORCAROUTER_API_KEY`        |
 | OpenAI     | `openai`            | `OPENAI_API_KEY`            |
 | Anthropic  | `anthropic`         | `ANTHROPIC_API_KEY`         |
 | Gemini     | `gemini` / `google` | `GEMINI_API_KEY`            |
@@ -60,7 +61,7 @@ the `custom_providers` key in the config file:
 
 | Field                         | Type    | Description                                                                                                                                                                   |
 | ----------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider_type`               | string  | Must be one of the built-in provider types (`openrouter`, `openai`, `anthropic`, `gemini`, `ollama`).                                                                         |
+| `provider_type`               | string  | Must be one of the built-in provider types (`openrouter`, `orcarouter`, `openai`, `anthropic`, `gemini`, `ollama`).                                                                         |
 | `base_url`                    | string  | The API base URL.                                                                                                                                                             |
 | `api_key_env`                 | string  | Optional. Name of an environment variable holding the API key. Falls back to the provider-kind default if not set.                                                            |
 | `api_style`                   | string  | Optional. For OpenAI-based providers: `"responses"` (Responses API, default when no `base_url` is set) or `"completions"` (Chat Completions, default when `base_url` is set). |

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,6 +5,7 @@ use std::env::VarError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
     OpenRouter,
+    OrcaRouter,
     OpenAI,
     Anthropic,
     Gemini,
@@ -15,6 +16,7 @@ impl ProviderKind {
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_lowercase().as_str() {
             "openrouter" => Some(Self::OpenRouter),
+            "orcarouter" => Some(Self::OrcaRouter),
             "openai" | "custom" => Some(Self::OpenAI), // "custom" is an alias for OpenAI client
             "anthropic" => Some(Self::Anthropic),
             "gemini" | "google" => Some(Self::Gemini),
@@ -132,12 +134,14 @@ impl AuthResolver {
             ProviderKind::Gemini => "GEMINI_API_KEY",
             ProviderKind::Ollama => "OLLAMA_API_KEY",
             ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
+            ProviderKind::OrcaRouter => "ORCAROUTER_API_KEY",
         }
     }
 
     fn provider_slug(&self) -> &'static str {
         match self.provider_kind {
             ProviderKind::OpenRouter => "openrouter",
+            ProviderKind::OrcaRouter => "orcarouter",
             ProviderKind::OpenAI => "openai",
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::Gemini => "gemini",

--- a/src/extras/advisor/mod.rs
+++ b/src/extras/advisor/mod.rs
@@ -220,6 +220,7 @@ async fn run_advisor_completion(
 
     match model {
         AnyModel::OpenRouter(m, _) => advisor_call(m, prompt).await,
+        AnyModel::OrcaRouter(m, _) => advisor_call(m, prompt).await,
         AnyModel::OpenAI(m) => match m {
             OpenAiModel::Responses(m) => advisor_call(m, prompt).await,
             OpenAiModel::Completions(m) => advisor_call(m, prompt).await,

--- a/src/extras/subagents/builder.rs
+++ b/src/extras/subagents/builder.rs
@@ -105,6 +105,18 @@ pub(crate) async fn build_explore_agent(
             #[cfg(feature = "archmd")]
             arch_ref,
         )),
+        AnyModel::OrcaRouter(m, extra) => AnyAgent::OrcaRouter(build_explore_agent_inner(
+            m,
+            max_turns,
+            max_text_file_size,
+            max_read_lines,
+            max_grep_results,
+            max_find_results,
+            max_list_dir_entries,
+            extra,
+            #[cfg(feature = "archmd")]
+            arch_ref,
+        )),
         AnyModel::OpenAI(m) => AnyAgent::OpenAI(match m {
             OpenAiModel::Responses(m) => OpenAiAgent::Responses(build_explore_agent_inner(
                 m,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -56,7 +56,7 @@ pub fn resolve_provider_config(
     }
     let kind = ProviderKind::from_name(name).ok_or_else(|| {
         anyhow::anyhow!(
-            "Unknown provider: '{}'. Supported: openrouter, openai, anthropic, gemini, ollama. Run `zerostack --setup` to configure providers.",
+            "Unknown provider: '{}'. Supported: openrouter, orcarouter, openai, anthropic, gemini, ollama. Run `zerostack --setup` to configure providers.",
             name
         )
     })?;
@@ -108,6 +108,7 @@ pub(crate) fn default_model_for_provider(
         "openai" => "gpt-5.1",
         "gemini" | "google" => "gemini-2.5-pro",
         "openrouter" => "openrouter/auto", // OpenRouter's always-valid auto-router
+        "orcarouter" => "orcarouter/auto", // OrcaRouter's always-valid auto-router
         "ollama" => "llama3.1",
         _ => return None,
     };
@@ -157,6 +158,7 @@ pub enum OpenAiAgent {
 #[derive(Clone)]
 pub enum AnyClient {
     OpenRouter(openrouter::Client),
+    OrcaRouter(openrouter::Client),
     OpenAI(OpenAiClient),
     Anthropic(anthropic::Client),
     Gemini(gemini::Client),
@@ -210,6 +212,7 @@ impl AnyClient {
     pub fn provider_name(&self) -> &'static str {
         match self {
             AnyClient::OpenRouter(_) => "openrouter",
+            AnyClient::OrcaRouter(_) => "orcarouter",
             AnyClient::OpenAI(_) => "openai",
             AnyClient::Anthropic(_) => "anthropic",
             AnyClient::Gemini(_) => "gemini",
@@ -223,6 +226,12 @@ impl AnyClient {
             AnyClient::OpenRouter(c) => {
                 let extra = openrouter_anthropic_routing(&name);
                 AnyModel::OpenRouter(c.completion_model(name).with_prompt_caching(), extra)
+            }
+            AnyClient::OrcaRouter(c) => {
+                // OrcaRouter is an OpenRouter-compatible gateway, so the same
+                // Anthropic direct-route pinning applies for `anthropic/*` ids.
+                let extra = openrouter_anthropic_routing(&name);
+                AnyModel::OrcaRouter(c.completion_model(name).with_prompt_caching(), extra)
             }
             AnyClient::OpenAI(c) => AnyModel::OpenAI(c.completion_model(name)),
             AnyClient::Anthropic(c) => {
@@ -330,6 +339,7 @@ impl AnyClient {
             AnyClient::OpenAI(OpenAiClient::Responses(c)) => c.list_models().await?,
             AnyClient::Anthropic(c) => c.list_models().await?,
             AnyClient::OpenRouter(c) => c.list_models().await?,
+            AnyClient::OrcaRouter(c) => c.list_models().await?,
             AnyClient::Gemini(c) => c.list_models().await?,
             AnyClient::Ollama(c) => c.list_models().await?,
             // If any arm above does NOT impl ModelListingClient it won't compile —
@@ -438,10 +448,13 @@ pub async fn fetch_live_model_info(
         .resolve()
         .ok();
     let custom = custom_providers.get(provider_name);
-    let base = config
-        .base_url
-        .clone()
-        .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
+    let base = config.base_url.clone().unwrap_or_else(|| {
+        if provider_name == "orcarouter" {
+            "https://api.orcarouter.ai/v1".to_string()
+        } else {
+            "https://openrouter.ai/api/v1".to_string()
+        }
+    });
     let http = build_http_client(
         provider_name,
         config.danger_accept_invalid_certs,
@@ -520,6 +533,7 @@ pub(crate) fn parse_model_infos(
 async fn summarize_with_model(model: AnyModel, prompt: String) -> anyhow::Result<String> {
     match model {
         AnyModel::OpenRouter(m, _) => run_summarizer(m, prompt).await,
+        AnyModel::OrcaRouter(m, _) => run_summarizer(m, prompt).await,
         AnyModel::OpenAI(m) => match m {
             OpenAiModel::Responses(m) => run_summarizer(m, prompt).await,
             OpenAiModel::Completions(m) => run_summarizer(m, prompt).await,
@@ -607,6 +621,12 @@ pub enum AnyModel {
         openrouter::completion::CompletionModel,
         Option<serde_json::Value>,
     ),
+    /// OrcaRouter is an OpenRouter-compatible gateway, so the same
+    /// `provider.order` routing applies for `anthropic/*` model ids.
+    OrcaRouter(
+        openrouter::completion::CompletionModel,
+        Option<serde_json::Value>,
+    ),
     OpenAI(OpenAiModel),
     Anthropic(anthropic::completion::CompletionModel),
     Gemini(gemini::completion::CompletionModel),
@@ -616,6 +636,7 @@ pub enum AnyModel {
 #[derive(Clone)]
 pub enum AnyAgent {
     OpenRouter(Agent<openrouter::completion::CompletionModel>),
+    OrcaRouter(Agent<openrouter::completion::CompletionModel>),
     OpenAI(OpenAiAgent),
     Anthropic(Agent<anthropic::completion::CompletionModel>),
     Gemini(Agent<gemini::completion::CompletionModel>),
@@ -658,6 +679,18 @@ impl AnyAgent {
     ) -> anyhow::Result<runner::PrintOutcome> {
         match self {
             AnyAgent::OpenRouter(a) => {
+                runner::run_print(
+                    a,
+                    prompt,
+                    pure_stdout,
+                    retry_config,
+                    history,
+                    #[cfg(feature = "hooks")]
+                    loop_info,
+                )
+                .await
+            }
+            AnyAgent::OrcaRouter(a) => {
                 runner::run_print(
                     a,
                     prompt,
@@ -759,6 +792,9 @@ impl AnyAgent {
             AnyAgent::OpenRouter(a) => {
                 runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
             }
+            AnyAgent::OrcaRouter(a) => {
+                runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
+            }
             AnyAgent::OpenAI(a) => match a {
                 OpenAiAgent::Responses(a) => {
                     runner::run_subagent(a, prompt, max_turns, event_tx, retry_config).await
@@ -805,6 +841,14 @@ impl AnyAgent {
         };
         match self {
             AnyAgent::OpenRouter(a) => runner::spawn_agent(
+                a,
+                prompt,
+                history,
+                retry_config,
+                #[cfg(feature = "hooks")]
+                loop_info,
+            ),
+            AnyAgent::OrcaRouter(a) => runner::spawn_agent(
                 a,
                 prompt,
                 history,
@@ -876,6 +920,9 @@ impl AnyAgent {
     ) -> crate::agent::runner::BtwRunner {
         match self {
             AnyAgent::OpenRouter(a) => {
+                runner::spawn_btw(a, prompt, history, event_tx, id, retry_config)
+            }
+            AnyAgent::OrcaRouter(a) => {
                 runner::spawn_btw(a, prompt, history, event_tx, id, retry_config)
             }
             AnyAgent::OpenAI(a) => match a {
@@ -1071,6 +1118,7 @@ pub fn create_client(
         ProviderKind::Gemini => build_gemini_client(&key, base_url.as_deref()),
         ProviderKind::Ollama => build_ollama_client(&key, base_url.as_deref()),
         ProviderKind::OpenRouter => build_openrouter_client(&key, base_url.as_deref()),
+        ProviderKind::OrcaRouter => build_orcarouter_client(&key, base_url.as_deref()),
     }
 }
 
@@ -1115,6 +1163,17 @@ fn build_openrouter_client(key: &str, base_url: Option<&str>) -> anyhow::Result<
         .with_app_identity("zerostack", "https://github.com/gi-dellav/zerostack")
         .with_app_categories(&["cli-agent", "coding"]);
     Ok(AnyClient::OpenRouter(builder.build()?))
+}
+
+fn build_orcarouter_client(key: &str, base_url: Option<&str>) -> anyhow::Result<AnyClient> {
+    // OrcaRouter exposes an OpenRouter-compatible API at
+    // `https://api.orcarouter.ai/v1`, so we reuse rig's OpenRouter client type
+    // pointed at OrcaRouter's base URL (with the same `provider.order` body
+    // params and OpenRouter-style `/models` listing). We skip the
+    // OpenRouter-only app-identity headers, which OrcaRouter does not read.
+    let base = base_url.unwrap_or("https://api.orcarouter.ai/v1");
+    let builder = openrouter::Client::builder().api_key(key).base_url(base);
+    Ok(AnyClient::OrcaRouter(builder.build()?))
 }
 
 /// Builds an OpenAiModel (Responses / Completions) into the matching OpenAiAgent.
@@ -1186,6 +1245,23 @@ pub async fn build_agent(
 ) -> AnyAgent {
     match model {
         AnyModel::OpenRouter(m, routing) => AnyAgent::OpenRouter(
+            builder::build_agent_inner(
+                m,
+                cli,
+                cfg,
+                context,
+                permission,
+                ask_tx,
+                sandbox.clone(),
+                reasoning_enabled,
+                temperature,
+                merge_extra_body(routing, extra_body),
+                #[cfg(feature = "mcp")]
+                mcp_manager,
+            )
+            .await,
+        ),
+        AnyModel::OrcaRouter(m, routing) => AnyAgent::OrcaRouter(
             builder::build_agent_inner(
                 m,
                 cli,
@@ -1288,6 +1364,17 @@ pub fn build_btw_agent(
 ) -> AnyAgent {
     match model {
         AnyModel::OpenRouter(m, routing) => AnyAgent::OpenRouter(builder::build_btw_agent_inner(
+            m,
+            cli,
+            cfg,
+            context,
+            permission,
+            ask_tx,
+            reasoning_enabled,
+            temperature,
+            merge_extra_body(routing, extra_body),
+        )),
+        AnyModel::OrcaRouter(m, routing) => AnyAgent::OrcaRouter(builder::build_btw_agent_inner(
             m,
             cli,
             cfg,

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -156,12 +156,20 @@ struct Ctx {
 }
 
 fn builtin_provider_names() -> &'static [&'static str] {
-    &["openrouter", "openai", "anthropic", "gemini", "ollama"]
+    &[
+        "openrouter",
+        "orcarouter",
+        "openai",
+        "anthropic",
+        "gemini",
+        "ollama",
+    ]
 }
 
 fn provider_env_var(name: &str) -> &'static str {
     match name {
         "openrouter" => "OPENROUTER_API_KEY",
+        "orcarouter" => "ORCAROUTER_API_KEY",
         "openai" => "OPENAI_API_KEY",
         "anthropic" => "ANTHROPIC_API_KEY",
         "gemini" => "GEMINI_API_KEY",
@@ -1675,6 +1683,7 @@ fn apply_autoconfigure(cfg: &mut Config) {
         ("anthropic", "ANTHROPIC_API_KEY"),
         ("gemini", "GEMINI_API_KEY"),
         ("openrouter", "OPENROUTER_API_KEY"),
+        ("orcarouter", "ORCAROUTER_API_KEY"),
     ];
 
     for (provider, env_var) in providers_to_check {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -382,6 +382,7 @@ impl Startup {
         // built-in openrouter and to any custom provider exposing an
         // OpenRouter-style `GET {base_url}/models` (e.g. laroute).
         let live_info_provider = self.provider == "openrouter"
+            || self.provider == "orcarouter"
             || self
                 .cfg
                 .custom_providers_map()

--- a/src/tests/auth_tests.rs
+++ b/src/tests/auth_tests.rs
@@ -30,6 +30,16 @@ fn auth_resolver_returns_env_var_when_no_cli_key() {
 }
 
 #[test]
+fn auth_resolver_orcarouter_uses_own_env_var() {
+    let env = mock_env(vec![("ORCAROUTER_API_KEY", "orc-key-123")]);
+    let resolver = AuthResolver::new(ProviderKind::OrcaRouter)
+        .with_cli_key(None)
+        .with_config_keys(None);
+    let result = resolver.resolve_with_env(env).unwrap();
+    assert_eq!(result, "orc-key-123");
+}
+
+#[test]
 fn auth_resolver_returns_config_key_when_no_env() {
     let mut keys = HashMap::new();
     keys.insert("openai".to_string(), "config-key-789".to_string());
@@ -115,6 +125,10 @@ fn provider_kind_from_name_recognizes_all() {
     assert_eq!(
         ProviderKind::from_name("openrouter"),
         Some(ProviderKind::OpenRouter)
+    );
+    assert_eq!(
+        ProviderKind::from_name("orcarouter"),
+        Some(ProviderKind::OrcaRouter)
     );
     assert_eq!(
         ProviderKind::from_name("openai"),

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -216,6 +216,12 @@ fn resolve_builtin_openrouter() {
 }
 
 #[test]
+fn resolve_builtin_orcarouter() {
+    let cfg = resolve_provider_config("orcarouter", &HashMap::new()).unwrap();
+    assert_eq!(cfg.kind, ProviderKind::OrcaRouter);
+}
+
+#[test]
 fn resolve_unknown_provider_errors() {
     let result = resolve_provider_config("nonexistent_provider_xyz", &HashMap::new());
     assert!(result.is_err());

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -182,11 +182,17 @@ impl<'a> App<'a> {
         }
         input.set_quick_model_names(config::quick_models_map(ui.cfg).into_keys().collect());
         {
-            let mut providers: Vec<String> =
-                ["anthropic", "openai", "gemini", "openrouter", "ollama"]
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect();
+            let mut providers: Vec<String> = [
+                "anthropic",
+                "openai",
+                "gemini",
+                "openrouter",
+                "orcarouter",
+                "ollama",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
             providers.extend(ui.cfg.custom_providers_map().keys().cloned());
             input.set_provider_names(providers);
         }

--- a/src/ui/slash/providers.rs
+++ b/src/ui/slash/providers.rs
@@ -74,7 +74,7 @@ pub(crate) async fn fetch_models_cached(
     };
     models.retain(crate::provider::is_agent_model);
 
-    if provider == "openrouter" || is_custom {
+    if provider == "openrouter" || provider == "orcarouter" || is_custom {
         match crate::provider::fetch_live_model_info(
             provider,
             cli.api_key.as_deref(),
@@ -189,6 +189,7 @@ async fn apply_model(ctx: &mut SlashCtx<'_>, model_id: &str) {
         ctx.session.input_token_cost = input;
         ctx.session.output_token_cost = output;
     } else if (ctx.session.provider == "openrouter"
+        || ctx.session.provider == "orcarouter"
         || ctx
             .cfg
             .custom_providers_map()
@@ -289,6 +290,7 @@ async fn handle_model(parts: &[&str], ctx: &mut SlashCtx<'_>) -> anyhow::Result<
         ctx.session.input_token_cost = input;
         ctx.session.output_token_cost = output;
     } else if (ctx.session.provider == "openrouter"
+        || ctx.session.provider == "orcarouter"
         || ctx
             .cfg
             .custom_providers_map()


### PR DESCRIPTION
This PR makes [OrcaRouter](https://www.orcarouter.ai) selectable as a first-class provider in zerostack — the same way OpenRouter is today — so users of this minimal Rust coding agent can point `--provider orcarouter` at a single OpenAI-compatible gateway without hand-rolling a custom `base_url`. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means zerostack users get that whole stack directly, rather than treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The implementation mirrors zerostack's existing OpenRouter wiring exactly: a new `ProviderKind::OrcaRouter`, `AnyClient`/`AnyModel`/`AnyAgent` variants that reuse rig's OpenRouter client pointed at `https://api.orcarouter.ai/v1`, its own `ORCAROUTER_API_KEY` env var, `orcarouter/auto` as the default model, and the same OpenRouter-style live `/models` pricing/context discovery plus `provider.order` routing for `anthropic/*` ids. It's also wired into the `/provider` picker, the `--setup` TUI, `--provider`/`ZS_PROVIDER`, `custom_providers` `provider_type`, subagents, the advisor, and the docs. OrcaRouter's `/models` listing reports OpenRouter-style `pricing`/`context_length`, so cost tracking and the context meter work from the first turn.

Verified locally: `cargo fmt --check`, `cargo clippy --all-features` and `--no-default-features` with `-D warnings`, and the full test suite all pass (the two `shell_mode_tests` kill-behavior cases fail identically on `main` in a container without process-group semantics). I also ran a live one-shot through the new code path — `zerostack --provider orcarouter --model orcarouter/auto -p 'Reply with pong'` against a real `ORCAROUTER_API_KEY` — and got a `pong` reply.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
