### PR TITLE
fix(ci): clear engine clippy lints and the advisor panic under --all-features

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -372,7 +372,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         }
 
         #[cfg(feature = "advisor")]
-        if crate::extras::advisor::with_config(|c| c.enabled) {
+        if crate::extras::advisor::is_enabled() {
             use crate::extras::advisor::AdvisorTool;
             all_tools.push(Box::new(AdvisorTool::new()));
         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -97,7 +97,7 @@ impl RunOutput {
 }
 
 /// Owned headless execution context. Construct with [`Engine::new`] (fresh
-/// in-process state, no disk writes unless a command needs them) or
+/// in-process state, no disk writes unless a command needs them), then chain
 /// [`Engine::with_agent`] to inject a scripted agent in tests.
 pub struct Engine {
     cli: Cli,
@@ -151,20 +151,10 @@ impl Engine {
         }
     }
 
-    /// Build an engine with a pre-built agent (tests inject `AnyAgent::Mock`).
-    pub fn with_agent(
-        cli: Cli,
-        cfg: Config,
-        session: Session,
-        context: ContextFiles,
-        client: AnyClient,
-        permission: Option<PermCheck>,
-        sandbox: Sandbox,
-        agent: AnyAgent,
-    ) -> Self {
-        let mut engine = Self::new(cli, cfg, session, context, client, permission, sandbox);
-        engine.agent = Some(agent);
-        engine
+    /// Inject a pre-built agent (tests inject `AnyAgent::Mock`).
+    pub fn with_agent(mut self, agent: AnyAgent) -> Self {
+        self.agent = Some(agent);
+        self
     }
 
     /// Borrow the session (assertions, persistence).
@@ -220,7 +210,7 @@ impl Engine {
         match self.start_agent_run(text.to_string()).await {
             Ok((response, usage)) => RunOutput::agent(response, usage),
             Err(e) => {
-                sink.write_error(&e.to_string());
+                sink.write_error(e.to_string());
                 // Roll back the optimistic user message like the TUI does on
                 // a failed send (`App::finalize_turn`).
                 let len = self.session.messages.len();
@@ -431,7 +421,7 @@ impl Engine {
         if self.cfg.resolve_compact_enabled() && self.session.needs_compaction(self.reserve()) {
             let mut sink = StringSink::new();
             if let Err(e) = self.compress(None, true, &mut sink).await {
-                sink.write_error(&format!("auto-compact error: {e}"));
+                sink.write_error(format!("auto-compact error: {e}"));
             }
         }
         self.save_session_best_effort();
@@ -500,7 +490,7 @@ impl Engine {
         {
             // Headless engines never connect MCP lazily: pass `None` like
             // `dispatch_print` does. Callers needing MCP build the agent
-            // up front via `with_agent`.
+            // up front via `Engine::new(...).with_agent(...)`.
         }
         let model = self.client.completion_model(self.session.model.to_string());
         let temperature = config::resolve_temperature(&self.cli, &self.cfg, &self.session.model);
@@ -787,14 +777,13 @@ impl Engine {
         // Await the single terminal event (no session mutation: `BtwEvent`
         // never touches history, enforced by the type).
         let mut answer = String::new();
-        while let Some(ev) = event_rx.recv().await {
+        if let Some(ev) = event_rx.recv().await {
             match ev {
                 crate::event::BtwEvent::Done { response, .. } => {
                     answer = response.to_string();
-                    break;
                 }
                 crate::event::BtwEvent::Error { message, .. } => {
-                    sink.write_error(message.to_string());
+                    sink.write_error(&message);
                     return RunOutput::command(sink.transcript());
                 }
             }
@@ -864,7 +853,7 @@ impl Engine {
 
     fn sink_echo_user(&self, text: &str, sink: &mut StringSink) {
         for line in text.lines() {
-            sink.write_line(&format!("> {line}"));
+            sink.write_line(format!("> {line}"));
         }
         sink.write_line("");
     }
@@ -2070,7 +2059,7 @@ impl Engine {
         #[cfg(not(feature = "memory"))]
         {
             sink.write_error("/memory is not available in this build");
-            return Ok(SlashFlow::Done);
+            Ok(SlashFlow::Done)
         }
         #[cfg(feature = "memory")]
         {

--- a/src/extras/advisor/mod.rs
+++ b/src/extras/advisor/mod.rs
@@ -69,6 +69,17 @@ where
     f(cfg)
 }
 
+/// Whether the advisor tool is enabled. Returns `false` when `init_config`
+/// has not run yet (headless engines and tests build agents before, or
+/// without, advisor startup).
+pub fn is_enabled() -> bool {
+    CONFIG
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .is_some_and(|c| c.enabled)
+}
+
 pub fn update_client(client: AnyClient) {
     let mut guard = CONFIG.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(ref mut cfg) = *guard {

--- a/src/tests/engine_tests.rs
+++ b/src/tests/engine_tests.rs
@@ -58,7 +58,7 @@ fn engine_with_turns(turns: Vec<Vec<&str>>) -> (Engine, FakeModel) {
     isolate_data_dirs();
     let model = fake_model::text_turns(turns);
     let agent = AnyAgent::Mock(rig::agent::AgentBuilder::new(model.clone()).build());
-    let engine = Engine::with_agent(
+    let engine = Engine::new(
         test_cli(),
         Config::default(),
         test_session(),
@@ -66,8 +66,8 @@ fn engine_with_turns(turns: Vec<Vec<&str>>) -> (Engine, FakeModel) {
         test_client(),
         None,
         Sandbox::new(false, "bwrap"),
-        agent,
-    );
+    )
+    .with_agent(agent);
     (engine, model)
 }
 
@@ -128,7 +128,7 @@ async fn run_string_agent_error_rolls_back_user_message() {
         crate::tests::fake_model::MockStreamEvent::error("stream broke"),
     ]]);
     let agent = AnyAgent::Mock(rig::agent::AgentBuilder::new(model).build());
-    let mut engine = Engine::with_agent(
+    let mut engine = Engine::new(
         test_cli(),
         Config::default(),
         test_session(),
@@ -136,8 +136,8 @@ async fn run_string_agent_error_rolls_back_user_message() {
         test_client(),
         None,
         Sandbox::new(false, "bwrap"),
-        agent,
-    );
+    )
+    .with_agent(agent);
 
     let out = engine.run_string("hello").await.expect("run_string");
     assert_eq!(out.kind, RunKind::Agent);
@@ -289,7 +289,7 @@ async fn run_string_mode_switches_security_mode() {
     let perm: crate::permission::checker::PermCheck = Arc::new(Mutex::new(checker));
     let model = fake_model::text_turns(Vec::<Vec<&str>>::new());
     let agent = AnyAgent::Mock(rig::agent::AgentBuilder::new(model).build());
-    let mut engine = Engine::with_agent(
+    let mut engine = Engine::new(
         test_cli(),
         Config::default(),
         test_session(),
@@ -297,8 +297,8 @@ async fn run_string_mode_switches_security_mode() {
         test_client(),
         Some(perm.clone()),
         Sandbox::new(false, "bwrap"),
-        agent,
-    );
+    )
+    .with_agent(agent);
 
     let out = engine
         .run_string("/mode readonly")


### PR DESCRIPTION
main has been red since a968535 (the Engine module), which landed without a CI run. Four jobs fail: both clippy legs and both `--all-features` test legs. #281 and #282 inherited the same failures.

## Commit 1: `fix(engine): clear clippy lints in the engine module`

Seven lints, all in `src/engine/mod.rs`, no `#[allow]` added:

- `needless_borrows_for_generic_args` on three `write_error` / `write_line` calls (the sink methods take `impl AsRef<str>`).
- `unnecessary_to_owned` in the `/btw` handler.
- `never_loop` in the `/btw` handler: the `while let` over the `BtwEvent` channel breaks or returns on every arm, so it is an `if let`.
- `needless_return` in the `not(feature = "memory")` branch of `slash_memory` (only visible on the `--no-default-features` leg).
- `too_many_arguments` on `Engine::with_agent` (8/7). It becomes a consuming builder method, so tests now write `Engine::new(...).with_agent(agent)`. Three call sites in `src/tests/engine_tests.rs` updated; no other callers.

## Commit 2: `fix(advisor): treat uninitialized config as disabled when building agents`

`build_agent` called `advisor::with_config(|c| c.enabled)` unconditionally, and `with_config` panics with "advisor config not initialized" when `init_config` has not run. Headless engines that rebuild the agent (for example `/reasoning`) reach this before advisor startup; `run_string_reasoning_toggles` hit it under `--all-features`.

New `advisor::is_enabled()` returns `false` when the config is not initialized, and `build_agent` uses it. No test was changed: the failing test now passes because of the production fix and doubles as the regression test for rebuilding an agent without advisor startup.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo clippy --locked --all-targets --no-default-features -- -D warnings`
- `cargo test --locked --all-features`: 1194 passed, 0 failed
- `cargo test --locked --no-default-features`: 808 passed, 0 failed
