### PR TITLE
fix(ci): turn the six red jobs on main green

### DIFF
--- a/src/tests/cli_custom_flags_tests.rs
+++ b/src/tests/cli_custom_flags_tests.rs
@@ -2,6 +2,7 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(feature = "mcp")]
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -25,6 +26,7 @@ fn acquire_env() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(|e| e.into_inner())
 }
 
+#[cfg(feature = "mcp")]
 fn mcp_map(
     cfg: &crate::config::Config,
 ) -> &HashMap<String, crate::extras::mcp::config::McpServerConfig> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -147,6 +147,8 @@ mod worktree_tests;
 /// expectation. Declared here (rather than per-file) so every such test
 /// shares one lock.
 ///
+/// Acquiring also repairs a deleted cwd: see [`acquire_cwd`].
+///
 /// NOTE: this deliberately does NOT cover the TUI loop tests
 /// (`tui_loop_tests`, `headless_*`, `parallel_tool_call_tests`):
 /// those never chdir, so they don't need it.
@@ -155,8 +157,17 @@ static CWD_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock
 
 #[cfg(test)]
 pub(crate) fn acquire_cwd() -> std::sync::MutexGuard<'static, ()> {
-    CWD_LOCK
+    let lock = CWD_LOCK
         .get_or_init(|| std::sync::Mutex::new(()))
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(|e| e.into_inner());
+    // A previous holder may have left the process in a directory it then
+    // deleted (a TempRepo dropped before its restore ran, or the binary was
+    // started from one). Park in a directory that exists so child
+    // processes such as `git` can read their cwd. Not restored: the next
+    // holder that cares chdirs to where it wants to be anyway.
+    if std::env::current_dir().is_err() {
+        let _ = std::env::set_current_dir(std::env::temp_dir());
+    }
+    lock
 }

--- a/src/tests/worktree_tests.rs
+++ b/src/tests/worktree_tests.rs
@@ -98,35 +98,34 @@ mod tests {
                 .arg(&self.root)
                 .args(["worktree", "list", "--porcelain"])
                 .output()
+                && out.status.success()
             {
-                if out.status.success() {
-                    let stdout = String::from_utf8_lossy(&out.stdout);
-                    let paths: Vec<String> = stdout
-                        .lines()
-                        .filter_map(|l| l.strip_prefix("worktree "))
-                        .map(|p| p.trim().to_string())
-                        .filter(|p| {
-                            std::path::Path::new(p) != self.root
-                                && std::path::Path::new(p).starts_with(
-                                    self.root.parent().unwrap_or(std::path::Path::new("/tmp")),
-                                )
-                        })
-                        .collect();
-                    for p in &paths {
-                        let _ = Command::new("git")
-                            .arg("-C")
-                            .arg(&self.root)
-                            .args(["worktree", "remove", "--force", p])
-                            .output();
-                        // The dir may survive a stale admin entry; remove it.
-                        let _ = std::fs::remove_dir_all(p);
-                    }
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let paths: Vec<String> = stdout
+                    .lines()
+                    .filter_map(|l| l.strip_prefix("worktree "))
+                    .map(|p| p.trim().to_string())
+                    .filter(|p| {
+                        std::path::Path::new(p) != self.root
+                            && std::path::Path::new(p).starts_with(
+                                self.root.parent().unwrap_or(std::path::Path::new("/tmp")),
+                            )
+                    })
+                    .collect();
+                for p in &paths {
                     let _ = Command::new("git")
                         .arg("-C")
                         .arg(&self.root)
-                        .args(["worktree", "prune"])
+                        .args(["worktree", "remove", "--force", p])
                         .output();
+                    // The dir may survive a stale admin entry; remove it.
+                    let _ = std::fs::remove_dir_all(p);
                 }
+                let _ = Command::new("git")
+                    .arg("-C")
+                    .arg(&self.root)
+                    .args(["worktree", "prune"])
+                    .output();
             }
             let _ = std::env::set_current_dir(&self.orig);
             let _ = std::fs::remove_dir_all(&self.root);

--- a/src/tests/worktree_tests.rs
+++ b/src/tests/worktree_tests.rs
@@ -407,6 +407,7 @@ mod tests {
 
     #[test]
     fn test_validate_branch_name_ok() {
+        let _lock = acquire_cwd();
         assert!(validate_branch_name("feature-x").is_ok());
         assert!(validate_branch_name("wt-123-456").is_ok());
         assert!(validate_branch_name("a").is_ok());
@@ -414,6 +415,7 @@ mod tests {
 
     #[test]
     fn test_validate_branch_name_rejects() {
+        let _lock = acquire_cwd();
         for bad in [
             "",
             "has space",
@@ -441,6 +443,7 @@ mod tests {
 
     #[test]
     fn test_validate_branch_name_whitespace_variants() {
+        let _lock = acquire_cwd();
         assert!(validate_branch_name("a\tb").is_err());
         assert!(validate_branch_name("a\nb").is_err());
         assert!(validate_branch_name(" a").is_err());

--- a/src/tests/worktree_tests.rs
+++ b/src/tests/worktree_tests.rs
@@ -67,7 +67,15 @@ mod tests {
             });
             let root = unique_dir(tag);
             let _ = std::fs::remove_dir_all(&root);
-            std::fs::create_dir_all(&root).unwrap();
+            // create_dir, not create_dir_all: the name is predictable in a
+            // shared temp dir, and the root is canonicalised below, after
+            // which Drop's remove_dir_all would follow a planted symlink.
+            // Failing on an existing entry closes that.
+            std::fs::create_dir(&root).unwrap();
+            // Canonical so comparisons against paths the code under test
+            // returns (it canonicalises via `absolutize`) hold on macOS,
+            // where `temp_dir()` is `/var/...` but resolves to `/private/var/...`.
+            let root = root.canonicalize().unwrap();
             // `git -C` (not CWD-relative): the process may currently sit in
             // a directory owned by another in-flight test.
             run(&root, &["init", "-b", branch]);
@@ -575,10 +583,7 @@ mod tests {
         assert!(repo.root.join("new.txt").exists());
         assert!(!info.worktree_path.exists());
         assert!(!branch_exists(&repo.root, &info.branch));
-        assert_eq!(
-            std::env::current_dir().unwrap(),
-            repo.root.canonicalize().unwrap()
-        );
+        assert_eq!(std::env::current_dir().unwrap(), repo.root);
     }
 
     #[test]

--- a/src/ui/pickers/switcher.rs
+++ b/src/ui/pickers/switcher.rs
@@ -259,7 +259,7 @@ impl ModelSwitcher {
             return true;
         }
         match key.code {
-            KeyCode::Char(c) if c == '\x08' => {
+            KeyCode::Char('\x08') => {
                 self.backspace();
             }
             KeyCode::Char(c) => {
@@ -483,7 +483,7 @@ impl PromptSwitcher {
             return true;
         }
         match key.code {
-            KeyCode::Char(c) if c == '\x08' => {
+            KeyCode::Char('\x08') => {
                 self.backspace();
             }
             KeyCode::Char(c) => {


### PR DESCRIPTION
## Summary

Main has been red on six CI jobs since 2820e6e: both clippy legs, the `--no-default-features` test job on ubuntu, and all three macOS test jobs. Four small commits, one per cause, turn them green. The only production change is two match arms rewritten the way clippy asked.

## Motivation

The CI workflow runs `cargo clippy -- -D warnings` on two feature sets and `cargo test` on a 2 OS x 3 feature matrix, so drift now blocks every PR, including ones that do not touch the affected files (#277 shows the same six red jobs as main). Each failure has a distinct cause:

- `redundant_guard` twice in `src/ui/pickers/switcher.rs` fails both clippy legs under `-D warnings`. The `collapsible_if` in `src/tests/worktree_tests.rs` is fixed in the same commit; it only trips the repo's own `just check` (`--all-targets`), not CI, which lints no test targets. That mismatch is why test-side lint drift keeps landing on main unnoticed.
- `src/tests/cli_custom_flags_tests.rs` gated its tests behind `feature = "mcp"` but not the `mcp_map` helper or its `HashMap` import, so the test binary does not compile without the feature (`extras::mcp` and `Config::mcp_servers` do not exist there).
- On macOS, `std::env::temp_dir()` is `/var/folders/...`, which resolves to `/private/var/folders/...`. `create()` and `main_repo_path()` canonicalise their results through `absolutize()`, the test fixture built its root from `temp_dir()` as is, and two equality assertions compared the two spellings.
- `test_validate_branch_name_ok` calls `validate_branch_name`, which shells out to `git check-ref-format --branch`. git reads the process cwd, the test held no cwd lock, and sibling tests in the same binary chdir into temp repos that are deleted on Drop. A run that lands in the gap between the delete and the restore sees `fatal: Unable to read current working directory` and reports the name invalid. macOS runners hit that gap every time; Linux runners have so far been lucky.

## Design decisions

**Why canonicalise the fixture root instead of relaxing the assertions.** The code under test already commits to canonical paths (`absolutize` ends in `canonicalize`), and one test in the same file already compared against `repo.root.canonicalize()`. Making the fixture canonical from the start gives every assertion the same spelling the code returns. It also un-breaks the fixture's own cleanup on macOS: `git worktree list --porcelain` prints resolved paths, so the Drop filter that matches worktrees under the fixture root compared `/private/var/...` against `/var/...` and removed nothing there. Because the root is canonical before Drop's `remove_dir_all`, the fixture now creates it with `create_dir` rather than `create_dir_all`: the name is predictable in a shared temp dir, and failing on an existing entry means a planted symlink can never be followed into a recursive delete.

**Why the cwd repair lives in `acquire_cwd` rather than in the one test.** `git check-ref-format` needs no repository, but it does need a readable cwd. The lock in `src/tests/mod.rs` already documents that a previous holder can leave the process in a deleted directory, so the repair (park in `temp_dir()` when `current_dir()` fails) belongs there, where every suite that takes the lock benefits. The validate tests now simply take the lock, like the other worktree tests.

**Why a test-side fix rather than making `validate_branch_name` cwd-independent.** Its only production caller is `create`, which immediately calls the cwd-dependent `main_repo_path()`, so hardening `validate_branch_name` alone buys nothing outside the test binary. Only `test_validate_branch_name_ok` could go red from the race; `test_validate_branch_name_rejects` passed vacuously when git failed, since `Err` was the expected outcome, so eleven of its cases were untested whenever the race hit. Both take the lock now, and so does the whitespace-variants test, whose cases short-circuit before git today but would not with one more case.

**Why one commit per cause.** Each fix is independently revertable and reviewable, and the commit messages carry the diagnosis so the reasoning survives the merge.

## Testing

- Both macOS failures reproduced on Linux before the fix and pass after it. The symlink case: `TMPDIR` pointed at a symlink to a real directory makes `temp_dir()` and `canonicalize()` disagree exactly as on macOS; `cargo test worktree_tests` fails the two round-trip tests before and passes all 49 after. The cwd case: the test binary started from a directory deleted immediately after `cd` fails `test_validate_branch_name_ok` before and passes all three validate tests after.
- `cargo clippy --all-features -- -D warnings` and `cargo clippy --no-default-features -- -D warnings` (the CI legs) exit 0, as do both with `--all-targets`.
- `cargo test`: 939 passed. `cargo test --no-default-features`: 774 passed. `cargo fmt --check` clean.
- The macOS legs of this PR's own CI are the final confirmation; the fixes were developed on Linux.
- vibe-diff: not run
- cross-check: not run
- verify: not run

## Reviewing

Read the four commits in order; each subject names its cause. The lint commit is mechanical. The cfg-gate commit is two attribute lines. The two worktree commits are the interesting ones: the fixture's root handling in `TempRepo::new`, the cwd repair in `acquire_cwd`, and the three validate tests taking the lock.

## Notes

- `CLAUDE.md` still describes CI as build plus test; the workflow has had clippy legs and an OS matrix for a while. Not touched here.
- The cwd race exists on Linux too and could surface there under a slow enough scheduler; the repair in `acquire_cwd` closes it on every platform.
- `TempRepo::new` keeps its own fallback for a failing `current_dir()`; with the repair in `acquire_cwd` it is now rarely reached, and removing it can follow separately.
