### PR TITLE
Fix CPU=100% after quitting parent terminal

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -501,6 +501,15 @@ impl<'a> App<'a> {
                 _ = tokio::time::sleep(Duration::from_millis(100)), if self.run.is_running => {
                     self.refresh()?;
                 }
+                _ = tokio::time::sleep(Duration::from_millis(250)) => {
+                    // The event thread sets this to false when it exits
+                    // (e.g. stdin closed because the parent terminal quit).
+                    // Without this check the app would otherwise idle
+                    // forever with no way to receive input.
+                    if !self.running.load(Ordering::Relaxed) {
+                        return Ok(ControlFlow::Break(()));
+                    }
+                }
                 else => {
                     if let Some(rx) = self.prebuild_rx.as_mut()
                         && self.run.agent.is_none()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -261,7 +261,10 @@ pub(crate) fn spawn_event_thread(
         let mut paste_burst = PasteBurst::default();
         while running.load(Ordering::Relaxed) {
             let Ok(ready) = event::poll(paste_burst.wait_timeout()) else {
-                continue;
+                // Stdin is gone (e.g. the parent terminal quit) — poll()
+                // fails instantly and forever, so retrying here would busy
+                // spin at 100% CPU with no backoff.
+                break;
             };
             if !ready {
                 paste_burst.on_timeout();
@@ -337,6 +340,9 @@ pub(crate) fn spawn_event_thread(
                 Err(_) => break,
             }
         }
+        // Let the app loop know this thread is gone so it can shut down
+        // instead of idling forever with no input source.
+        running.store(false, Ordering::Relaxed);
     })
 }
 


### PR DESCRIPTION
Hi Giuseppe, I tried zerostack around v1.3.0, but after it started eating 100% when I quit Terminal.app, I patched it; but never sent a PR. Today I realized that v1.8.0 still suffers from the same problem, so asked Claude to send a PR.


To reproduce the problem, open Terminal.app and zerostack there, then close the Terminal.app and check CPU usage.

_below is AI-generated text_.

## Summary
- `spawn_event_thread`'s poll-error path retried in a tight loop with no backoff once stdin closed (e.g. the parent terminal quit), pinning a CPU core at 100%.
- The poll-error branch now breaks the thread instead of retrying, and sets the shared `running` flag to `false` on every exit path.
- `App::step`'s main select loop now watches `running` on a 250ms tick and shuts the app down once the event thread is gone, instead of idling forever with no input source.

This ports the fix originally landed against v1.3.0 (the pre-refactor `src/ui/mod.rs` event loop) onto the current `app.rs`/`mod.rs` split, where the same unhandled-poll-error pattern was still present.

## Test plan
- [x] `cargo check --all-features`
- [x] `cargo test --all-features ui::` (all passing)
- [ ] Manual: launch, close the parent terminal, confirm the orphaned process exits instead of spinning at 100% CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSMoyfrah7srH1CuatH73i