### PR TITLE
feat(status-signals): report permission waits (protocol v1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 - **Subagents**: Parallel and fast, used for exploring the codebase
 - **ARCHITECTURE.md**: Our own companion file for AGENTS.md, it allows to offer a shared core knowledge for all agents working on the same codebase
 - **Prompt chaining**: offers to advance brainstorm → plan → code → review as each phase finishes, config-gated per transition
-- **Status signals**: emits start/stop/git-conflict events over a Unix socket for external status bars or tooling
+- **Status signals**: emits run-state events (start, stop, git-conflict, permission waits) over a Unix socket for external status bars or tooling ([docs/STATUS_SIGNALS.md](docs/STATUS_SIGNALS.md))
 
 **NOTE**: Windows support is not tested is any way, but feel free to try and open an issue if you encounter any bugs!
 
@@ -391,9 +391,9 @@ provider's multimodal support.
 **NOTE:** Status signals require the `status-signals` feature, which is
 included in the default build.
 
-Pass `--status-socket <path>` to have zerostack emit `start`, `stop`, and
-`git-conflict` events over a Unix domain socket, for external status bars or
-tooling to watch.
+Pass `--status-socket <path>` to have zerostack report its run state over a
+Unix domain socket, for external status bars or tooling to watch. See
+[docs/STATUS_SIGNALS.md](docs/STATUS_SIGNALS.md) for the full protocol.
 
 ## Parallel Agent
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -763,10 +763,9 @@ when one of them is used). All other items are read from the session.
 ## Status signals
 
 Requires the `status-signals` feature (included in the default build). Pass
-`--status-socket <path>` to have zerostack emit `start`, `stop`, and
-`git-conflict` events over a Unix domain socket at `<path>`, for external
-status bars or tooling to watch. This is separate from the in-TUI status bar
-above.
+`--status-socket <path>` to have zerostack report its run state over a Unix
+domain socket at `<path>`, for external status bars or tooling to watch. See
+[STATUS_SIGNALS.md](STATUS_SIGNALS.md) for the full protocol.
 
 ## Colors
 

--- a/docs/STATUS_SIGNALS.md
+++ b/docs/STATUS_SIGNALS.md
@@ -1,0 +1,135 @@
+---
+description: "Wire protocol for the status-signal Unix domain socket: every message, its ordering guarantees, the run-boundary invariant, listener rules, and which modes emit what."
+---
+
+# Status signals
+
+This is the single source of truth for the status-signal protocol. `docs/CONFIG.md` and
+`README.md` link here instead of restating the message list; if you are editing the
+protocol, this is the only file that needs to change.
+
+## Overview
+
+zerostack can report its run state to an external supervisor (a status bar, a
+parallel-agent manager, or any other tooling) over a Unix domain socket. The
+direction is one-way: zerostack is the sender, the listener is a passive
+observer. Delivery is best effort: zerostack connects, writes, and drops the
+connection for every message; it never blocks its own run waiting for the
+listener to be there, and it never retries or queues a message the listener
+missed.
+
+## Enabling
+
+The `status-signals` feature is included in the default build, so no extra
+build flags are needed. Pass `--status-socket <path>` on the command line to
+turn emission on; with the flag omitted, zerostack sends nothing.
+
+The listener must bind and `accept()` the Unix domain socket at `<path>`
+before zerostack starts sending. Each message is a fresh connection: if
+nothing is listening when zerostack connects, the write is silently dropped
+and the run continues exactly as it would without `--status-socket`.
+
+## Message table
+
+Every message is one ASCII line terminated by a single `\n`, delivered as its
+own connect-write-close.
+
+| Message              | Since | Meaning |
+| --------------------- | ----- | ------- |
+| `start`               | v1.0  | A turn has begun. |
+| `stop`                | v1.0  | A turn has ended. |
+| `git-conflict`        | v1.0  | A worktree merge hit a conflict and is prompting the user. Emitted at two worktree-merge prompts; there is currently no matching "left this wait" signal. |
+| `blocked:permission`  | v1.1  | The interactive permission prompt is on screen and zerostack is waiting for a human decision. |
+| `state:working`       | v1.1  | A wait reported by a `blocked:<reason>` message has ended and zerostack is working again. |
+
+`blocked:<reason>` and `state:<state>` are lowercase ASCII tokens with no
+whitespace and no `\n`. This protocol version defines exactly one reason,
+`permission`, and exactly one state, `working`. Further reasons and states
+(for example a `/chain` wait, a headless plan-reuse wait, or an `idle` state)
+are reserved for later protocol versions and are not emitted today.
+
+## Ordering guarantees
+
+A permission wait is bracketed in this exact order:
+
+```
+start -> blocked:permission -> state:working -> ... -> stop
+```
+
+`blocked:permission` is sent only after the prompt is visible on screen, and
+`state:working` is sent only after the user's decision has been taken, before
+that decision is handed back to the waiting tool. This holds for every
+decision the prompt accepts: allow once, allow always, deny, and Esc. If the
+prompt path fails with an error after reporting `blocked:permission`, the
+listener still receives `state:working` before the prompt path returns, so
+the pair is always balanced.
+
+`state:<state>` is a level-triggered report of the state zerostack is in
+after a wait ends, not an event with pairing or nesting semantics. Waits are
+serialised today (one prompt at a time), and a consumer must not build a
+stack on `blocked:` / `state:` pairs. `git-conflict` stays a v1.0 attention
+event without a release signal in this version.
+
+## Run-boundary invariant
+
+A `blocked:<reason>` or `state:<state>` message never adds an extra `start`
+or `stop`, and never removes one. Across a whole turn, the subsequence made
+of only `start`, `stop`, and `git-conflict` messages is byte-for-byte
+identical, in the same relative order, to what protocol v1.0 emitted for that
+turn. In other words: filter out every line that is not `start`, `stop`, or
+`git-conflict`, and what remains is exactly the v1.0 stream.
+
+## Listener rules
+
+- Split incoming bytes on `\n`; a message is everything up to and including
+  each `\n`.
+- Ignore any line you do not recognise. This is how the protocol stays
+  backward compatible: a v1.0 listener that ignores `blocked:*` and
+  `state:*` sees no behaviour change when talking to a v1.1 sender.
+- Every message is its own connection carrying exactly one line, so a read on
+  an accepted stream yields at most one line; batching is not part of v1.1.
+- Unlink a stale socket file before bind: a crashed listener leaves the inode
+  behind, and every later signal is then silently dropped with
+  `ECONNREFUSED`.
+- The sender connects per message and blocks synchronously on `connect` and
+  `write_all`, ignoring the result. Accept and read promptly: a listener that
+  stalls in its accept loop stalls zerostack's own run, because the sender is
+  waiting on that same connect/write to complete.
+- If you track a single "current state" for display purposes, let the last
+  recognised `state:<state>` win. A `state:working` that arrives after a
+  `stop` (possible on some error paths) is harmless: `stop` still arrives and
+  wins over it as the run boundary, and showing `working` for slightly
+  longer than the run actually lasted is preferable to showing nothing.
+
+## Trust model
+
+zerostack connects to whatever path `--status-socket` names, never creates
+it, and never checks the peer. Anything that can bind that path first
+observes the agent's activity timeline, and, because the sender blocks on
+`connect` and `write` with no timeout, can stall the agent (an accepted
+trade-off of the flag, documented rather than bounded in this protocol
+version). Put the socket in `$XDG_RUNTIME_DIR` or a 0700 directory, never a
+shared `/tmp`. Messages intentionally carry no session content, no tool
+names, no commands, no prompt text, and future reasons must keep that
+property.
+
+## Per-mode matrix
+
+| Mode                | Emits v1.0 messages (`start`/`stop`/`git-conflict`) | Emits `blocked:permission` / `state:working` |
+| -------------------- | ---------------------------------------------------- | ---------------------------------------------- |
+| Interactive TUI      | Yes                                                   | Yes |
+| Headless `-p`        | Yes                                                   | No |
+| Headless `--loop`    | Yes                                                   | No |
+
+Non-interactive modes (`-p` and `--loop`) pass no ask channel to the
+permission checker, so an Ask verdict is denied before any prompt is ever
+drawn. There is no permission wait to report, so these modes never emit
+`blocked:permission` or the paired `state:working`; a consumer running
+zerostack headlessly should not wait for either line.
+
+## Version history
+
+| Protocol version | First shipped in           | Messages added |
+| ----------------- | --------------------------- | --------------- |
+| v1.0               | zerostack v1.5.0             | `start`, `stop`, `git-conflict` |
+| v1.1               | unreleased                   | `blocked:permission`, `state:working` |

--- a/docs/index.html
+++ b/docs/index.html
@@ -406,7 +406,7 @@ footer p{margin-bottom:6px;font-size:.8rem;color:var(--faint)}
       <li><strong>Sandbox mode</strong> &mdash; bubblewrap / zerobox isolation</li>
       <li><strong>Exa search</strong> &mdash; WebFetch &amp; WebSearch tools</li>
       <li><strong>Prompt chaining</strong> &mdash; offers to advance brainstorm &rarr; plan &rarr; code &rarr; review</li>
-      <li><strong>Status signals</strong> &mdash; start/stop/git-conflict events over a Unix socket</li>
+      <li><strong>Status signals</strong> &mdash; run-state and permission-wait events over a Unix socket (<a href="https://github.com/gi-dellav/zerostack/blob/main/docs/STATUS_SIGNALS.md">docs/STATUS_SIGNALS.md</a>)</li>
     </ul>
     <figure>
       <img src="https://raw.githubusercontent.com/gi-dellav/zerostack/main/assets/tui_screenshot0.png" alt="zerostack TUI screenshot">

--- a/src/extras/status_signals.rs
+++ b/src/extras/status_signals.rs
@@ -8,6 +8,48 @@ pub struct StatusSignals {
     path: String,
 }
 
+/// Reasons zerostack can be blocked waiting on something external.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockedReason {
+    Permission,
+}
+
+impl BlockedReason {
+    fn line(self) -> &'static str {
+        match self {
+            BlockedReason::Permission => "blocked:permission\n",
+        }
+    }
+}
+
+/// Run states zerostack can report once a block has ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunState {
+    Working,
+}
+
+impl RunState {
+    fn line(self) -> &'static str {
+        match self {
+            RunState::Working => "state:working\n",
+        }
+    }
+}
+
+/// RAII guard that reports `blocked:<reason>` on construction and
+/// `state:working` on drop, keeping the pair balanced across every exit
+/// path (including early returns via `?`).
+#[must_use = "dropping the guard immediately sends state:working right after blocked:permission; bind it to a local"]
+pub struct BlockedScope<'a> {
+    signals: &'a StatusSignals,
+}
+
+impl Drop for BlockedScope<'_> {
+    fn drop(&mut self) {
+        self.signals.send_state(RunState::Working);
+    }
+}
+
 impl StatusSignals {
     #[allow(dead_code)]
     pub fn new(path: String) -> Self {
@@ -15,40 +57,51 @@ impl StatusSignals {
     }
 
     #[cfg(unix)]
+    fn send_line(&self, line: &str) {
+        let _ = (|| -> std::io::Result<()> {
+            let mut stream = UnixStream::connect(&self.path)?;
+            stream.write_all(line.as_bytes())?;
+            Ok(())
+        })();
+    }
+
+    #[cfg(not(unix))]
+    fn send_line(&self, _line: &str) {}
+
     pub fn send_start(&self) {
-        let _ = (|| -> std::io::Result<()> {
-            let mut stream = UnixStream::connect(&self.path)?;
-            stream.write_all(b"start\n")?;
-            Ok(())
-        })();
+        self.send_line("start\n");
     }
 
-    #[cfg(not(unix))]
-    pub fn send_start(&self) {}
-
-    #[cfg(unix)]
     pub fn send_stop(&self) {
-        let _ = (|| -> std::io::Result<()> {
-            let mut stream = UnixStream::connect(&self.path)?;
-            stream.write_all(b"stop\n")?;
-            Ok(())
-        })();
+        self.send_line("stop\n");
     }
 
-    #[cfg(not(unix))]
-    pub fn send_stop(&self) {}
-
-    #[cfg(unix)]
     #[allow(dead_code)]
     pub fn send_git_conflict(&self) {
-        let _ = (|| -> std::io::Result<()> {
-            let mut stream = UnixStream::connect(&self.path)?;
-            stream.write_all(b"git-conflict\n")?;
-            Ok(())
-        })();
+        self.send_line("git-conflict\n");
     }
 
-    #[cfg(not(unix))]
-    #[allow(dead_code)]
-    pub fn send_git_conflict(&self) {}
+    /// Raw sender for `blocked:<reason>`. TUI code must go through
+    /// `blocked_scope` instead so the `blocked:`/`state:` pair stays
+    /// balanced; this exists as a raw sender because later waits (chain)
+    /// span several event-loop turns and cannot hold a guard across them.
+    pub fn send_blocked(&self, reason: BlockedReason) {
+        self.send_line(reason.line());
+    }
+
+    /// Raw sender for `state:<state>`. TUI code must go through
+    /// `blocked_scope` instead so the `blocked:`/`state:` pair stays
+    /// balanced; this exists as a raw sender because later waits (chain)
+    /// span several event-loop turns and cannot hold a guard across them.
+    pub fn send_state(&self, state: RunState) {
+        self.send_line(state.line());
+    }
+
+    /// Permission waits always resume the same run, which is why the guard
+    /// releases with `RunState::Working` while `send_state` stays
+    /// parameterised for the reserved `idle` state.
+    pub fn blocked_scope(&self, reason: BlockedReason) -> BlockedScope<'_> {
+        self.send_blocked(reason);
+        BlockedScope { signals: self }
+    }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -78,6 +78,8 @@ mod normalize_tests;
 mod parallel_tool_call_tests;
 #[cfg(test)]
 mod paste_burst_tests;
+#[cfg(all(test, unix))]
+mod permission_signal_tests;
 #[cfg(test)]
 mod picker_tests;
 #[cfg(test)]

--- a/src/tests/permission_signal_tests.rs
+++ b/src/tests/permission_signal_tests.rs
@@ -1,0 +1,496 @@
+//! Handler-level tests for the status signals that bracket the interactive
+//! permission prompt.
+//!
+//! These drive `ui::permission_handler::handle_permission_request` directly:
+//! a `Renderer` over `FakeBackend` (no terminal), a `UiContext` whose
+//! `status_signals` point at a real `UnixListener` in a temp dir, and a
+//! `user_rx` pre-loaded with the one key the prompt is meant to see. What
+//! the listener collects is the wire truth for "the prompt reported its
+//! wait", for every decision the prompt accepts and for the error path that
+//! leaves the prompt without a decision at all.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::io::{self, Read};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::pin::pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::context::ContextFiles;
+use crate::event::UserEvent;
+use crate::extras::status_signals::StatusSignals;
+use crate::permission::ask::{AskRequest, UserDecision};
+use crate::sandbox::Sandbox;
+use crate::session::Session;
+use crate::ui::permission_handler::handle_permission_request;
+use crate::ui::renderer::{FakeBackend, RenderBackend, Renderer};
+use crate::ui::state::{AgentRunState, UiContext};
+
+/// A listening status socket in a temp dir, plus the thread that drains it.
+///
+/// The senders connect once per message and write a single line, so the
+/// accept loop turns the stream of connections into a flat list of lines in
+/// arrival order.
+struct SignalListener {
+    dir: PathBuf,
+    path: PathBuf,
+    lines: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    accepter: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SignalListener {
+    fn bind(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("zs_sig_{}_{}", std::process::id(), name));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("status.sock");
+        assert!(
+            path.to_string_lossy().len() < 100,
+            "socket path {:?} is too close to the 104-byte sun_path limit \
+             (macOS CI runners fail bind() well before that with ENAMETOOLONG); \
+             shorten the test name passed to SignalListener::bind",
+            path
+        );
+        let listener = UnixListener::bind(&path).unwrap();
+        // Non-blocking accept so the thread can notice the stop flag; the
+        // accepted streams stay blocking, so each read runs to EOF.
+        listener.set_nonblocking(true).unwrap();
+
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let accepter = std::thread::spawn({
+            let lines = Arc::clone(&lines);
+            let stop = Arc::clone(&stop);
+            move || {
+                while !stop.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            stream.set_nonblocking(false).unwrap();
+                            let mut buf = String::new();
+                            let _ = stream.read_to_string(&mut buf);
+                            let mut collected = lines.lock().unwrap();
+                            collected.extend(buf.lines().map(str::to_string));
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(Duration::from_millis(2));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        });
+
+        Self {
+            dir,
+            path,
+            lines,
+            stop,
+            accepter: Some(accepter),
+        }
+    }
+
+    fn signals(&self) -> StatusSignals {
+        StatusSignals::new(self.path.to_string_lossy().to_string())
+    }
+
+    /// Wait for `expected` lines, then keep waiting a beat so a surplus line
+    /// would still show up: the assertions are about the exact sequence, not
+    /// about a prefix of it.
+    fn settle(&self, expected: usize) -> Vec<String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && self.lines.lock().unwrap().len() < expected {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        self.lines.lock().unwrap().clone()
+    }
+}
+
+impl Drop for SignalListener {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.accepter.take() {
+            let _ = handle.join();
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// A listening status socket with no accept thread behind it: every
+/// connection the senders make stays queued in the kernel until the test
+/// accepts it by hand.
+///
+/// `SignalListener` drains asynchronously, which is fine for "what was said"
+/// but useless for "when was it said" - by the time its thread has the line,
+/// the handler has moved on. Here the test decides the instant of
+/// observation, so a line is visible exactly when the sender's `connect` +
+/// `write` + close has already happened.
+struct QueuedListener {
+    dir: PathBuf,
+    path: PathBuf,
+    listener: UnixListener,
+}
+
+impl QueuedListener {
+    fn bind(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("zs_sig_{}_{}", std::process::id(), name));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("status.sock");
+        assert!(
+            path.to_string_lossy().len() < 100,
+            "socket path {:?} is too close to the 104-byte sun_path limit; \
+             shorten the test name passed to QueuedListener::bind",
+            path
+        );
+        let listener = UnixListener::bind(&path).unwrap();
+        // Non-blocking accept so draining can stop at the end of the queue
+        // instead of waiting for a connection that may never come.
+        listener.set_nonblocking(true).unwrap();
+        Self {
+            dir,
+            path,
+            listener,
+        }
+    }
+
+    fn signals(&self) -> StatusSignals {
+        StatusSignals::new(self.path.to_string_lossy().to_string())
+    }
+
+    /// Take every connection that is queued *right now*, in arrival order,
+    /// and flatten it into lines. Each sender writes one line and closes, so
+    /// every accepted stream reads to EOF without blocking.
+    fn drain(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        loop {
+            match self.listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_nonblocking(false).unwrap();
+                    let mut buf = String::new();
+                    stream.read_to_string(&mut buf).unwrap();
+                    lines.extend(buf.lines().map(str::to_string));
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) => panic!("accept failed: {e}"),
+            }
+        }
+        lines
+    }
+}
+
+impl Drop for QueuedListener {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Waker for the tool side of the permission oneshot, which drains the status
+/// socket the moment it is woken.
+///
+/// `oneshot::Sender::send` calls the registered waker inline, on the sending
+/// thread, before it returns - so this snapshot is the state of the socket at
+/// the exact instant the decision is handed to the waiting tool, not at some
+/// later point the handler has already run past.
+struct SnapshotOnWake {
+    listener: Arc<QueuedListener>,
+    at_send: Mutex<Option<Vec<String>>>,
+}
+
+impl Wake for SnapshotOnWake {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        let lines = self.listener.drain();
+        // Only the first wake is the send; a later one must not overwrite it.
+        self.at_send.lock().unwrap().get_or_insert(lines);
+    }
+}
+
+/// Render backend that fails every write once `marker` has appeared in the
+/// bytes written so far. It turns one specific `renderer` call inside the
+/// prompt loop into an `Err`, which is how the handler's `?` early return
+/// gets exercised without touching production code.
+struct FailOnMarkerBackend {
+    buf: Vec<u8>,
+    marker: &'static str,
+    failed: bool,
+}
+
+impl FailOnMarkerBackend {
+    fn new(marker: &'static str) -> Self {
+        Self {
+            buf: Vec::new(),
+            marker,
+            failed: false,
+        }
+    }
+}
+
+impl io::Write for FailOnMarkerBackend {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        if self.failed || String::from_utf8_lossy(&self.buf).contains(self.marker) {
+            self.failed = true;
+            return Err(io::Error::other("backend write failed"));
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.failed {
+            return Err(io::Error::other("backend flush failed"));
+        }
+        Ok(())
+    }
+}
+
+impl RenderBackend for FailOnMarkerBackend {
+    fn size(&self) -> io::Result<(u16, u16)> {
+        Ok((80, 24))
+    }
+}
+
+type PromptOutcome = (
+    anyhow::Result<()>,
+    Result<UserDecision, oneshot::error::TryRecvError>,
+);
+
+/// The `UiContext` every prompt test runs against: real config and session
+/// objects, leaked so the context can outlive the borrows the handler takes.
+fn leaked_ui(signals: Option<StatusSignals>) -> UiContext<'static> {
+    let cli: &'static Cli = Box::leak(Box::new(Cli {
+        api_key: Some("test-key".to_string()),
+        no_session: true,
+        no_color: true,
+        ..Default::default()
+    }));
+    let cfg: &'static Config = Box::leak(Box::new(Config::default()));
+    let session: &'static mut Session = Box::leak(Box::new(Session::new(
+        "anthropic",
+        "claude-sonnet-4-5",
+        200_000,
+        "permission-signal-test",
+    )));
+    let context: &'static mut ContextFiles =
+        Box::leak(Box::new(crate::context::load_with_prompts_dirs(true, &[])));
+    let client =
+        crate::provider::create_client("anthropic", Some("test-key"), &HashMap::new(), None)
+            .expect("create test client");
+    UiContext::new(
+        cli,
+        cfg,
+        session,
+        context,
+        client,
+        None,
+        None,
+        Sandbox::new(false, "bwrap"),
+        signals,
+    )
+}
+
+/// Run one permission prompt to completion: `key` is the single key the user
+/// "presses", `signals` is what `UiContext` carries, `backend` is what the
+/// renderer draws onto. Returns the handler's result and whatever the tool
+/// side of the oneshot ended up with.
+async fn run_prompt(
+    key: KeyCode,
+    signals: Option<StatusSignals>,
+    backend: Box<dyn RenderBackend>,
+) -> PromptOutcome {
+    let mut ui = leaked_ui(signals);
+    let mut renderer = Renderer::with_backend(backend);
+    let mut run = AgentRunState::default();
+
+    let (user_tx, mut user_rx) = mpsc::channel(4);
+    user_tx
+        .send(UserEvent::Key(KeyEvent::new(key, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+
+    let (reply_tx, mut reply_rx) = oneshot::channel();
+    let ask_req = AskRequest {
+        tool: "bash".into(),
+        input: "ls -la".to_string(),
+        reply: reply_tx,
+    };
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle_permission_request(ask_req, &mut renderer, &mut ui, &mut run, &mut user_rx),
+    )
+    .await
+    .expect("handler did not return within 5s");
+    let decision = reply_rx.try_recv();
+    (result, decision)
+}
+
+fn fake_backend() -> Box<dyn RenderBackend> {
+    Box::new(FakeBackend::new(80, 24))
+}
+
+const BRACKET: [&str; 2] = ["blocked:permission", "state:working"];
+
+#[tokio::test]
+async fn allow_once_brackets_wait() {
+    let listener = SignalListener::bind("allow_once");
+    let (result, decision) =
+        run_prompt(KeyCode::Char('y'), Some(listener.signals()), fake_backend()).await;
+
+    result.expect("prompt path succeeded");
+    assert!(matches!(decision, Ok(UserDecision::AllowOnce)));
+    assert_eq!(listener.settle(2), BRACKET);
+}
+
+#[tokio::test]
+async fn allow_always_brackets_wait() {
+    let listener = SignalListener::bind("allow_always");
+    let (result, decision) =
+        run_prompt(KeyCode::Char('a'), Some(listener.signals()), fake_backend()).await;
+
+    result.expect("prompt path succeeded");
+    assert!(matches!(decision, Ok(UserDecision::AllowAlways(_))));
+    assert_eq!(listener.settle(2), BRACKET);
+}
+
+#[tokio::test]
+async fn deny_brackets_wait() {
+    let listener = SignalListener::bind("deny");
+    let (result, decision) =
+        run_prompt(KeyCode::Char('n'), Some(listener.signals()), fake_backend()).await;
+
+    result.expect("prompt path succeeded");
+    assert!(matches!(decision, Ok(UserDecision::Deny)));
+    assert_eq!(listener.settle(2), BRACKET);
+}
+
+#[tokio::test]
+async fn esc_brackets_wait() {
+    let listener = SignalListener::bind("esc");
+    let (result, decision) =
+        run_prompt(KeyCode::Esc, Some(listener.signals()), fake_backend()).await;
+
+    result.expect("prompt path succeeded");
+    assert!(matches!(decision, Ok(UserDecision::Deny)));
+    assert_eq!(listener.settle(2), BRACKET);
+}
+
+#[tokio::test]
+async fn no_socket_emits_nothing() {
+    let listener = SignalListener::bind("no_socket");
+    let (result, decision) = run_prompt(KeyCode::Char('y'), None, fake_backend()).await;
+
+    result.expect("prompt path succeeded");
+    assert!(matches!(decision, Ok(UserDecision::AllowOnce)));
+    assert!(listener.settle(0).is_empty());
+}
+
+/// The allow-always branch writes a confirmation line while the wait is still
+/// open; a backend that fails on exactly that write makes the handler return
+/// through `?` before any decision reaches the tool. The listener must still
+/// see the wait end.
+#[tokio::test]
+async fn error_after_prompt_still_releases() {
+    let listener = SignalListener::bind("error_path");
+    let (result, decision) = run_prompt(
+        KeyCode::Char('a'),
+        Some(listener.signals()),
+        Box::new(FailOnMarkerBackend::new("-> will allow")),
+    )
+    .await;
+
+    assert!(result.is_err(), "expected the prompt path to fail");
+    assert!(decision.is_err(), "no decision should reach the tool");
+    assert_eq!(listener.settle(2), BRACKET);
+}
+
+/// The ordering half of the bracket: `state:working` must be on the wire
+/// *before* the decision reaches the waiting tool, not merely by the time the
+/// handler returns.
+///
+/// The two channels cannot be compared after the fact - the status socket is
+/// drained by another thread, the decision by a oneshot - so the comparison
+/// happens at the one instant both are pinned: the waker `oneshot::Sender::send`
+/// invokes inline, before it returns. Registering our own waker on the tool
+/// side of the oneshot and draining the socket from inside it makes the
+/// snapshot a property of the kernel queue at send time. Moving the guard's
+/// `drop` below `reply.send` in the handler leaves only `blocked:permission`
+/// in that snapshot, which is the regression this pins.
+#[tokio::test]
+async fn state_working_reaches_the_wire_before_the_decision() {
+    let listener = Arc::new(QueuedListener::bind("order"));
+    let mut ui = leaked_ui(Some(listener.signals()));
+    let mut renderer = Renderer::with_backend(fake_backend());
+    let mut run = AgentRunState::default();
+
+    let (user_tx, mut user_rx) = mpsc::channel(4);
+    user_tx
+        .send(UserEvent::Key(KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let ask_req = AskRequest {
+        tool: "bash".into(),
+        input: "ls -la".to_string(),
+        reply: reply_tx,
+    };
+
+    // Register the snapshotting waker and leave it registered: nothing else
+    // polls this receiver, so the next wake it sees is the handler's send.
+    let observer = Arc::new(SnapshotOnWake {
+        listener: Arc::clone(&listener),
+        at_send: Mutex::new(None),
+    });
+    let waker = Waker::from(Arc::clone(&observer));
+    let mut cx = Context::from_waker(&waker);
+    let mut reply_rx = pin!(reply_rx);
+    assert!(
+        reply_rx.as_mut().poll(&mut cx).is_pending(),
+        "no decision can exist before the prompt runs"
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        handle_permission_request(ask_req, &mut renderer, &mut ui, &mut run, &mut user_rx),
+    )
+    .await
+    .expect("handler did not return within 5s");
+    result.expect("prompt path succeeded");
+
+    let at_send = observer
+        .at_send
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the handler never handed a decision back");
+    assert_eq!(
+        at_send, BRACKET,
+        "state:working must already be on the socket when the decision reaches the tool"
+    );
+    assert!(
+        matches!(
+            reply_rx.as_mut().poll(&mut cx),
+            Poll::Ready(Ok(UserDecision::AllowOnce))
+        ),
+        "the decision the prompt took"
+    );
+}

--- a/src/tests/status_signals_tests.rs
+++ b/src/tests/status_signals_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use crate::extras::status_signals::StatusSignals;
+use crate::extras::status_signals::{BlockedReason, RunState, StatusSignals};
 use std::io::Read;
 use std::os::unix::net::UnixListener;
 
@@ -51,6 +51,10 @@ fn nonexistent_socket_does_not_panic() {
     ss.send_start();
     ss.send_stop();
     ss.send_git_conflict();
+    ss.send_blocked(BlockedReason::Permission);
+    ss.send_state(RunState::Working);
+    let guard = ss.blocked_scope(BlockedReason::Permission);
+    drop(guard);
 }
 
 #[test]
@@ -63,5 +67,73 @@ fn send_git_conflict_writes_expected_message() {
     let mut buf = String::new();
     stream.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, "git-conflict\n");
+    cleanup(&socket_path);
+}
+
+#[test]
+fn send_blocked_writes_expected_message() {
+    let (socket_path, listener) = temp_socket_path("blocked");
+    let ss = StatusSignals::new(socket_path.to_string_lossy().to_string());
+    ss.send_blocked(BlockedReason::Permission);
+
+    let (mut stream, _) = listener.accept().unwrap();
+    let mut buf = String::new();
+    stream.read_to_string(&mut buf).unwrap();
+    assert_eq!(buf, "blocked:permission\n");
+    cleanup(&socket_path);
+}
+
+#[test]
+fn send_state_writes_expected_message() {
+    let (socket_path, listener) = temp_socket_path("state");
+    let ss = StatusSignals::new(socket_path.to_string_lossy().to_string());
+    ss.send_state(RunState::Working);
+
+    let (mut stream, _) = listener.accept().unwrap();
+    let mut buf = String::new();
+    stream.read_to_string(&mut buf).unwrap();
+    assert_eq!(buf, "state:working\n");
+    cleanup(&socket_path);
+}
+
+#[test]
+fn blocked_scope_sends_pair_in_order() {
+    let (socket_path, listener) = temp_socket_path("scope_order");
+    let ss = StatusSignals::new(socket_path.to_string_lossy().to_string());
+
+    let guard = ss.blocked_scope(BlockedReason::Permission);
+    drop(guard);
+
+    let mut received = Vec::new();
+    for _ in 0..2 {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = String::new();
+        stream.read_to_string(&mut buf).unwrap();
+        received.push(buf.trim_end().to_string());
+    }
+    assert_eq!(received, vec!["blocked:permission", "state:working"]);
+    cleanup(&socket_path);
+}
+
+#[test]
+fn blocked_scope_releases_on_error_path() {
+    let (socket_path, listener) = temp_socket_path("scope_error");
+    let ss = StatusSignals::new(socket_path.to_string_lossy().to_string());
+
+    let result: Result<(), ()> = (|| {
+        let _guard = ss.blocked_scope(BlockedReason::Permission);
+        Err(())?;
+        Ok(())
+    })();
+    assert_eq!(result, Err(()));
+
+    let mut received = Vec::new();
+    for _ in 0..2 {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = String::new();
+        stream.read_to_string(&mut buf).unwrap();
+        received.push(buf.trim_end().to_string());
+    }
+    assert_eq!(received, vec!["blocked:permission", "state:working"]);
     cleanup(&socket_path);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,7 +6,7 @@ pub mod events;
 pub(crate) mod feed;
 pub(crate) mod input;
 pub(crate) mod markdown;
-mod permission_handler;
+pub(crate) mod permission_handler;
 pub(crate) mod pickers;
 // `pub`: `EventSink` is implemented for `Renderer` so TUI code can target
 // the trait while slash handlers migrate off `&mut Renderer`.

--- a/src/ui/permission_handler.rs
+++ b/src/ui/permission_handler.rs
@@ -2,6 +2,7 @@ use crossterm::style::Color;
 use tokio::sync::mpsc;
 
 use crate::event::UserEvent;
+use crate::extras::status_signals::BlockedReason;
 use crate::ui::renderer::Renderer;
 use crate::ui::state::{AgentRunState, UiContext};
 use crate::ui::utils::suggest_pattern;
@@ -37,6 +38,11 @@ pub async fn handle_permission_request(
     renderer.render_viewport()?;
     renderer.draw_bottom("", 0, &[], false)?;
 
+    let blocked_guard = ui
+        .status_signals
+        .as_ref()
+        .map(|ss| ss.blocked_scope(BlockedReason::Permission));
+
     let decision = loop {
         tokio::select! {
             Some(ev) = user_rx.recv() => {
@@ -65,6 +71,11 @@ pub async fn handle_permission_request(
         crate::permission::ask::UserDecision::AllowAlways(p) => Some(p.clone()),
         _ => None,
     };
+    // The explicit drop sends state:working before the decision reaches the
+    // waiting tool (the protocol promises that order); it must stay above
+    // ask_req.reply.send, since moving it later still compiles but breaks
+    // the documented ordering.
+    drop(blocked_guard);
     let _ = ask_req.reply.send(decision);
 
     if let Some(pattern) = allow_pattern {


### PR DESCRIPTION
## Summary

Status-signal protocol v1.1: zerostack now reports the interactive permission wait over `--status-socket` as `blocked:permission` and reports the end of that wait as `state:working`, so an external supervisor can tell "working" apart from "waiting for a human". The three v1.0 lines (`start`, `stop`, `git-conflict`) are byte-for-byte unchanged and a v1.0 consumer that ignores unknown lines sees no difference. A new `docs/STATUS_SIGNALS.md` becomes the single source of truth for the wire protocol.

## Motivation

Tools such as multistack bind the status socket and spawn zerostack to run several agents side by side. Today the last thing they hear before a permission prompt is `start`, so an agent parked on `(y) allow once (a) allow always (n) deny` looks exactly like one that is busy: the panel shows "working", the per-agent timer keeps counting, and nobody gets notified. That is the one moment a parallel-agent manager exists to surface. This change makes it observable with two extra lines and no change to anything a v1.0 listener already parses.

## Design decisions

**Why `state:working` rather than `unblocked:<reason>`.** The release message names the state zerostack is in after the wait, not the inverse of the block. A permission decision resumes the same run, so the only state this version can report is `working`; the reserved `state:idle` exists because a later wait (the `/chain` question, which arrives after `stop`) can end with no run at all when the user declines, and "unblocked" would leave the consumer guessing which of the two it is. The document states that `state:` is level-triggered with no pairing or nesting semantics; waits are serialised today, so a consumer must not build a stack on the pair.

**Why an RAII guard with an explicit `drop`.** `handle_permission_request` has three fallible calls between drawing the prompt and taking the decision. Two bare sends would leave a listener stuck on `blocked` after any `?` early return. `BlockedScope` sends `blocked:permission` on construction and `state:working` on drop, so every exit path, including unwind, stays balanced; the explicit `drop` right before `ask_req.reply.send` is what enforces the documented order (release before the decision reaches the tool), and it is commented as load-bearing. The raw `send_blocked` / `send_state` stay available because the reserved chain wait spans several event-loop turns and cannot be guarded; the doc comments say to prefer the guard.

**Why the transport is untouched.** The sender still connects per message, blocks synchronously, and ignores every error, exactly as v1.0 does. Bounding that (write timeouts, a sender thread) is a real improvement but a separate concern from the protocol extension, and mixing it in would make this diff harder to review. The trust-model section of the protocol document states the consequence plainly: whoever can bind the socket path can observe the timeline and, by never reading, stall the agent; put the socket in a private directory.

**Why `permission_handler` became `pub(crate)`.** The handler-level tests live in `src/tests/` per this repo's convention, and a private module of `ui` is not nameable from there. One visibility keyword, matching every sibling module in `src/ui/mod.rs`, no behaviour change.

**What stays out on purpose.** `blocked:chain`, `blocked:loop-plan`, `state:idle`, a release signal for `git-conflict`, a protocol version banner, and a `ZEROSTACK_STATUS_SOCKET` environment variable are all reserved for later versions; each has its own ordering subtlety and deserves its own change.

## Testing

- Unit tests (`src/tests/status_signals_tests.rs`): exact bytes for the two new lines, guard emits the pair in order, guard releases on a `?` error path, missing socket stays silent for every sender.
- Handler-level tests (`src/tests/permission_signal_tests.rs`): a temp UnixListener plus a fake render backend drive `handle_permission_request` for allow once, allow always, deny, and Esc, asserting exactly `["blocked:permission", "state:working"]` on the wire and the matching decision on the oneshot; a no-socket case asserts nothing is sent; an error-path case uses a backend that fails mid-prompt and asserts the handler returns `Err` while the wire still carries the full pair; every handler call is bounded by a 5-second timeout so a regression fails instead of hanging CI.
- Ordering test: `state_working_reaches_the_wire_before_the_decision` registers a waker on the tool side of the oneshot and snapshots the socket's accept queue from inside `wake_by_ref`, which runs inline in `reply.send`; the snapshot must already contain `state:working`. Moving the guard's drop below the send makes it fail deterministically (checked by mutation); 20 sequential runs, no flake.
- Full suite: `cargo test` 972 passed. `cargo fmt --check` clean. Both clippy legs (`--all-features`, `--no-default-features`) report nothing in the files this branch touches.
- Live verification: the binary built from this branch was driven over a pty against a scripted local provider with a listener on a fresh socket; the observed sequence across one turn with one permission prompt was `start`, `blocked:permission`, `state:working`, `stop`, with the four-second gap between the middle two matching the driver's pause before pressing `y`.
- Line breakdown for reviewers: production +86 / -22 (`status_signals.rs`, `permission_handler.rs`, one keyword in `ui/mod.rs`), tests +571, docs +143 / -9. Most of the test volume is the handler-level harness and the ordering test.
- vibe-diff: not run
- cross-check: not run
- verify: /opsx:verify ran in-session; no CRITICAL findings, one WARNING (leftover `#[allow(dead_code)]`) fixed before shipping.
- adversarial review: opus, fresh context, upstream-maintainer persona; 17 findings, all either folded into the commits above or answered in Design decisions and Notes.

## Reviewing

Start with `docs/STATUS_SIGNALS.md` (the contract), then `src/extras/status_signals.rs` (the guard, about 70 lines), then the eleven-line change in `src/ui/permission_handler.rs`. The test files are mechanical: `status_signals_tests.rs` pins bytes, `permission_signal_tests.rs` pins the bracket per decision and, in its last test, the ordering. `docs/CONFIG.md`, `README.md`, and `docs/index.html` only shrink to a link.

## Notes

- CI is expected to be red on clippy for reasons unrelated to this branch: `main` at a968535 carries six clippy errors in `src/engine/mod.rs` (`too_many_arguments`, `needless_borrows_for_generic_args` x3, `never_loop`, `unnecessary_to_owned`, plus `needless_return` on the `--no-default-features` leg). This branch does not touch that file; filtering it out of either clippy leg leaves zero diagnostics. Cleaning it up belongs in its own `fix(engine)` change.
- The cross-check and vibe-diff review layers were waived by the author for this branch; the in-session verify pass and a fresh-context adversarial review (whose findings are folded in here) were run instead.
- The status line goes blank while the permission prompt is displayed (`permission_handler` passes an empty status line to `draw_bottom`). Pre-existing, unrelated to signals, left for a separate fix.
- Follow-ups reserved by the protocol document: `blocked:chain` (ordering is `stop` then `blocked:chain`, so a consumer sees a brief idle), `blocked:loop-plan`, `state:idle`, and a release signal for `git-conflict`.
