### PR TITLE
chore: refresh model catalog from models.dev

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -8,6 +8,13 @@
       "output_price": 50
     },
     {
+      "id": "claude-fable-5-1",
+      "name": "Claude Fable 5.1",
+      "context": 1000000,
+      "input_price": 10,
+      "output_price": 50
+    },
+    {
       "id": "claude-haiku-4-5",
       "name": "Claude Haiku 4.5 (latest)",
       "context": 200000,
@@ -293,8 +300,8 @@
       "id": "gpt-5.6",
       "name": "GPT-5.6",
       "context": 1050000,
-      "input_price": 5,
-      "output_price": 30
+      "input_price": 4,
+      "output_price": 20
     },
     {
       "id": "gpt-5.6-luna",
@@ -307,8 +314,8 @@
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",
       "context": 1050000,
-      "input_price": 5,
-      "output_price": 30
+      "input_price": 4,
+      "output_price": 20
     },
     {
       "id": "gpt-5.6-terra",
@@ -523,6 +530,13 @@
       "output_price": 3.75
     },
     {
+      "id": "gemini-3.8-flash",
+      "name": "Gemini 3.8 Flash",
+      "context": 1048576,
+      "input_price": 0.75,
+      "output_price": 3.75
+    },
+    {
       "id": "gemini-flash-latest",
       "name": "Gemini Flash Latest",
       "context": 1048576,
@@ -535,13 +549,6 @@
       "context": 1048576,
       "input_price": 0.3,
       "output_price": 2.5
-    },
-    {
-      "id": "gemini-robotics-er-1.6-preview",
-      "name": "Gemini Robotics-ER 1.6 Preview",
-      "context": 131072,
-      "input_price": 1,
-      "output_price": 5
     },
     {
       "id": "gemma-4-26b-a4b-it",
@@ -584,6 +591,11 @@
       "context": 1000000
     },
     {
+      "id": "anthropic/claude-fable-5.1",
+      "name": "Claude Fable 5.1",
+      "context": 1000000
+    },
+    {
       "id": "anthropic/claude-haiku-4.5",
       "name": "Claude Haiku 4.5 (latest)",
       "context": 200000
@@ -614,28 +626,13 @@
       "context": 1000000
     },
     {
-      "id": "anthropic/claude-opus-4.7-fast",
-      "name": "Claude Opus 4.7 (Fast)",
-      "context": 1000000
-    },
-    {
       "id": "anthropic/claude-opus-4.8",
       "name": "Claude Opus 4.8",
       "context": 1000000
     },
     {
-      "id": "anthropic/claude-opus-4.8-fast",
-      "name": "Claude Opus 4.8 (Fast)",
-      "context": 1000000
-    },
-    {
       "id": "anthropic/claude-opus-5",
       "name": "Claude Opus 5",
-      "context": 1000000
-    },
-    {
-      "id": "anthropic/claude-opus-5-fast",
-      "name": "Claude Opus 5 (Fast)",
       "context": 1000000
     },
     {
@@ -829,6 +826,11 @@
       "context": 1048576
     },
     {
+      "id": "google/gemini-3.8-flash",
+      "name": "Gemini 3.8 Flash",
+      "context": 1048576
+    },
+    {
       "id": "google/gemma-2-27b-it",
       "name": "Gemma 2 27B",
       "context": 8192
@@ -841,17 +843,12 @@
     {
       "id": "google/gemma-3-27b-it",
       "name": "Gemma 3 27B",
-      "context": 262144
+      "context": 131072
     },
     {
       "id": "google/gemma-3-4b-it",
       "name": "Gemma 3 4B",
       "context": 131072
-    },
-    {
-      "id": "google/gemma-3n-e4b-it",
-      "name": "Gemma 3n 4B",
-      "context": 32768
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -921,12 +918,17 @@
     {
       "id": "meta-llama/llama-guard-4-12b",
       "name": "Llama Guard 4 12B",
-      "context": 1048576
+      "context": 163840
     },
     {
       "id": "mistralai/codestral-2508",
       "name": "Codestral 2508",
       "context": 256000
+    },
+    {
+      "id": "mistralai/devstral-2512",
+      "name": "Devstral 2",
+      "context": 262144
     },
     {
       "id": "mistralai/ministral-14b-2512",
@@ -937,11 +939,6 @@
       "id": "mistralai/ministral-3b-2512",
       "name": "Ministral 3 3B 2512",
       "context": 131072
-    },
-    {
-      "id": "mistralai/ministral-8b",
-      "name": "Ministral 8B",
-      "context": 128000
     },
     {
       "id": "mistralai/ministral-8b-2512",
@@ -1016,7 +1013,7 @@
     {
       "id": "mistralai/voxtral-small-24b-2507",
       "name": "Voxtral Small 24B 2507",
-      "context": 32000
+      "context": 32768
     },
     {
       "id": "moonshotai/kimi-k2",
@@ -1359,11 +1356,6 @@
       "context": 1000000
     },
     {
-      "id": "qwen/qwen-plus-2025-07-28:thinking",
-      "name": "Qwen Plus 0728 (thinking)",
-      "context": 1000000
-    },
-    {
       "id": "qwen/qwen2.5-vl-72b-instruct",
       "name": "Qwen2.5 VL 72B Instruct",
       "context": 128000
@@ -1386,7 +1378,7 @@
     {
       "id": "qwen/qwen3-235b-a22b-thinking-2507",
       "name": "Qwen3 235B A22B Thinking 2507",
-      "context": 262144
+      "context": 131072
     },
     {
       "id": "qwen/qwen3-30b-a3b",
@@ -1584,6 +1576,11 @@
       "context": 1000000
     },
     {
+      "id": "qwen/qwen3.8-flash",
+      "name": "Qwen3.8 Flash",
+      "context": 1000000
+    },
+    {
       "id": "qwen/qwen3.8-max",
       "name": "Qwen3.8 Max",
       "context": 1000000
@@ -1681,7 +1678,12 @@
     {
       "id": "z-ai/glm-5.3",
       "name": "GLM-5.3",
-      "context": 1048576
+      "context": 1310720
+    },
+    {
+      "id": "z-ai/glm-5.3-flash",
+      "name": "GLM-5.3-Flash",
+      "context": 1310720
     },
     {
       "id": "z-ai/glm-5v-turbo",


### PR DESCRIPTION
Automated refresh of `data/models.json` from https://models.dev/api.json via `scripts/gen-models-catalog.sh`.

## Summary

| Provider | Models | Added | Removed | Changed |
|---|---|---|---|---|
| anthropic | 13 → 14 | 1 | 0 | 0 |
| gemini | 30 → 30 | 1 | 1 | 0 |
| openai | 38 → 38 | 0 | 0 | 2 |
| openrouter | 223 → 222 | 5 | 6 | 5 |

### anthropic

**Added**
- `claude-fable-5-1` (Claude Fable 5.1, context 1000000, in $10/M, out $50/M)

### gemini

**Added**
- `gemini-3.8-flash` (Gemini 3.8 Flash, context 1048576, in $0.75/M, out $3.75/M)

**Removed**
- `gemini-robotics-er-1.6-preview` (Gemini Robotics-ER 1.6 Preview, context 131072, in $1/M, out $5/M)

### openai

**Changed**
- `gpt-5.6`: input_price 5 → 4, output_price 30 → 20
- `gpt-5.6-sol`: input_price 5 → 4, output_price 30 → 20

### openrouter

**Added**
- `anthropic/claude-fable-5.1` (Claude Fable 5.1, context 1000000)
- `google/gemini-3.8-flash` (Gemini 3.8 Flash, context 1048576)
- `mistralai/devstral-2512` (Devstral 2, context 262144)
- `qwen/qwen3.8-flash` (Qwen3.8 Flash, context 1000000)
- `z-ai/glm-5.3-flash` (GLM-5.3-Flash, context 1310720)

**Removed**
- `anthropic/claude-opus-4.7-fast` (Claude Opus 4.7 (Fast), context 1000000)
- `anthropic/claude-opus-4.8-fast` (Claude Opus 4.8 (Fast), context 1000000)
- `anthropic/claude-opus-5-fast` (Claude Opus 5 (Fast), context 1000000)
- `google/gemma-3n-e4b-it` (Gemma 3n 4B, context 32768)
- `mistralai/ministral-8b` (Ministral 8B, context 128000)
- `qwen/qwen-plus-2025-07-28:thinking` (Qwen Plus 0728 (thinking), context 1000000)

**Changed**
- `google/gemma-3-27b-it`: context 262144 → 131072
- `meta-llama/llama-guard-4-12b`: context 1048576 → 163840
- `mistralai/voxtral-small-24b-2507`: context 32000 → 32768
- `qwen/qwen3-235b-a22b-thinking-2507`: context 262144 → 131072
- `z-ai/glm-5.3`: context 1048576 → 1310720

Review the diff for unexpected additions or removals before merging.
