### PR TITLE
chore: refresh model catalog from models.dev

### DIFF
--- a/data/models.json
+++ b/data/models.json
@@ -325,6 +325,13 @@
       "output_price": 12
     },
     {
+      "id": "gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "context": 1050000,
+      "input_price": 10,
+      "output_price": 50
+    },
+    {
       "id": "o1",
       "name": "o1",
       "context": 200000,
@@ -767,7 +774,7 @@
     },
     {
       "id": "google/gemini-3-pro-image-preview",
-      "name": "Nano Banana Pro",
+      "name": "Nano Banana Pro Preview",
       "context": 65536
     },
     {
@@ -777,7 +784,7 @@
     },
     {
       "id": "google/gemini-3.1-flash-image-preview",
-      "name": "Nano Banana 2",
+      "name": "Nano Banana 2 Preview",
       "context": 65536
     },
     {
@@ -1271,6 +1278,16 @@
       "context": 1050000
     },
     {
+      "id": "openai/gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "context": 1050000
+    },
+    {
+      "id": "openai/gpt-6-astra-pro",
+      "name": "GPT-6 Astra Pro",
+      "context": 1050000
+    },
+    {
       "id": "openai/gpt-chat-latest",
       "name": "GPT Chat Latest",
       "context": 400000
@@ -1581,8 +1598,8 @@
       "context": 1000000
     },
     {
-      "id": "qwen/qwen3.8-max",
-      "name": "Qwen3.8 Max",
+      "id": "qwen/qwen3.8-max-0902",
+      "name": "Qwen3.8 Max 0902",
       "context": 1000000
     },
     {
@@ -1669,11 +1686,6 @@
       "id": "z-ai/glm-5.2",
       "name": "GLM-5.2",
       "context": 1048576
-    },
-    {
-      "id": "z-ai/glm-5.2:free",
-      "name": "GLM 5.2 (free)",
-      "context": 256000
     },
     {
       "id": "z-ai/glm-5.3",


### PR DESCRIPTION
Automated refresh of `data/models.json` from https://models.dev/api.json via `scripts/gen-models-catalog.sh`.

## Summary

| Provider | Models | Added | Removed | Changed |
|---|---|---|---|---|
| anthropic | 14 → 14 | 0 | 0 | 0 |
| gemini | 30 → 30 | 0 | 0 | 0 |
| openai | 38 → 39 | 1 | 0 | 0 |
| openrouter | 222 → 223 | 3 | 2 | 2 |

### openai

**Added**
- `gpt-6-astra` (GPT-6 Astra, context 1050000, in $10/M, out $50/M)

### openrouter

**Added**
- `openai/gpt-6-astra` (GPT-6 Astra, context 1050000)
- `openai/gpt-6-astra-pro` (GPT-6 Astra Pro, context 1050000)
- `qwen/qwen3.8-max-0902` (Qwen3.8 Max 0902, context 1000000)

**Removed**
- `qwen/qwen3.8-max` (Qwen3.8 Max, context 1000000)
- `z-ai/glm-5.2:free` (GLM 5.2 (free), context 256000)

**Changed**
- `google/gemini-3-pro-image-preview`: name Nano Banana Pro → Nano Banana Pro Preview
- `google/gemini-3.1-flash-image-preview`: name Nano Banana 2 → Nano Banana 2 Preview

Review the diff for unexpected additions or removals before merging.
