### PR TITLE
ci: lint all targets so test code cannot drift past clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Run Clippy (${{ matrix.features }})
-        run: cargo clippy --locked ${{ matrix.features }} -- -D warnings
+        # --all-targets so tests, benches and examples are linted too; this is
+        # what `just check` runs locally, and lint drift in test code used to
+        # land on main unnoticed because CI linted only the library and bin.
+        run: cargo clippy --locked --all-targets ${{ matrix.features }} -- -D warnings
 
   test:
     strategy:

--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ fmt:
 check:
     cargo fmt --check
     cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --all-targets --no-default-features -- -D warnings
 
 test: fmt
     cargo test


### PR DESCRIPTION
## Summary

CI's clippy job linted only the library and bin; `just check` lints with `--all-targets`. Lint drift in test code passed CI, landed on main, and turned the next local `just check` red. This adds `--all-targets` to both CI clippy legs and gives `just check` the `--no-default-features` leg CI already runs, so the local gate and CI execute the same commands.

## Motivation

#272 and #278 were both cleanups of test-side clippy drift that CI never saw. With CI and the local gate aligned, a PR that introduces such drift fails in CI instead of in the next contributor's terminal.

## Design decisions

**Why make CI stricter rather than relax `just check`.** The point of `-D warnings` on the local gate is to keep test code to the same standard as the rest; dropping `--all-targets` locally would just hide the drift. Adding it to CI costs seconds per run (the test targets are compiled by the test job anyway).

**Why add the `--no-default-features` leg to `just check`.** CI already runs it, and #278 showed test code that only fails to compile without default features (`cli_custom_flags_tests`). The local gate should catch that before push.

## Testing

- `just check` (now `fmt --check` plus both clippy legs with `--all-targets`) exits 0 on main after #278.
- `cargo clippy --locked --all-targets --all-features -- -D warnings` and `cargo clippy --locked --all-targets --no-default-features -- -D warnings`, the exact new CI commands, exit 0 locally.
- This PR's own clippy jobs run the new commands.
- vibe-diff: not run
- cross-check: not run
- verify: not run

## Reviewing

Two files, six lines: one flag and a comment in `.github/workflows/ci.yml`, one recipe line in `justfile`.

## Notes

- `CLAUDE.md` in this repo is untracked (`.git/info/exclude`), so its CI description is not part of this PR.
