### PR TITLE
fix(clippy): clear lint drift on main for the 1.96 toolchain

### DIFF
--- a/src/extras/hooks/trust.rs
+++ b/src/extras/hooks/trust.rs
@@ -95,8 +95,8 @@ pub(crate) fn confirm_untrusted_hook(description: &str) -> bool {
     matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
 }
 
-/// Async variant that runs `stdin.read_line` on the blocking pool so it does
-/// not stall the tokio async worker.
+// Async variant that runs `stdin.read_line` on the blocking pool so it does
+// not stall the tokio async worker.
 /*pub(crate) async fn confirm_untrusted_hook_async(description: String) -> bool {
     tokio::task::spawn_blocking(move || confirm_untrusted_hook(&description))
         .await

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1658,27 +1658,25 @@ fn handle_model_detail_key(ctx: &Ctx, key: KeyEvent) -> anyhow::Result<KeyResult
                     .map(|f| f.value.trim().to_string())
                     .unwrap_or_default();
 
-                let parse_cost = |label: &str, raw: &str| -> Result<f64, KeyResult> {
+                let parse_cost = |label: &str, raw: &str| -> Result<f64, String> {
                     if raw.is_empty() {
                         return Ok(0.0);
                     }
                     match raw.parse::<f64>() {
                         Ok(v) if v.is_finite() && v >= 0.0 => Ok(v),
-                        _ => Err(KeyResult::Screen(make_screen(
-                            fields.clone(),
-                            selected_field,
-                            None,
-                            Some(format!("{label} must be a non-negative number")),
-                        ))),
+                        _ => Err(format!("{label} must be a non-negative number")),
                     }
+                };
+                let cost_error = |msg: String| {
+                    KeyResult::Screen(make_screen(fields.clone(), selected_field, None, Some(msg)))
                 };
                 let new_input_cost = match parse_cost("Input Cost ($/M)", &new_input_cost) {
                     Ok(v) => v,
-                    Err(r) => return Ok(r),
+                    Err(msg) => return Ok(cost_error(msg)),
                 };
                 let new_output_cost = match parse_cost("Output Cost ($/M)", &new_output_cost) {
                     Ok(v) => v,
-                    Err(r) => return Ok(r),
+                    Err(msg) => return Ok(cost_error(msg)),
                 };
 
                 let new_context_window = if new_context_window_raw.is_empty() {


### PR DESCRIPTION
Both `clippy` legs in CI (`--all-features` and `--no-default-features`, Rust 1.96.0, `-D warnings`) have been red on every `main` commit since at least b9ea2da. This clears them.

Lints fixed:

- `result_large_err` at `src/setup/mod.rs:1661` (both legs): the `parse_cost` closure returned `Result<f64, KeyResult>`, whose largest variant is about 1.8 KB. The `Err` payload only ever carried a validation message, so the closure now returns `Result<f64, String>` and a small `cost_error` closure builds the `KeyResult::Screen` at the two call sites, matching how the rest of that handler reports field validation errors. No behavior change.
- `empty_line_after_doc_comments` at `src/extras/hooks/trust.rs:99` (`--all-features` leg): `confirm_untrusted_hook_async` was commented out earlier to silence a dead-code warning, which left its doc comment attached to the following `SourceConfig` struct; the orphaned doc comment is demoted to a plain comment and the parked helper is left in place.

Verified locally on 1.96.0:

- `cargo clippy --locked --all-features -- -D warnings`: clean
- `cargo clippy --locked --no-default-features -- -D warnings`: clean
- `cargo test`: 867 passed, 0 failed
- `cargo fmt --check` plus `cargo clippy --all-targets --all-features -- -D warnings`: clean

No other lints were red on `main` in these legs.

