### PR TITLE
fix(provider): keep the metadata deadline off completion streams

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -192,7 +192,7 @@ Accepted top-level keys:
 | `auto-update-prompts`     | boolean | When `true`, update prompt files that changed in the new version without asking. When `false`, never update. When unset, asks interactively. Nothing happens when the installed prompts already match the embedded defaults. |
 | `auto-update-themes`      | boolean | When `true`, update theme files that changed in the new version without asking. When `false`, never update. When unset, asks interactively. Nothing happens when the installed themes already match the embedded defaults. |
 | `edit_system`             | string  | Edit system mode: `"similarity"` (SEARCH/REPLACE with fuzzy matching, default) or `"hashedit"` (CRC-32 tag-based CAS edits). See Edit System Modes below.                     |
-| `custom_providers`        | object  | Map of provider aliases to `{ "provider_type", "base_url", "api_key_env", "api_style", "headers", "danger_accept_invalid_certs", "timeout_secs" }`. `provider_type` must resolve to a built-in provider type; `api_key_env` is optional. For OpenAI providers, `api_style` selects `"responses"` or `"completions"`, `headers` sets custom HTTP headers (values support `${ENV_VAR}` expansion), and `timeout_secs` overrides the HTTP timeout. `danger_accept_invalid_certs` disables TLS verification. See the OpenAI API styles section below. |
+| `custom_providers`        | object  | Map of provider aliases to `{ "provider_type", "base_url", "api_key_env", "api_style", "headers", "danger_accept_invalid_certs", "timeout_secs" }`. `provider_type` must resolve to a built-in provider type; `api_key_env` is optional. For OpenAI providers, `api_style` selects `"responses"` or `"completions"`, `headers` sets custom HTTP headers (values support `${ENV_VAR}` expansion), and `timeout_secs` sets a whole-request deadline (leave unset to let long streamed replies run). `danger_accept_invalid_certs` disables TLS verification. See the OpenAI API styles section below. |
 | `permission`              | object  | Permission rules using glob patterns; see the permission config notes below.                                |
 | `permission-regex`        | object  | Same structure as `permission` but patterns are interpreted as regex instead of glob.                       |
 | `permission-allow`        | object  | Map of tool names to lists of glob patterns to allow. Works alongside the `permission` field. See below.    |
@@ -566,8 +566,14 @@ config file:
 }
 ```
 
-The optional `timeout_secs` field overrides the default HTTP timeout for the
-provider. TLS certificate verification can be disabled with
+The optional `timeout_secs` field is a whole-request deadline in seconds, and
+it covers the streamed reply: a completion still running when it elapses is
+cut off. Leave it unset unless a gateway needs one. By default completion
+requests have no deadline beyond a 5s connect cap and fail only after 300s
+without a byte, while the `GET /models` requests zerostack issues itself (at
+startup and from `/provider`) are capped at 8s per attempt. Like `headers`,
+this applies to `provider_type: openai`; other provider types take rig's
+default client. TLS certificate verification can be disabled with
 `"danger_accept_invalid_certs": true` (for self-signed or internal-CA
 gateways) — use with care, as it makes the connection vulnerable to MITM.
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -66,7 +66,7 @@ the `custom_providers` key in the config file:
 | `api_style`                   | string  | Optional. For OpenAI-based providers: `"responses"` (Responses API, default when no `base_url` is set) or `"completions"` (Chat Completions, default when `base_url` is set). |
 | `headers`                     | object  | Optional. HTTP headers to include in every request. Values support `${ENV_VAR}` expansion.                                                                                    |
 | `danger_accept_invalid_certs` | boolean | Optional. Disables TLS certificate verification (MITM risk — use with care).                                                                                                  |
-| `timeout_secs`                | integer | Optional. Overrides the default HTTP timeout.                                                                                                                                 |
+| `timeout_secs`                | integer | Optional. Whole-request deadline in seconds; it covers the streamed reply, so leave it unset unless a gateway needs one. Unset: completions have no deadline (5s connect cap, request fails after 300s of silence) and `GET /models` requests are capped at 8s per attempt. Like `headers`, applies to `provider_type: openai` only. |
 | `model`                       | string  | Optional. Default model name for this provider. Used when no model is specified via `--model` or `ZS_MODEL`.                                                                  |
 
 ### Live context window and pricing

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -397,6 +397,7 @@ pub(crate) async fn fetch_custom_models_raw(
         config.danger_accept_invalid_certs,
         custom,
         Some(&base),
+        HttpPurpose::Metadata,
     )?;
     let url = format!("{}/models", base.trim_end_matches('/'));
     tracing::debug!("list_models_manual: GET {}", url);
@@ -467,6 +468,7 @@ pub async fn fetch_live_model_info(
         config.danger_accept_invalid_certs,
         custom,
         Some(&base),
+        HttpPurpose::Metadata,
     )?;
     let url = format!("{}/models", base.trim_end_matches('/'));
     let bearer = key
@@ -936,14 +938,52 @@ pub(crate) fn expand_env(value: &str) -> anyhow::Result<String> {
     }
 }
 
-/// Builds a shared reqwest client, combining:
-/// - `danger_accept_invalid_certs` (from #62; the TLS toggle shared by all providers)
-/// - a custom provider's `headers` (values support `${ENV_VAR}` expansion) and `timeout_secs`
-///
-/// When the provider is not custom (`custom == None`) and TLS is not disabled,
-/// the resulting client is equivalent to `reqwest::Client::default()`, so the
-/// behavior of existing providers is unchanged.
-static BUILTIN_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+/// What an HTTP client is for. The two kinds of traffic need opposite
+/// deadlines, so the purpose picks them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HttpPurpose {
+    /// Completion traffic handed to rig. A streamed reply legitimately runs
+    /// for minutes, so it gets no whole-request deadline; a total deadline
+    /// here cuts every reply longer than it mid-stream (reqwest reports that
+    /// as "error decoding response body"). Only silence is bounded: no bytes
+    /// for [`COMPLETION_IDLE_TIMEOUT`] fails the request as a timeout, which
+    /// the runner's retry recognises.
+    Completion,
+    /// Metadata requests zerostack issues itself (`GET /models` at startup
+    /// and from `/provider`), capped per attempt by
+    /// [`DEFAULT_METADATA_TIMEOUT`] so a stalled DNS, TLS handshake, or
+    /// server cannot hold the caller.
+    Metadata,
+}
+
+/// Connect-phase cap shared by every client.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Whole-request deadline for [`HttpPurpose::Metadata`] when the provider
+/// sets no `timeout_secs`.
+pub(crate) const DEFAULT_METADATA_TIMEOUT: Duration = Duration::from_secs(8);
+/// Idle cap for [`HttpPurpose::Completion`]: a stream that sends nothing for
+/// this long is dead. Long reasoning turns are silent for a while, so this is
+/// generous; it matches the stream idle timeout the Codex CLI uses.
+const COMPLETION_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Whole-request deadline to apply, if any: an explicit `timeout_secs` wins
+/// for both purposes; otherwise metadata requests get
+/// [`DEFAULT_METADATA_TIMEOUT`] and completions get none (their connect
+/// phase is still capped by `connect_timeout`).
+pub(crate) fn http_total_timeout(
+    purpose: HttpPurpose,
+    custom: Option<&CustomProviderConfig>,
+) -> Option<Duration> {
+    match (purpose, custom.and_then(|c| c.timeout_secs)) {
+        (_, Some(secs)) => Some(Duration::from_secs(secs)),
+        (HttpPurpose::Metadata, None) => Some(DEFAULT_METADATA_TIMEOUT),
+        (HttpPurpose::Completion, None) => None,
+    }
+}
+
+/// Builder with the defaults every provider client shares: user agent,
+/// keepalive, pool sizing, and the connect cap.
+fn base_client_builder() -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .user_agent(format!(
             "zerostack/{} (https://github.com/gi-dellav/zerostack)",
@@ -952,32 +992,63 @@ static BUILTIN_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::La
         .tcp_keepalive(Duration::from_secs(30))
         .pool_idle_timeout(Duration::from_secs(90))
         .pool_max_idle_per_host(8)
-        .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(8))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
-});
+        .connect_timeout(CONNECT_TIMEOUT)
+}
 
+/// Apply the settings that differ by purpose: the whole-request deadline
+/// from [`http_total_timeout`], and the idle cap on completion streams.
+fn apply_purpose(
+    builder: reqwest::ClientBuilder,
+    purpose: HttpPurpose,
+    custom: Option<&CustomProviderConfig>,
+) -> reqwest::ClientBuilder {
+    let builder = match http_total_timeout(purpose, custom) {
+        Some(deadline) => builder.timeout(deadline),
+        None => builder,
+    };
+    match purpose {
+        HttpPurpose::Completion => builder.read_timeout(COMPLETION_IDLE_TIMEOUT),
+        HttpPurpose::Metadata => builder,
+    }
+}
+
+/// Shared pooled clients for built-in providers with default settings, one
+/// per purpose so the metadata deadline never reaches completion streams.
+static BUILTIN_COMPLETION_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(|| {
+        apply_purpose(base_client_builder(), HttpPurpose::Completion, None)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    });
+
+static BUILTIN_METADATA_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(|| {
+        apply_purpose(base_client_builder(), HttpPurpose::Metadata, None)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    });
+
+/// Builds a reqwest client for `purpose`, combining:
+/// - `danger_accept_invalid_certs` (from #62; the TLS toggle shared by all providers)
+/// - a custom provider's `headers` (values support `${ENV_VAR}` expansion) and `timeout_secs`
+/// - the per-purpose deadline from [`http_total_timeout`]
+///
+/// Built-in providers with default settings share one pooled client per
+/// purpose instead of opening a new connection pool per request.
 pub(crate) fn build_http_client(
     provider_name: &str,
     danger_accept_invalid_certs: bool,
     custom: Option<&CustomProviderConfig>,
     base_url: Option<&str>,
+    purpose: HttpPurpose,
 ) -> anyhow::Result<reqwest::Client> {
-    // Fast path: built-in providers with default settings reuse a single
-    // pooled client — avoids creating a new connection pool per request.
     if custom.is_none() && !danger_accept_invalid_certs && !is_localhost(base_url) {
-        return Ok(BUILTIN_HTTP_CLIENT.clone());
+        return Ok(match purpose {
+            HttpPurpose::Completion => BUILTIN_COMPLETION_CLIENT.clone(),
+            HttpPurpose::Metadata => BUILTIN_METADATA_CLIENT.clone(),
+        });
     }
-    let mut builder = reqwest::Client::builder()
-        .user_agent(format!(
-            "zerostack/{} (https://github.com/gi-dellav/zerostack)",
-            env!("CARGO_PKG_VERSION")
-        ))
-        .tcp_keepalive(Duration::from_secs(30))
-        .pool_idle_timeout(Duration::from_secs(90))
-        .pool_max_idle_per_host(8)
-        .connect_timeout(Duration::from_secs(5));
+    let mut builder = base_client_builder();
     if is_localhost(base_url) {
         // Disable connection pooling for local LLM servers (notably
         // llama.cpp's cpp-httplib) which close idle keep-alive
@@ -986,31 +1057,19 @@ pub(crate) fn build_http_client(
         builder = builder.pool_max_idle_per_host(0);
     }
 
-    if let Some(cfg) = custom {
-        if !cfg.headers.is_empty() {
-            let mut headers = HeaderMap::new();
-            for (name, raw_value) in &cfg.headers {
-                let value = expand_env(raw_value)?;
-                let header_name = HeaderName::from_bytes(name.as_bytes())
-                    .map_err(|e| anyhow::anyhow!("Invalid header name '{name}': {e}"))?;
-                let header_value = HeaderValue::from_str(&value)
-                    .map_err(|e| anyhow::anyhow!("Invalid value for header '{name}': {e}"))?;
-                headers.insert(header_name, header_value);
-            }
-            builder = builder.default_headers(headers);
+    if let Some(cfg) = custom.filter(|cfg| !cfg.headers.is_empty()) {
+        let mut headers = HeaderMap::new();
+        for (name, raw_value) in &cfg.headers {
+            let value = expand_env(raw_value)?;
+            let header_name = HeaderName::from_bytes(name.as_bytes())
+                .map_err(|e| anyhow::anyhow!("Invalid header name '{name}': {e}"))?;
+            let header_value = HeaderValue::from_str(&value)
+                .map_err(|e| anyhow::anyhow!("Invalid value for header '{name}': {e}"))?;
+            headers.insert(header_name, header_value);
         }
-        if let Some(secs) = cfg.timeout_secs {
-            builder = builder.timeout(Duration::from_secs(secs));
-        } else {
-            // Custom provider without explicit timeout: apply a sane default so
-            // startup network stalls don't hang indefinitely.
-            builder = builder.timeout(Duration::from_secs(8));
-        }
-    } else {
-        // Built-in providers (e.g. openrouter) had no timeout at all — a
-        // stalled DNS/TLS could block startup for 30s+. Cap it.
-        builder = builder.timeout(Duration::from_secs(8));
+        builder = builder.default_headers(headers);
     }
+    builder = apply_purpose(builder, purpose, custom);
 
     if danger_accept_invalid_certs {
         tracing::warn!(
@@ -1180,6 +1239,7 @@ pub fn create_client(
                 config.danger_accept_invalid_certs,
                 custom,
                 base_url.as_deref(),
+                HttpPurpose::Completion,
             )?;
             Ok(AnyClient::OpenAI(build_openai_client(
                 &key,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -425,9 +425,9 @@ impl Startup {
         // OpenRouter-style `GET {base_url}/models` (e.g. laroute).
         // Bounded by a 5s timeout so a slow DNS/TLS does not stall startup;
         // the baked catalog (models_catalog) is the fallback and the TUI
-        // remains interactive. The HTTP client itself also has an 8s per-request
-        // timeout (provider::build_http_client), but the outer timeout caps
-        // the whole fetch tightly.
+        // remains interactive. The metadata client itself carries an 8s
+        // per-attempt deadline (provider::HttpPurpose::Metadata), but the
+        // outer timeout caps the whole fetch tightly.
         let live_info_provider = self.provider == "openrouter"
             || self
                 .cfg

--- a/src/tests/provider_tests.rs
+++ b/src/tests/provider_tests.rs
@@ -2,9 +2,9 @@ use crate::auth::ProviderKind;
 use crate::config::{ApiStyle, CustomProviderConfig};
 use crate::provider::ModelEntry;
 use crate::provider::{
-    AnyClient, create_client, expand_env, is_agent_model, merge_extra_body,
-    openrouter_anthropic_routing, resolve_api_style, resolve_provider_config,
-    serialize_conversation,
+    AnyClient, DEFAULT_METADATA_TIMEOUT, HttpPurpose, build_http_client, create_client, expand_env,
+    http_total_timeout, is_agent_model, merge_extra_body, openrouter_anthropic_routing,
+    resolve_api_style, resolve_provider_config, serialize_conversation,
 };
 use crate::session::{MessageRole, SessionMessage};
 use compact_str::CompactString;
@@ -242,6 +242,23 @@ fn resolve_custom_provider() {
     assert_eq!(cfg.base_url.as_deref(), Some("https://mygw.example/v1"));
 }
 
+/// Read one HTTP request head (through the blank line) off `stream`.
+/// Returns `None` on a read error or EOF before the head is complete.
+fn read_request_head(stream: &mut std::net::TcpStream) -> Option<Vec<u8>> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        let count = stream.read(&mut buffer).ok()?;
+        if count == 0 {
+            return None;
+        }
+        request.extend_from_slice(&buffer[..count]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            return Some(request);
+        }
+    }
+}
+
 #[tokio::test]
 async fn anthropic_custom_base_appends_v1_messages() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -253,18 +270,7 @@ async fn anthropic_custom_base_appends_v1_messages() {
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
 
-        let mut request = Vec::new();
-        let mut buffer = [0_u8; 4096];
-        loop {
-            let count = stream.read(&mut buffer).unwrap();
-            if count == 0 {
-                break;
-            }
-            request.extend_from_slice(&buffer[..count]);
-            if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                break;
-            }
-        }
+        let request = read_request_head(&mut stream).expect("request head");
 
         let request_line = String::from_utf8_lossy(&request)
             .lines()
@@ -465,4 +471,113 @@ fn manual_models_pick_up_context_length_when_reported() {
     assert_eq!(models[0].context_length, Some(1_048_576));
     assert_eq!(models[1].id, "plain-model");
     assert_eq!(models[1].context_length, None);
+}
+
+// ── HTTP client deadlines ────────────────────────────────────────────────────
+
+#[test]
+fn completion_client_has_no_default_deadline() {
+    assert_eq!(http_total_timeout(HttpPurpose::Completion, None), None);
+    let custom = cfg(None);
+    assert_eq!(
+        http_total_timeout(HttpPurpose::Completion, Some(&custom)),
+        None
+    );
+}
+
+#[test]
+fn metadata_client_defaults_to_the_metadata_deadline() {
+    assert_eq!(
+        http_total_timeout(HttpPurpose::Metadata, None),
+        Some(DEFAULT_METADATA_TIMEOUT)
+    );
+    let custom = cfg(None);
+    assert_eq!(
+        http_total_timeout(HttpPurpose::Metadata, Some(&custom)),
+        Some(DEFAULT_METADATA_TIMEOUT)
+    );
+}
+
+#[test]
+fn explicit_timeout_secs_applies_to_both_purposes() {
+    let mut custom = cfg(None);
+    custom.timeout_secs = Some(42);
+    for purpose in [HttpPurpose::Completion, HttpPurpose::Metadata] {
+        assert_eq!(
+            http_total_timeout(purpose, Some(&custom)),
+            Some(Duration::from_secs(42))
+        );
+    }
+}
+
+/// Serve `chunks` chunked-body frames one second apart on a fresh port, for
+/// as many connections as arrive. Returns the base URL. The accept loop lives
+/// as long as the test binary; that is fine for a loopback stub.
+fn spawn_slow_stream_server(chunks: u64) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            std::thread::spawn(move || {
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                if read_request_head(&mut stream).is_none() {
+                    return;
+                }
+                if stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                          Transfer-Encoding: chunked\r\n\r\n",
+                    )
+                    .is_err()
+                {
+                    return;
+                }
+                for index in 0..chunks {
+                    let frame = format!("data: tok{index}\n\n");
+                    let chunk = format!("{:x}\r\n{frame}\r\n", frame.len());
+                    // The metadata client hangs up at its deadline; a write
+                    // error there is the expected outcome, not a failure.
+                    if stream.write_all(chunk.as_bytes()).is_err() || stream.flush().is_err() {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+                let _ = stream.write_all(b"0\r\n\r\n");
+            });
+        }
+    });
+    format!("http://{address}")
+}
+
+/// Regression for the whole-request deadline that used to sit on the
+/// completion client: a reply streaming longer than it died mid-stream as
+/// "error decoding response body". Both clients come from the pooled
+/// built-in path (`custom == None`, no base URL), the path the bug was on.
+/// The stream outlasts the metadata deadline by one second, so bumping the
+/// constant keeps the boundary. The sleeps overlap with the rest of the suite.
+#[tokio::test]
+async fn completion_client_survives_stream_longer_than_metadata_deadline() {
+    let base = spawn_slow_stream_server(DEFAULT_METADATA_TIMEOUT.as_secs() + 1);
+    let completion = build_http_client("slow", false, None, None, HttpPurpose::Completion).unwrap();
+    let metadata = build_http_client("slow", false, None, None, HttpPurpose::Metadata).unwrap();
+
+    let (streamed, fetched) = tokio::join!(
+        async { completion.get(&base).send().await.unwrap().text().await },
+        async { metadata.get(&base).send().await.unwrap().text().await },
+    );
+
+    let body = streamed.expect("completion client must read the whole slow stream");
+    assert_eq!(
+        body.matches("data: tok").count() as u64,
+        DEFAULT_METADATA_TIMEOUT.as_secs() + 1
+    );
+
+    // Users saw reqwest render this as "error decoding response body"; the
+    // wording is reqwest's, so only the timeout classification is asserted.
+    let err = fetched.expect_err("metadata client must give up at its deadline");
+    assert!(
+        err.is_timeout(),
+        "metadata error should be a timeout: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

`build_http_client` put one 8s whole-request timeout on every client it built, and reqwest's timeout covers the response body. Any OpenAI or OpenAI-compatible reply that streamed for longer than 8s was cut mid-stream and surfaced as `Http client error: error decoding response body`. This splits the client by purpose: metadata requests (`GET /models`) keep the 8s deadline, completion streams get none.

## Motivation

Since b38a125 and f5955d1 (2026-09-03), `--provider openai` and every custom provider without an explicit `timeout_secs` fail on any answer longer than 8s of streaming. That covers most agentic turns and every local llama.cpp or similar slow backend. The other built-in providers were unaffected only because `build_provider_client!` never hands them a custom client, so the deadline never reached them. The 8s cap was added for the startup `/models` fetch (the comment says "a stalled DNS/TLS could block startup for 30s+"), but the completion client rig uses came from the same builder.

Reproduced against a loopback mock that streams one token per second for 12s: with the default config zerostack hangs up at exactly 8s and prints the error above; with `timeout_secs: 60` the same stream completes.

## Design decisions

**Why an `HttpPurpose` enum and two pooled clients instead of a per-request `.timeout()` on the two `/models` call sites.** The deadline decision reads the provider's `timeout_secs`, so it belongs next to the config in one function (`http_total_timeout`) rather than at each metadata call site. The two clients also differ in more than the deadline: completion clients carry a 300s idle `read_timeout` that a one-shot metadata request has no use for. The cost is a second idle pool for built-in providers, bounded at 8 sockets per host and used a handful of times per session.

**Why completion clients get a `read_timeout` rather than nothing.** Only the connect phase was capped after removing the total deadline, so a gateway that accepts the connection and then goes silent would pin a headless `-p` or `--loop` run forever, and the runner's retry keys on a timeout error that would never arrive. A 300s idle cap fails only a stream that has sent nothing for five minutes, which leaves room for long silent reasoning turns; it is the same stream idle timeout the Codex CLI uses. Applying it as an idle cap instead of a total deadline is the whole point: a long reply that keeps sending bytes never trips it.

**Why an explicit `timeout_secs` still applies to completions.** That is not a change: an explicit `timeout_secs` has reached the completion client since the field was added in May. Only the default changed, from 8s to none. Keeping the explicit value a whole-request deadline preserves what current configs do; the docs now say what it bounds so nobody sets a small value expecting it to affect only startup. A purpose-specific key (`completion_timeout_secs`) can follow if someone needs a different completion deadline than metadata deadline.

## Testing

- `completion_client_survives_stream_longer_than_metadata_deadline`: a loopback server streams a chunked body one second per frame for one second longer than the metadata deadline. Both clients come from the pooled built-in path (`custom == None`, no base URL), the path the bug was on. The completion client reads every frame; the metadata client fails with a timeout. The chunk count derives from the constant, so bumping the deadline keeps the boundary. The sleep overlaps with the rest of the suite, so the suite's wall-clock barely moves.
- Three unit tests pin the decision table in `http_total_timeout`: completion has no default deadline, metadata defaults to the constant, an explicit `timeout_secs` applies to both.
- Live: a rebuilt binary against the slow mock (custom provider, no `timeout_secs`) now receives all 12 tokens over 13s with no hang-up on the server side; the same scenario on main hangs up at 8s.
- `cargo test`: 939 passed. `cargo fmt --check` clean. `cargo clippy --all-targets --all-features -- -D warnings` is clean for the changed files; see Notes for the pre-existing red.
- vibe-diff: not run
- cross-check: not run
- verify: not run

## Reviewing

Size, added/removed lines: logic 111/51 (`src/provider.rs` 108/48, `src/startup.rs` 3/3), tests 130/15 (`src/tests/provider_tests.rs`), docs 10/4. About half the logic delta is doc comments on the enum, constants, and helpers.

Start with `HttpPurpose` and `http_total_timeout` in `src/provider.rs`: the enum's doc comments and that one match arm are the whole decision. Then `apply_purpose` and the two statics, which are the only places the decision is applied. The three call sites of `build_http_client` just name their purpose. Everything else is mechanical: the header block in `build_http_client` is the original code with one less nesting level, `src/startup.rs` is a comment, and the docs rows describe the new default. The tests file adds a shared `read_request_head` helper that the existing loopback test now also uses.

## Notes

- `cargo clippy --all-targets --all-features -- -D warnings` on current main is already red in `src/ui/pickers/switcher.rs` (two redundant guards) and `src/tests/worktree_tests.rs` (collapsible if), and `--no-default-features --all-targets` fails to compile `src/tests/cli_custom_flags_tests.rs`. None of that is touched here, and it is why this PR's CI shows the same six red jobs as main at 2820e6e (both clippy legs, the `--no-default-features` test on ubuntu, and the three macOS test legs, where `worktree_tests` also trips on `/private/var` vs `/var` path canonicalisation). The two ubuntu test jobs that compile pass, and the new regression test passes on every leg that builds, macOS included. Happy to send a separate lint-drift fix like #272.
- Pre-existing and left alone: `timeout_secs: 0` is not rejected anywhere, and custom providers whose `provider_type` is not `openai` never receive the custom client, so `headers`, `danger_accept_invalid_certs` and `timeout_secs` are silently ignored for them. The docs now say the HTTP options apply to `provider_type: openai`.
- The startup fetch is wrapped in an outer 5s `tokio::time::timeout`, so the 8s client deadline matters mostly for the `/provider` slash-command paths, where `get_bytes_with_retry` may take up to three attempts; the deadline is per attempt.
