### PR TITLE
fix(ui): make bash allow-always patterns match paths

### DIFF
--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -1,5 +1,6 @@
 use crate::permission::checker::{CheckResult, PermissionChecker};
 use crate::permission::{Action, PermissionConfig, PermissionConfigs, SecurityMode, ToolPerm};
+use crate::ui::utils::suggest_pattern;
 
 fn default_modes() -> Option<Vec<String>> {
     Some(vec![
@@ -363,6 +364,14 @@ fn session_allowlist_cannot_bypass_deny_rules() {
         "deny rule must not be bypassed by session allowlist, got {:?}",
         result,
     );
+}
+
+#[test]
+fn session_allowlist_covers_a_bash_command_with_a_path_argument() {
+    let cmd = "pytest tests/test_login.py";
+    let mut checker = make_checker(SecurityMode::Guarded);
+    checker.add_session_allowlist("bash".into(), &suggest_pattern("bash", cmd));
+    assert!(matches!(checker.check("bash", cmd), CheckResult::Allowed));
 }
 
 #[test]

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -201,7 +201,7 @@ pub(crate) fn suggest_pattern(tool: &str, input: &str) -> String {
     match tool {
         "bash" => {
             let first = input.split_whitespace().next().unwrap_or("*");
-            format!("{} *", first)
+            format!("{} **", first)
         }
         "read" | "write" | "edit" | "list_dir" => {
             let expanded = crate::fs::expand_tilde(input);


### PR DESCRIPTION
When you press `a` on a bash permission prompt for a command containing `/`, youre asked again on the very next call, because the suggested session rule doesn't match the command it came from. The broken rule is persisted, so the prompts carry on after a resume too.

Since commit 5c1aa4e (v1.8.2), this affects the default Standard mode. A stock install prompts for `sudo cp app.conf /etc/app.conf` under the new `("sudo", Ask)` and `("sudo **", Ask)` rules, but pressing `a` still leaves the next sudo command with a path asking again.

Bare commands remain uncovered: `pytest` suggests `pytest **`, which expects a space. That was already the case, and I couldnt tell whether allowing a bare command should cover only that command or its whole family.

The suggester uses a single `*`, and `glob_to_regex` compiles that as `[^/]*` while `**` becomes `.*`:

| command | suggested | compiles to | matches itself? |
|---|---|---|---|
| `pytest tests/test_login.py` | `pytest *` | `^pytest [^/]*$` | no |
| `npm install ./packages/web` | `npm *` | `^npm [^/]*$` | no |
| `cargo test --all` | `cargo *` | `^cargo [^/]*$` | yes |

Direct denies still win, though compund commands can escape a deny prefix, and that already applies to built-in Allow rules such as `cat **`.

Changing single-star matching would widen user allow and deny patterns, and break the documented `src/*` / `src/**` distinction. The built-in bash rules and every bash example in `docs/CONFIG.md` already use `**`; the suggester was the odd one out.
