### PR TITLE
feat: UI proposals: ctrl+left/right in input, paste in input, selection in input

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -282,3 +282,5 @@ message, and after the response restores the previous prompt and
 | `Home / End` | Scroll to top / bottom. |
 | `Escape` | Close active picker / cancel. |
 | `Right / Middle click` | Paste from the system clipboard into the input. |
+| `Mouse drag` | Select text (chat line-wise, input char-wise); releasing copies it to the clipboard. |
+| `Escape` (while selected) | Clear the selection without copying. |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -264,6 +264,7 @@ message, and after the response restores the previous prompt and
 | `Ctrl+W` | Delete word backwards. |
 | `Ctrl+U` / `Ctrl+K` | Delete to start / end of line. |
 | `Ctrl+Y` | Yank (paste) the most recently deleted text. |
+| `Ctrl+V` | Paste from the system clipboard into the input. |
 | `Ctrl+A` / `Ctrl+E` | Jump to start / end of line. |
 | `Ctrl+B` / `Ctrl+F` | Move one character left / right. |
 | `Ctrl+Left` / `Ctrl+Right` | Move one word left / right. |
@@ -280,3 +281,4 @@ message, and after the response restores the previous prompt and
 | `PageUp / PageDown` | Scroll viewport. |
 | `Home / End` | Scroll to top / bottom. |
 | `Escape` | Close active picker / cancel. |
+| `Right / Middle click` | Paste from the system clipboard into the input. |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -266,6 +266,7 @@ message, and after the response restores the previous prompt and
 | `Ctrl+Y` | Yank (paste) the most recently deleted text. |
 | `Ctrl+A` / `Ctrl+E` | Jump to start / end of line. |
 | `Ctrl+B` / `Ctrl+F` | Move one character left / right. |
+| `Ctrl+Left` / `Ctrl+Right` | Move one word left / right. |
 | `Ctrl+P` / `Ctrl+N` | Previous / next line (history on the first / last line). |
 | `Alt+B` / `Alt+F` | Move one word left / right. |
 | `Alt+D` / `Alt+Y` | Delete next word / cycle the kill ring. |

--- a/src/event.rs
+++ b/src/event.rs
@@ -77,6 +77,10 @@ pub enum UserEvent {
     ScrollDown,
     Resize,
     Paste(String),
+    /// Right- or middle-click paste: read the system clipboard and insert it
+    /// into the input buffer. The read happens in the app loop, not the event
+    /// thread.
+    PasteRequest,
     FocusGained,
     #[allow(dead_code)]
     MouseDown {

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -73,6 +73,27 @@ fn right_arrow_steps_one_char_not_one_byte() {
 }
 
 #[test]
+fn ctrl_left_jumps_to_prev_word_start() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL));
+    assert_eq!(editor.cursor, 6); // start of "world"
+    editor.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL));
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn ctrl_right_jumps_to_next_word_end() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = 0;
+    editor.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL));
+    assert_eq!(editor.cursor, 5); // just past "hello"
+    editor.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL));
+    assert_eq!(editor.cursor, 11); // end of buffer
+}
+
+#[test]
 fn enter_returns_buffer_and_resets() {
     let mut editor = InputEditor::new();
     type_str(&mut editor, "hei på");

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -132,7 +132,19 @@ mod dirty {
             monochrome: false,
             input_bg: None,
             status_bg: None,
+            input_selection: None,
         }
+    }
+
+    #[test]
+    fn input_selection_change_forces_full_bottom_redraw() {
+        let prev = bottom_snapshot();
+        let mut next = bottom_snapshot();
+        next.input_selection = Some((0, 3));
+        assert_eq!(
+            Renderer::bottom_redraw_plan(Some(&prev), &next, false),
+            BottomRedrawPlan::Full
+        );
     }
 
     #[test]
@@ -412,5 +424,59 @@ mod cursor_positioning {
     fn cursor_at_end_of_overflowing_line() {
         let line = repeat_ascii(VISIBLE_WIDTH + 12);
         assert_eq!(emitted_cursor(&line, VISIBLE_WIDTH + 12).1, COLS - 1);
+    }
+}
+
+mod input_selection {
+    use crate::ui::renderer::Renderer;
+
+    #[test]
+    fn range_sorts_and_empty_is_none() {
+        let mut r = Renderer::new().unwrap();
+        r.input_selection = Some((5, 2));
+        assert_eq!(r.input_selection_range(), Some((2, 5)));
+        r.input_selection = Some((4, 4));
+        assert_eq!(r.input_selection_range(), None);
+        r.input_selection = None;
+        assert_eq!(r.input_selection_range(), None);
+    }
+
+    #[test]
+    fn selected_input_text_slices_between_offsets() {
+        let mut r = Renderer::new().unwrap();
+        r.input_selection = Some((0, 5));
+        assert_eq!(
+            r.selected_input_text("hello world").as_deref(),
+            Some("hello")
+        );
+        r.input_selection = Some((6, 11));
+        assert_eq!(
+            r.selected_input_text("hello world").as_deref(),
+            Some("world")
+        );
+        // A stale end offset clamps to the buffer end...
+        r.input_selection = Some((1, 99));
+        assert_eq!(r.selected_input_text("hø").as_deref(), Some("ø"));
+        // ...while an offset inside a multi-byte char (buffer changed since
+        // the selection was made) is rejected instead of panicking.
+        r.input_selection = Some((1, 2));
+        assert_eq!(r.selected_input_text("ø"), None);
+    }
+
+    #[test]
+    fn drawing_input_with_selection_reverses_the_covered_span() {
+        let mut r = Renderer::with_backend(Box::new(crate::ui::renderer::FakeBackend::new(80, 24)));
+        r.set_statusline_height(1);
+        r.input_selection = Some((0, 2));
+        r.draw_bottom("hello", 5, &[], false).unwrap();
+        let out = r.captured_output();
+        assert!(
+            out.contains("\x1b[7mhe\x1b[27m"),
+            "reverse span missing in {out:?}"
+        );
+        assert!(
+            out.contains("llo"),
+            "unselected remainder missing in {out:?}"
+        );
     }
 }

--- a/src/tests/renderer_tests.rs
+++ b/src/tests/renderer_tests.rs
@@ -1,4 +1,4 @@
-use crate::ui::renderer::{base64_encode, copy_to_clipboard, is_safe_url};
+use crate::ui::renderer::{base64_encode, copy_to_clipboard, is_safe_url, paste_from_clipboard};
 
 #[test]
 fn base64_encode_empty() {
@@ -41,6 +41,19 @@ fn base64_encode_long_input() {
 fn copy_to_clipboard_does_not_panic() {
     // Succeeds via an external tool or the OSC 52 fallback.
     copy_to_clipboard("test text").expect("copy should succeed");
+}
+
+#[test]
+fn paste_from_clipboard_either_works_or_errors_cleanly() {
+    // Clipboard reads depend on the environment (wl-paste/xclip/pbpaste or
+    // none of them), so only assert the shape of the outcome.
+    match paste_from_clipboard() {
+        Ok(_) => {}
+        Err(e) => assert!(
+            e.to_string().contains("no clipboard tool"),
+            "unexpected error: {e}"
+        ),
+    }
 }
 
 #[test]

--- a/src/tests/tui_loop_tests.rs
+++ b/src/tests/tui_loop_tests.rs
@@ -595,3 +595,39 @@ async fn scroll_and_resize_events() {
 
     app.teardown().await;
 }
+
+#[tokio::test]
+async fn mouse_drag_selects_input_text_then_release_clears_it() {
+    let _guard = acquire();
+    let (mut app, _model) = headless_app(vec![vec!["ok"]]).await;
+
+    app.inject(UserEvent::Paste("hello world".to_string()))
+        .await;
+    pump(&mut app).await;
+
+    // Locate the input row: it's the only row whose click starts an input
+    // selection (chat rows start a chat selection instead, dead rows nothing).
+    let mut input_row = None;
+    for row in 0..24u16 {
+        app.inject(UserEvent::MouseDown { row, col: 4 }).await;
+        pump(&mut app).await;
+        if app.input_selection().is_some() {
+            input_row = Some(row);
+            break;
+        }
+    }
+    let row = input_row.expect("a mouse click should reach the input area");
+
+    app.inject(UserEvent::MouseDrag { row, col: 9 }).await;
+    pump(&mut app).await;
+    assert_eq!(app.input_selection(), Some((2, 7)));
+
+    // Release copies (environment-dependent clipboard, ignored here) and
+    // clears the selection; the buffer is untouched.
+    app.inject(UserEvent::MouseUp { row, col: 9 }).await;
+    pump(&mut app).await;
+    assert_eq!(app.input_selection(), None);
+    assert_eq!(app.input_buffer(), "hello world");
+
+    app.teardown().await;
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -592,6 +592,11 @@ impl<'a> App<'a> {
     }
 
     #[cfg(test)]
+    pub(crate) fn input_selection(&self) -> Option<(usize, usize)> {
+        self.renderer.input_selection
+    }
+
+    #[cfg(test)]
     pub(crate) fn backend_output(&self) -> String {
         self.renderer.captured_output()
     }
@@ -693,31 +698,59 @@ impl<'a> App<'a> {
                     self.renderer
                         .input_cursor_for_click(row, col, &self.input.buffer)
                 {
+                    self.renderer.clear_selection();
+                    self.renderer.input_selection = Some((pos, pos));
                     self.input.set_cursor(pos);
-                } else if row < self.renderer.visible_lines() as u16
-                    && let Some(idx) = self.renderer.buffer_line_at_row(row)
-                {
-                    if let Some(url) = self.renderer.link_url_at(idx, col) {
-                        if let Err(e) = renderer_mod::open_url(&url) {
-                            self.renderer
-                                .write_line(&format!("cannot open link: {}", e), C_ERROR)?;
+                } else {
+                    self.renderer.input_selection = None;
+                    if row < self.renderer.visible_lines() as u16
+                        && let Some(idx) = self.renderer.buffer_line_at_row(row)
+                    {
+                        if let Some(url) = self.renderer.link_url_at(idx, col) {
+                            if let Err(e) = renderer_mod::open_url(&url) {
+                                self.renderer
+                                    .write_line(&format!("cannot open link: {}", e), C_ERROR)?;
+                            }
+                        } else {
+                            self.renderer.selection_active = true;
+                            self.renderer.selection_start = Some(idx);
+                            self.renderer.selection_end = Some(idx);
                         }
-                    } else {
-                        self.renderer.selection_active = true;
-                        self.renderer.selection_start = Some(idx);
-                        self.renderer.selection_end = Some(idx);
                     }
                 }
             }
-            UserEvent::MouseDrag { row, col: _ } => {
-                if self.renderer.selection_active
+            UserEvent::MouseDrag { row, col } => {
+                if self.renderer.input_selection.is_some() {
+                    if let Some(pos) =
+                        self.renderer
+                            .input_cursor_for_click(row, col, &self.input.buffer)
+                    {
+                        let anchor = self.renderer.input_selection.unwrap().0;
+                        self.renderer.input_selection = Some((anchor, pos));
+                    }
+                } else if self.renderer.selection_active
                     && let Some(idx) = self.renderer.buffer_line_at_row(row)
                 {
                     self.renderer.selection_end = Some(idx);
                 }
             }
-            UserEvent::MouseUp { row, col: _ } => {
-                if self.renderer.selection_active {
+            UserEvent::MouseUp { row, col } => {
+                if self.renderer.input_selection.is_some() {
+                    if let Some(pos) =
+                        self.renderer
+                            .input_cursor_for_click(row, col, &self.input.buffer)
+                    {
+                        let anchor = self.renderer.input_selection.unwrap().0;
+                        self.renderer.input_selection = Some((anchor, pos));
+                    }
+                    if let Some(text) = self.renderer.selected_input_text(&self.input.buffer)
+                        && let Err(e) = copy_to_clipboard(&text)
+                    {
+                        self.renderer
+                            .write_line(&format!("copy to clipboard failed: {}", e), C_ERROR)?;
+                    }
+                    self.renderer.input_selection = None;
+                } else if self.renderer.selection_active {
                     if let Some(idx) = self.renderer.buffer_line_at_row(row) {
                         self.renderer.selection_end = Some(idx);
                     }
@@ -731,9 +764,11 @@ impl<'a> App<'a> {
                 }
             }
             UserEvent::Paste(data) => {
+                self.renderer.input_selection = None;
                 self.input.handle_paste(data);
             }
             UserEvent::PasteRequest => {
+                self.renderer.input_selection = None;
                 self.paste_clipboard_into_input()?;
             }
             #[cfg(feature = "mcp")]
@@ -777,6 +812,15 @@ impl<'a> App<'a> {
     }
 
     async fn handle_key_event(&mut self, key: KeyEvent) -> anyhow::Result<()> {
+        // Any key dismisses an input selection; Esc stops there so it also
+        // works as an explicit cancel.
+        if self.renderer.input_selection.is_some() {
+            if key.code == KeyCode::Esc {
+                self.renderer.input_selection = None;
+                return Ok(());
+            }
+            self.renderer.input_selection = None;
+        }
         if self.renderer.selection_active && key.code == KeyCode::Char('y') {
             if let Some(text) = self.renderer.selected_text() {
                 match copy_to_clipboard(&text) {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -20,7 +20,9 @@ use crate::ui::input::InputEditor;
 use crate::ui::permission_handler::handle_permission_request;
 use crate::ui::pickers::rewind::RewindOutcome;
 use crate::ui::pickers::switcher::SwitcherResult;
-use crate::ui::renderer::{self as renderer_mod, ChainPrompt, Renderer, copy_to_clipboard};
+use crate::ui::renderer::{
+    self as renderer_mod, ChainPrompt, Renderer, copy_to_clipboard, paste_from_clipboard,
+};
 use crate::ui::slash::{apply_prompt_model, handle_compress, handle_slash};
 #[cfg(feature = "git-worktree")]
 use crate::ui::state::MergeRequest;
@@ -653,6 +655,19 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Read the system clipboard and insert it at the input cursor. Used by
+    /// both the Ctrl+V binding and right/middle-click paste.
+    fn paste_clipboard_into_input(&mut self) -> anyhow::Result<()> {
+        match paste_from_clipboard() {
+            Ok(text) if !text.is_empty() => self.input.handle_paste(text),
+            Ok(_) => {}
+            Err(e) => self
+                .renderer
+                .write_line(&format!("paste failed: {}", e), C_ERROR)?,
+        }
+        Ok(())
+    }
+
     async fn handle_user_event(&mut self, ev: UserEvent) -> anyhow::Result<ControlFlow<(), ()>> {
         match ev {
             UserEvent::FocusGained => {
@@ -718,6 +733,9 @@ impl<'a> App<'a> {
             UserEvent::Paste(data) => {
                 self.input.handle_paste(data);
             }
+            UserEvent::PasteRequest => {
+                self.paste_clipboard_into_input()?;
+            }
             #[cfg(feature = "mcp")]
             UserEvent::McpLoginDone { server, error } => {
                 self.handle_mcp_login_done(server, error).await?;
@@ -776,6 +794,11 @@ impl<'a> App<'a> {
         }
         if self.renderer.selection_active && key.code == KeyCode::Esc {
             self.renderer.clear_selection();
+            return Ok(());
+        }
+
+        if key.code == KeyCode::Char('v') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.paste_clipboard_into_input()?;
             return Ok(());
         }
 

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -438,6 +438,16 @@ impl InputEditor {
                     self.yank_pos = Some(pos);
                     return None;
                 }
+                KeyCode::Left => {
+                    self.cursor = self.prev_word_start();
+                    self.yank_pos = None;
+                    return None;
+                }
+                KeyCode::Right => {
+                    self.cursor = self.next_word_end();
+                    self.yank_pos = None;
+                    return None;
+                }
                 _ => {}
             }
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -392,6 +392,11 @@ pub(crate) fn spawn_event_thread(
                             col: m.column,
                         });
                     }
+                    // Right- and middle-click paste from the clipboard.
+                    MouseEventKind::Down(MouseButton::Right)
+                    | MouseEventKind::Down(MouseButton::Middle) => {
+                        let _ = user_tx.blocking_send(UserEvent::PasteRequest);
+                    }
                     _ => {}
                 },
                 Ok(event::Event::Resize(_cols, _rows)) => {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -189,6 +189,7 @@ pub(crate) struct BottomSnapshot {
     pub(crate) monochrome: bool,
     pub(crate) input_bg: Option<Color>,
     pub(crate) status_bg: Option<Color>,
+    pub(crate) input_selection: Option<(usize, usize)>,
 }
 
 /// How much of the bottom region a `draw_bottom` call must repaint.
@@ -228,6 +229,9 @@ pub struct Renderer {
     pub selection_active: bool,
     pub selection_start: Option<usize>,
     pub selection_end: Option<usize>,
+    /// Mouse selection inside the input box: (anchor, focus) byte offsets
+    /// into the input buffer, unsorted. `None` when no input selection.
+    pub input_selection: Option<(usize, usize)>,
     prev_input_height: usize,
     /// Number of statusline rows (1-3), fixed by the statusline config at startup.
     statusline_height: usize,
@@ -280,6 +284,7 @@ impl Renderer {
             selection_active: false,
             selection_start: None,
             selection_end: None,
+            input_selection: None,
             prev_input_height: 0,
             statusline_height: 1,
             chat_margin: 0,
@@ -583,6 +588,42 @@ impl Renderer {
         } else {
             Some(result)
         }
+    }
+
+    /// Sorted (start, end) byte range of the active input selection. An
+    /// empty selection (anchor == focus) is normalized to `None`.
+    pub fn input_selection_range(&self) -> Option<(usize, usize)> {
+        let (a, b) = self.input_selection?;
+        if a == b {
+            return None;
+        }
+        Some((a.min(b), a.max(b)))
+    }
+
+    /// Write one run of an input line, reversing video while `selected`.
+    /// Toggles only the reverse bit (SGR 7/27) so theme backgrounds survive.
+    fn write_input_run(&mut self, run: &str, selected: bool) -> io::Result<()> {
+        if selected {
+            write!(self.backend, "{}", SetAttribute(Attribute::Reverse))?;
+            write!(self.backend, "{}", run)?;
+            write!(self.backend, "{}", SetAttribute(Attribute::NoReverse))?;
+        } else {
+            write!(self.backend, "{}", run)?;
+        }
+        Ok(())
+    }
+
+    /// The input text covered by the active input selection. Stale offsets
+    /// (the buffer changed since the selection was made) are clamped to the
+    /// buffer; an offset that lands inside a multi-byte char yields `None`
+    /// instead of panicking on a non-boundary slice.
+    pub fn selected_input_text(&self, input: &str) -> Option<String> {
+        let (lo, hi) = self.input_selection_range()?;
+        let hi = hi.min(input.len());
+        if !input.is_char_boundary(lo) || !input.is_char_boundary(hi) {
+            return None;
+        }
+        Some(input[lo..hi].to_string())
     }
 
     fn commit_partial(&mut self) {
@@ -1108,6 +1149,7 @@ impl Renderer {
             monochrome: self.monochrome,
             input_bg: self.input_bg,
             status_bg: self.status_bg,
+            input_selection: self.input_selection,
         }
     }
 
@@ -1143,6 +1185,7 @@ impl Renderer {
             && prev.monochrome == next.monochrome
             && prev.input_bg == next.input_bg
             && prev.status_bg == next.status_bg
+            && prev.input_selection == next.input_selection
         {
             // Only statusline/scroll_indicator differ => statusline-only repaint.
             if prev.statusline != next.statusline || prev.scroll_indicator != next.scroll_indicator
@@ -1443,12 +1486,45 @@ impl Renderer {
             } else {
                 0
             };
-            let display: String = line_chars
-                .iter()
-                .skip(skip_chars)
-                .take(visible_width)
-                .collect();
-            write!(self.backend, "{}", display)?;
+            match self.input_selection_range() {
+                None => {
+                    let display: String = line_chars
+                        .iter()
+                        .skip(skip_chars)
+                        .take(visible_width)
+                        .collect();
+                    write!(self.backend, "{}", display)?;
+                }
+                Some((sel_lo, sel_hi)) => {
+                    // Byte offset of the first visible char within the buffer:
+                    // line start plus the skipped chars' lengths.
+                    let line_start: usize = lines[..i].iter().map(|l| l.len() + 1).sum();
+                    let mut byte_off = line_start
+                        + line_chars
+                            .iter()
+                            .take(skip_chars)
+                            .map(|c| c.len_utf8())
+                            .sum::<usize>();
+                    let mut run = String::new();
+                    let mut run_selected = false;
+                    let mut have_run = false;
+                    for &ch in line_chars.iter().skip(skip_chars).take(visible_width) {
+                        let selected = byte_off >= sel_lo && byte_off < sel_hi;
+                        if have_run && selected != run_selected {
+                            self.write_input_run(&run, run_selected)?;
+                            run.clear();
+                            have_run = false;
+                        }
+                        run_selected = selected;
+                        have_run = true;
+                        run.push(ch);
+                        byte_off += ch.len_utf8();
+                    }
+                    if have_run {
+                        self.write_input_run(&run, run_selected)?;
+                    }
+                }
+            }
             write!(self.backend, "{}", Clear(ClearType::UntilNewLine))?;
             write!(self.backend, "{}", ResetColor)?;
         }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1583,6 +1583,45 @@ pub fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Read the system clipboard. Tries the read-side counterpart of every tool
+/// [`copy_to_clipboard`] uses (`wl-paste`, `xclip`, `pbpaste`) and finally
+/// PowerShell's `Get-Clipboard` on Windows. Errors when none is available or
+/// all fail; an empty clipboard is a successful empty string.
+pub fn paste_from_clipboard() -> anyhow::Result<String> {
+    let cmds: &[(&str, &[&str])] = &[
+        ("wl-paste", &[]),
+        ("xclip", &["-selection", "clipboard", "-o"]),
+        ("pbpaste", &[]),
+    ];
+    for &(cmd, args) in cmds {
+        let Ok(output) = std::process::Command::new(cmd)
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+        else {
+            continue; // tool not installed
+        };
+        if output.status.success() {
+            return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+        }
+    }
+    if cfg!(windows) {
+        if let Ok(output) = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-Command", "Get-Clipboard"])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            && output.status.success()
+        {
+            let text = String::from_utf8_lossy(&output.stdout);
+            // Get-Clipboard appends the console line terminator.
+            return Ok(text.trim_end_matches(['\r', '\n']).to_string());
+        }
+    }
+    anyhow::bail!("no clipboard tool found (tried wl-paste, xclip, pbpaste)")
+}
+
 /// Minimal base64 encoder — avoids pulling in a crate just for clipboard support.
 pub(crate) fn base64_encode(input: &[u8]) -> String {
     const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/src/ui/slash/help.rs
+++ b/src/ui/slash/help.rs
@@ -287,6 +287,10 @@ pub fn handle(_parts: &[&str], ctx: &mut SlashCtx<'_>) {
         ctx.renderer,
         "  Esc (while selected)   clear selection (no copy)",
     );
+    write_result(
+        ctx.renderer,
+        "  Ctrl+V / right-click   paste from system clipboard",
+    );
     write_result(ctx.renderer, "  Ctrl+R                 toggle reasoning");
     write_result(
         ctx.renderer,


### PR DESCRIPTION
Hi.

Full disclosure, code written with heavy LLM lifting as I'm lacking in Rust knowledge.

It contains three things I considered worth improving:
1. first commit contains support for Ctrl+Left/Ctrl+Right keyboard shortcuts (using already existing bindings). Probably the most harmless of the three
2. Second contains support for paste in input. Probably the weirdest of the three and I still battle if it is worth including. Long story short, I use WezTerm and I couldn't get paste to work in wezterm for some reason. So, basically, it does that typical neovim way of working with paste does, e.g. going through clipper commands (xclip for X etc.). When working via SSH I still need to add -X for X11 pass-through which is annoying. 
3. Third adds support for mouse selection in input field. The longest commit and I'm not sure about all the code. 

Anyway, I know these are opinionated things (on top of being LLM code), and I'm in no way enforcing any vision upon you. You're free to pick only one change or throw away entire thing, it's your project and your rules.

Thanks a lot!